### PR TITLE
Adding net8.0 support for Wacs.Console AOT build

### DIFF
--- a/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console.csproj
@@ -4,8 +4,13 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    
     <AssemblyVersion>0.0.1</AssemblyVersion>
     <FileVersion>0.0.1</FileVersion>
     <Company>Kelvin Nishikawa</Company>
@@ -24,6 +29,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.4.8" />
+    <PackageReference Include="runtime.osx-arm64.Microsoft.DotNet.ILCompiler" Version="8.0.11" />
   </ItemGroup>
 
 </Project>

--- a/Wacs.Core/Instructions/Memory.cs
+++ b/Wacs.Core/Instructions/Memory.cs
@@ -312,27 +312,51 @@ namespace Wacs.Core.Instructions
                     break;
                 case BitWidth.S16:
                     short cI16 = (short)c.Int32;
+#if NETSTANDARD2_1
                     MemoryMarshal.Write(bs, ref cI16);
+#else
+                    MemoryMarshal.Write(bs, in cI16); // Assume you can change to 'in'
+#endif
                     break;
                 case BitWidth.U16:
                     ushort cU16 = (ushort)c.UInt32;
+#if NETSTANDARD2_1
                     MemoryMarshal.Write(bs, ref cU16);
+#else
+                    MemoryMarshal.Write(bs, in cU16);
+#endif
                     break;
                 case BitWidth.S32:
                     int cI32 = c.Int32;
+#if NETSTANDARD2_1
                     MemoryMarshal.Write(bs, ref cI32);
+#else
+                    MemoryMarshal.Write(bs, in cI32);
+#endif
                     break;
                 case BitWidth.U32:
                     uint cU32 = c.UInt32;
+#if NETSTANDARD2_1
                     MemoryMarshal.Write(bs, ref cU32);
+#else
+                    MemoryMarshal.Write(bs, in cU32);
+#endif
                     break;
                 case BitWidth.U64:
                     ulong cU64 = c.UInt64;
+#if NETSTANDARD2_1
                     MemoryMarshal.Write(bs, ref cU64);
+#else
+                    MemoryMarshal.Write(bs, in cU64);
+#endif
                     break;
                 case BitWidth.V128:
                     V128 cV128 = c.V128;
+#if NETSTANDARD2_1
                     MemoryMarshal.Write(bs, ref cV128);
+#else
+                    MemoryMarshal.Write(bs, in cV128);
+#endif
                     break;
             }
         }

--- a/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -111,7 +111,11 @@ namespace Wacs.Core.Runtime.Types
         {
             int size = Marshal.SizeOf<T>();
             var buf = this[(int)ptr..(int)(ptr + size)];
+#if NETSTANDARD2_1
             MemoryMarshal.Write(buf, ref str);
+#else
+            MemoryMarshal.Write(buf, in str);
+#endif
             return size;
         }
 

--- a/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
@@ -22,6 +21,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryType>git</RepositoryType>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="README.md">
+    <None Include="README.md">
       <Pack>true</Pack>
       <PackagePath/>
     </None>

--- a/Wacs.WASIp1/FsFd.cs
+++ b/Wacs.WASIp1/FsFd.cs
@@ -387,7 +387,11 @@ namespace Wacs.WASIp1
                 var entryTarget = window[start..delim];
                 var nameTarget = window[delim..end];
                 var dirEnt = struc;
+#if NETSTANDARD2_1
                 MemoryMarshal.Write(entryTarget, ref dirEnt);
+#else
+                MemoryMarshal.Write(entryTarget, in dirEnt);
+#endif
                 name.CopyTo(nameTarget);
             }
 

--- a/Wacs.WASIp1/Types/IoVec.cs
+++ b/Wacs.WASIp1/Types/IoVec.cs
@@ -44,7 +44,11 @@ namespace Wacs.WASIp1.Types
         public Value ToWasmType()
         {
             byte[] bytes = new byte[8];
+#if NETSTANDARD2_1
             MemoryMarshal.Write(bytes, ref this);
+#else
+            MemoryMarshal.Write(bytes, in this);
+#endif
             return MemoryMarshal.Read<ulong>(bytes);
         }
     }

--- a/Wacs.WASIp1/Wacs.WASIp1.csproj
+++ b/Wacs.WASIp1/Wacs.WASIp1.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <Title>Wacs WASIp1</Title>
@@ -17,6 +16,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>0.9.2</Version>
         <RepositoryType>git</RepositoryType>
+        <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -24,13 +24,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Update="README.md">
+        <None Include="README.md">
             <Pack>true</Pack>
             <PackagePath/>
-        </None>
-        <None Update="README.md">
-          <Pack>true</Pack>
-          <PackagePath></PackagePath>
         </None>
     </ItemGroup>
     


### PR DESCRIPTION
Wacs.Console can be built with net8.0 framework in AOT compiled mode.