### PR TITLE
WACS-v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.5] Fix rollup
+- Fix to indirect calls
+- Fix to reentrant calls
+- Exposing global var index for use in parsing-only contexts
+
 ## [0.7.4] Performance
 ### Link-time optimization
 - Instantiated functions are now flattened into a tape at link time

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads](https://img.shields.io/nuget/dt/WACS)](https://www.nuget.org/packages/WACS)
 
 ## Overview
-Latest changes: [0.7.4](https://github.com/kelnishi/WACS/tree/main/CHANGELOG.md)
+Latest changes: [0.7.5](https://github.com/kelnishi/WACS/tree/main/CHANGELOG.md)
 
 **WACS** is a pure C# WebAssembly Interpreter for running WASM modules in .NET environments, including Godot and AOT environments like Unity's IL2CPP.
 

--- a/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.7.4</AssemblyVersion>
-    <Version>0.7.4</Version>
+    <AssemblyVersion>0.7.5</AssemblyVersion>
+    <Version>0.7.5</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>


### PR DESCRIPTION
### Fix rollup
- Fix to indirect calls
- Fix to reentrant calls
- Exposing global var index for use in parsing-only contexts