### PR TITLE
Release WACS-v0.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ fabric.properties
 
 bin/
 obj/
+output/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/

--- a/Wacs.Console/CommandLineOptions.cs
+++ b/Wacs.Console/CommandLineOptions.cs
@@ -56,6 +56,9 @@ namespace Wacs.Console
         [Option('p', "profile", HelpText = "Bracket execution with a JetBrains profiling session.", Default = false)]
         public bool Profile { get; set; }
 
+        [Option('i', "invoke", HelpText = "Call a specific function.")]
+        public string InvokeFunction { get; set; } = "";
+
         // This will capture all values that aren't tied to an option
         [Value(0, Required = true, MetaName = "WasmModule", HelpText = "Path to the executable")]
         public string WasmModule { get; set; } = "";

--- a/Wacs.Core/Runtime/OpStack.cs
+++ b/Wacs.Core/Runtime/OpStack.cs
@@ -119,7 +119,11 @@ namespace Wacs.Core.Runtime
         {
             for (int i = 0, l = type.Arity; i < l; ++i)
             {
-                PushValue((Value)(scalars[i]));
+                var scalar = scalars[i];
+                if (scalar is Value v)
+                    PushValue(v);
+                else
+                    PushValue(new Value(type.Types[i], scalar));
             }
         }
     }

--- a/Wacs.Core/Runtime/Value.cs
+++ b/Wacs.Core/Runtime/Value.cs
@@ -413,6 +413,7 @@ namespace Wacs.Core.Runtime
 
         public static readonly Value NullFuncRef = new(ValType.Funcref);
         public static readonly Value NullExternRef = new(ValType.Externref);
+        public static readonly Value Void = new (ValType.Nil);
 
         public static Value RefNull(ReferenceType type) => type switch
         {
@@ -448,7 +449,7 @@ namespace Wacs.Core.Runtime
         public static implicit operator Value(V128 v128) => new(v128);
         
         public static implicit operator V128(Value value) => value.V128;
-
+        
         private static bool EqualFloats(float a, float b)
         {
             if (float.IsNaN(a) && float.IsNaN(b))

--- a/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.1.2</AssemblyVersion>
-    <FileVersion>0.1.2</FileVersion>
-    <Version>0.1.2</Version>
+    <AssemblyVersion>0.1.3</AssemblyVersion>
+    <FileVersion>0.1.3</FileVersion>
+    <Version>0.1.3</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>


### PR DESCRIPTION
Fixing CreateInvoker<T>, Delegates now uses compiled Linq Expression Trees. 
Streamlining Wacs.Console
Updating downstream test suite