### PR TITLE
Added `GetIndex` accessors (alternative to PR#58, which used properties)

### DIFF
--- a/Wacs.Core/Instructions/GlobalVariable.cs
+++ b/Wacs.Core/Instructions/GlobalVariable.cs
@@ -31,6 +31,8 @@ namespace Wacs.Core.Instructions
         
         private GlobalIdx Index;
 
+        public GlobalIdx GetIndex() => Index;
+
         public int LinkStackDiff => StackDiff;
         
         public bool IsConstant(IWasmValidationContext? context)
@@ -129,6 +131,8 @@ namespace Wacs.Core.Instructions
         public InstGlobalSet() : base(ByteCode.GlobalSet, -1) { }
         
         private GlobalIdx Index;
+
+        public GlobalIdx GetIndex() => Index;
 
         public int LinkStackDiff => StackDiff;
         


### PR DESCRIPTION
Alternative to #58, adding a `GetIndex()` function instead of using a proeperty.