### PR TITLE
Exposed GlobalIdx on Get/Set instructions

### DIFF
--- a/Wacs.Core/Instructions/GlobalVariable.cs
+++ b/Wacs.Core/Instructions/GlobalVariable.cs
@@ -29,7 +29,7 @@ namespace Wacs.Core.Instructions
     {
         public InstGlobalGet() : base(ByteCode.GlobalGet, +1) { }
         
-        private GlobalIdx Index;
+        public GlobalIdx Index { get; private set; }
 
         public int LinkStackDiff => StackDiff;
         
@@ -128,7 +128,7 @@ namespace Wacs.Core.Instructions
     {
         public InstGlobalSet() : base(ByteCode.GlobalSet, -1) { }
         
-        private GlobalIdx Index;
+        public GlobalIdx Index { get; private set; }
 
         public int LinkStackDiff => StackDiff;
         
@@ -210,5 +210,4 @@ namespace Wacs.Core.Instructions
             glob.Value = value;
         }
     }
-    
 }


### PR DESCRIPTION
I'm using WACS to parse WASM files and read the instructions. The Global Get/Set instructions aren't very useful without these exposed!