### PR TITLE
Handle reentrant host calls

### DIFF
--- a/Wacs.Core/Runtime/WasmRuntimeExecution.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeExecution.cs
@@ -467,24 +467,24 @@ namespace Wacs.Core.Runtime
 
                 return results;
             }
+        }
 
-            /// <summary>
-            /// Restores the instruction pointer and pushes results back onto the stack for nested calls.
-            /// </summary>
-            private void RestoreInstructionPointer(int savedInstructionPointer, Value[] results)
+        /// <summary>
+        /// Restores the instruction pointer and pushes results back onto the stack for nested calls.
+        /// </summary>
+        private void RestoreInstructionPointer(int savedInstructionPointer, Value[] results)
             {
                 Context.OpStack.PushValues(results);
                 Context.InstructionPointer = savedInstructionPointer;
             }
 
-            /// <summary>
-            /// Clears any remaining stack values for top-level calls.
-            /// </summary>
-            private void FlushCallStack()
-            {
-                while (Context.OpStack.HasValue)
-                    Context.OpStack.PopAny();
-            }
+        /// <summary>
+        /// Clears any remaining stack values for top-level calls.
+        /// </summary>
+        private void FlushCallStack()
+        {
+            while (Context.OpStack.HasValue)
+                Context.OpStack.PopAny();
         }
 
         public async Task ProcessThreadAsync(long gasLimit)


### PR DESCRIPTION
This fixes an issue I found where a host function calling back into WASM would cause the stack to get into an unrecoverable state.

Detect nested calls via operand stack, save/restore instruction pointer, and preserve results.

Detect nested CreateInvoker calls by checking the operand stack height. Save the current instruction pointer for nested calls and restore it on success or exceptions instead of unconditionally flushing the call stack. For nested calls push results back onto the operand stack so callers can consume them; for top-level calls keep the previous behavior of clearing remaining stack values.