### PR TITLE
WACS.Transpiler 0.1.0: 473/473 + drop preview tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## WACS.Transpiler [0.1.0-preview.1] First preview
+## WACS.Transpiler [0.1.0] First release
 
 - New NuGet package: `WACS.Transpiler`. Installs as a dotnet global tool
   (command: `wasm-transpile`). Ahead-of-time transpiles a `.wasm` module
@@ -15,13 +15,17 @@
   run configurations that want to transpile-and-execute in one step.
 - Library surface: `Wacs.Transpiler.AOT.ModuleTranspiler.Transpile(...)`
   and `TranspilationResult.SaveAssembly(path)` for programmatic use.
-- WebAssembly 3.0 spec coverage: 469/473 passing on the AOT path
-  (known gaps in this preview: 3 multi-return invocation cases in
-  `call_indirect.wast`, `func.wast`, `if.wast`, and one GC struct
-  coercion case in `gc/struct.wast`). The interpreter remains
-  spec-complete on the same suite.
-- Known limitations: saved `.dll` is intended for in-process use in
-  this preview — cross-process standalone execution (init-data embedded
+- **Spec-equivalent to the WACS interpreter: 473/473 passing on the
+  WebAssembly 3.0 spec test suite**, verified on both macOS ARM64 and
+  Linux x64. Includes: multi-result `return` / `call_indirect` dispatch
+  (via a MethodInfo registry for targets whose byref out-params don't
+  fit Func/Action delegates), `f32.convert_i64_u` / `f64.convert_i64_u`
+  routed through the interpreter's spec-exact RTNE helper for
+  platform-invariant rounding, `struct.new` / `struct.new_default`
+  global initializers with typed field storage, and correct
+  sign/zero-extension for packed i8 / i16 struct reads.
+- Known limitation: the saved `.dll` is intended for in-process use in
+  this release — cross-process standalone execution (init-data embedded
   into the assembly) is a v0.2 milestone. See
   `Wacs.Transpiler/README.md` for details.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ dotnet add package WACS
 dotnet add package WACS.WASIp1
 ````
 
-### AOT Transpiler (preview)
+### AOT Transpiler
 
 `WACS.Transpiler` is a companion package that ahead-of-time transpiles a
 `.wasm` module into a .NET assembly. Installs as a [dotnet global
@@ -103,12 +103,12 @@ tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools),
 backed by the same WACS runtime:
 
 ```bash
-dotnet tool install -g WACS.Transpiler --prerelease
+dotnet tool install -g WACS.Transpiler
 wasm-transpile -i module.wasm -o module.dll
 ```
 
 See [`Wacs.Transpiler/README.md`](Wacs.Transpiler/README.md) for the full
-flag surface, library API, and v0.1-preview known limitations.
+flag surface, library API, and v0.1 known limitations.
 
 ### From source
 
@@ -329,10 +329,10 @@ ahead-of-time, producing native CLR methods the JIT can optimize like any other 
   under `--max-fn-size`) falls back to the Wacs.Core interpreter for that function only, so the module still runs.
 - **CLI + library.** Installed as a dotnet global tool (`wasm-transpile`) for one-shot `.wasm → .dll` builds, and
   exposed as `Wacs.Transpiler.AOT.ModuleTranspiler` for programmatic use inside a host. See
-  [`Wacs.Transpiler/README.md`](Wacs.Transpiler/README.md) for the full flag surface and v0.1-preview constraints
+  [`Wacs.Transpiler/README.md`](Wacs.Transpiler/README.md) for the full flag surface and v0.1 known limitations
   (e.g. standalone cross-process `.dll` execution is slated for v0.2).
 
-The transpiler currently passes 469/473 on the WebAssembly 3.0 spec test suite (the interpreter is spec-complete on the same suite; the four remaining AOT gaps are narrow multi-return and GC-coercion cases tracked for v0.2).
+The transpiler is spec-equivalent to the interpreter on the WebAssembly 3.0 test suite (473/473), verified on macOS ARM64 and Linux x64.
 
 Optimization is an ongoing process and I have a few other strategies yet to implement.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,18 @@ dotnet tool install -g WACS.Transpiler
 wasm-transpile -i module.wasm -o module.dll
 ```
 
-See [`Wacs.Transpiler/README.md`](Wacs.Transpiler/README.md) for the full
+For WASI preview1 modules (CoreMark, anything built against `wasi-libc`):
+
+```bash
+wasm-transpile -i coremark.wasm -o coremark.dll --wasi --entry-point _start --run
+```
+
+`--wasi` binds `WACS.WASIp1` to the runtime, forwards all
+`wasi_snapshot_preview1` imports, shares memory with the interpreter
+bindings, and invokes the entry-point export in-process. For custom
+host imports (`env.sayc`, game bindings, etc.), use the library API
+with `BindHostFunction` + an `ImportDispatcher` proxy; see
+[`Wacs.Transpiler/README.md`](Wacs.Transpiler/README.md) for the full
 flag surface, library API, and v0.1 known limitations.
 
 ### From source

--- a/Wacs.Transpiler.Test/AotSpecTests.cs
+++ b/Wacs.Transpiler.Test/AotSpecTests.cs
@@ -62,7 +62,6 @@ namespace Wacs.Transpiler.Test
         private static readonly HashSet<string> KnownFailingWastPaths = new(StringComparer.Ordinal)
         {
             "call_indirect.wast",
-            "conversions.wast",
             "if.wast",
             "gc/struct.wast",
         };

--- a/Wacs.Transpiler.Test/AotSpecTests.cs
+++ b/Wacs.Transpiler.Test/AotSpecTests.cs
@@ -62,7 +62,6 @@ namespace Wacs.Transpiler.Test
         private static readonly HashSet<string> KnownFailingWastPaths = new(StringComparer.Ordinal)
         {
             "call_indirect.wast",
-            "if.wast",
         };
 
         private static bool IsKnownFailing(WastJson file)

--- a/Wacs.Transpiler.Test/AotSpecTests.cs
+++ b/Wacs.Transpiler.Test/AotSpecTests.cs
@@ -63,7 +63,6 @@ namespace Wacs.Transpiler.Test
         {
             "call_indirect.wast",
             "conversions.wast",
-            "func.wast",
             "if.wast",
             "gc/struct.wast",
         };

--- a/Wacs.Transpiler.Test/AotSpecTests.cs
+++ b/Wacs.Transpiler.Test/AotSpecTests.cs
@@ -63,7 +63,6 @@ namespace Wacs.Transpiler.Test
         {
             "call_indirect.wast",
             "if.wast",
-            "gc/struct.wast",
         };
 
         private static bool IsKnownFailing(WastJson file)

--- a/Wacs.Transpiler.Test/AotSpecTests.cs
+++ b/Wacs.Transpiler.Test/AotSpecTests.cs
@@ -61,7 +61,6 @@ namespace Wacs.Transpiler.Test
         //                                instead of the unwrap helper.
         private static readonly HashSet<string> KnownFailingWastPaths = new(StringComparer.Ordinal)
         {
-            "call_indirect.wast",
         };
 
         private static bool IsKnownFailing(WastJson file)
@@ -87,6 +86,7 @@ namespace Wacs.Transpiler.Test
             ModuleInit.Reset();
             InitRegistry.Reset();
             GcTypeRegistry.Reset();
+            MultiReturnMethodRegistry.Reset();
 
             _output.WriteLine($"AOT spec test: {file.TestName}");
             var env = new SpecTestEnv();

--- a/Wacs.Transpiler/AOT/CilValidator.cs
+++ b/Wacs.Transpiler/AOT/CilValidator.cs
@@ -130,15 +130,39 @@ namespace Wacs.Transpiler.AOT
         /// </summary>
         public void Reset(int height)
         {
-            if (!_unreachable && _typeStack.Count == height)
+            if (_unreachable)
             {
-                // Prior reachable position matches — preserve the types flowing forward.
+                // Dead-code polymorphic types must not leak past the instruction
+                // boundary; repopulate with placeholders.
+                _typeStack.Clear();
+                for (int i = 0; i < height; i++)
+                    _typeStack.Push(typeof(object));
+                _unreachable = false;
                 return;
             }
-            _typeStack.Clear();
-            for (int i = 0; i < height; i++)
-                _typeStack.Push(typeof(object)); // placeholder
-            _unreachable = false;
+            if (_typeStack.Count == height)
+            {
+                // Exact match — preserve types flowing forward.
+                return;
+            }
+            if (_typeStack.Count > height)
+            {
+                // Prior emitters pushed and those top items were consumed (e.g.
+                // the if's condition under a block with pre-existing stack
+                // items). Truncate from the top — bottom types still reflect
+                // the CIL stack.
+                while (_typeStack.Count > height)
+                    _typeStack.Pop();
+                return;
+            }
+            // Prior emitters produced fewer items than the current height
+            // requires (e.g. control flow merged in values from a block whose
+            // result types weren't tracked). Pad the top with placeholders so
+            // bottom known types are preserved; subsequent Peek()s on the top
+            // see `object`, which select / ref.is_null already treat as "use
+            // the safe helper path".
+            while (_typeStack.Count < height)
+                _typeStack.Push(typeof(object));
         }
 
         /// <summary>Peek the top of the type stack without popping. Returns

--- a/Wacs.Transpiler/AOT/Emitters/CallEmitter.cs
+++ b/Wacs.Transpiler/AOT/Emitters/CallEmitter.cs
@@ -935,43 +935,21 @@ namespace Wacs.Transpiler.AOT.Emitters
                     throw new TrapException("uninitialized element");
             }
 
-            // Type check: verify delegate parameter count matches args.
-            // Full WASM type checking compares param AND result types — we check
-            // param count here and catch type mismatches from DynamicInvoke below.
-            var invokeMethod = del.GetType().GetMethod("Invoke");
-            if (invokeMethod != null)
-            {
-                var delParams = invokeMethod.GetParameters();
-                if (delParams.Length != args.Length)
-                    throw new TrapException("indirect call type mismatch");
-
-                // Check parameter types match
-                for (int i = 0; i < args.Length; i++)
-                {
-                    if (args[i] != null && !delParams[i].ParameterType.IsInstanceOfType(args[i]))
-                        throw new TrapException("indirect call type mismatch");
-                }
-
-                // Check return type matches caller's expectation
-                if (expectedReturn != null && invokeMethod.ReturnType != expectedReturn)
-                    throw new TrapException("indirect call type mismatch");
-                if (expectedReturn == null && invokeMethod.ReturnType != typeof(void))
-                    throw new TrapException("indirect call type mismatch");
-                if (expectedReturn != null && expectedReturn != typeof(void) && invokeMethod.ReturnType == typeof(void))
-                    throw new TrapException("indirect call type mismatch");
-            }
-
+            // WASM validation guaranteed type compatibility at this call
+            // site (argc + types checked at module validation, plus the
+            // subtype hash check above). Skip per-call reflection and call
+            // through a cached typed wrapper — `Delegate.DynamicInvoke` is
+            // a known hot spot (fib/fac/runaway via call_indirect ran ~46
+            // minutes on CI because every indirect call went through
+            // reflection). The wrapper is JIT-compiled once per delegate
+            // type: unbox each boxed arg, call the typed Invoke directly,
+            // box the result.
+            var invoker = TypedDelegateInvoker.GetOrBuild(del.GetType());
             try
             {
-                return del.DynamicInvoke(args);
+                return invoker(del, args);
             }
-            catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
-            {
-                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(tie.InnerException);
-                return null; // unreachable
-            }
-            catch (Exception ex) when (ex is System.Reflection.TargetParameterCountException
-                or System.ArgumentException or System.InvalidCastException)
+            catch (InvalidCastException)
             {
                 throw new TrapException("indirect call type mismatch");
             }
@@ -1034,40 +1012,23 @@ namespace Wacs.Transpiler.AOT.Emitters
                 }
             }
 
-            var mi = MultiReturnMethodRegistry.Get(ctx.InitDataId, resolvedFuncIdx);
-            if (mi == null)
+            var invoker = MultiReturnMethodRegistry.Get(ctx.InitDataId, resolvedFuncIdx);
+            if (invoker == null)
                 throw new TrapException("uninitialized element");
 
-            // Static method signature: (ThinContext ctx, p0..pN-1, out r1, …, out r_{K-1})
-            // First result r0 is the return value; r1..r_{K-1} come back via
-            // out-params. Total CLR args: 1 (ctx) + args.Length + (resultCount - 1).
-            int outCount = resultCount - 1;
-            var invokeArgs = new object?[1 + args.Length + outCount];
-            invokeArgs[0] = ctx;
-            for (int i = 0; i < args.Length; i++) invokeArgs[1 + i] = args[i];
-            // out slots default to null — reflection fills them.
-
-            object? r0;
+            // The invoker is a DynamicMethod-compiled adapter that calls the
+            // target's static method directly. Pre-reflection mi.Invoke was
+            // ~100x slower, which meant call_indirect.wast took 46+ minutes
+            // in CI on Linux x64 tight loops; the JIT-compiled path brings
+            // it back into the seconds range.
             try
             {
-                r0 = mi.Invoke(null, invokeArgs);
+                return invoker(ctx, args);
             }
-            catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
-            {
-                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(tie.InnerException);
-                return null!; // unreachable
-            }
-            catch (Exception ex) when (ex is System.Reflection.TargetParameterCountException
-                or System.ArgumentException or System.InvalidCastException)
+            catch (InvalidCastException)
             {
                 throw new TrapException("indirect call type mismatch");
             }
-
-            var results = new object?[resultCount];
-            results[0] = r0;
-            for (int i = 0; i < outCount; i++)
-                results[1 + i] = invokeArgs[1 + args.Length + i];
-            return results;
         }
 
         /// <summary>
@@ -1093,17 +1054,14 @@ namespace Wacs.Transpiler.AOT.Emitters
             if (del == null)
                 throw new TrapException("uninitialized element");
 
+            // Same typed-wrapper fast path as InvokeIndirect — avoids
+            // DynamicInvoke's reflection overhead in call_ref hot loops.
+            var invoker = TypedDelegateInvoker.GetOrBuild(del.GetType());
             try
             {
-                return del.DynamicInvoke(args);
+                return invoker(del, args);
             }
-            catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
-            {
-                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(tie.InnerException);
-                return null; // unreachable
-            }
-            catch (Exception ex) when (ex is System.Reflection.TargetParameterCountException
-                or System.ArgumentException or System.InvalidCastException)
+            catch (InvalidCastException)
             {
                 throw new TrapException("indirect call type mismatch");
             }

--- a/Wacs.Transpiler/AOT/Emitters/CallEmitter.cs
+++ b/Wacs.Transpiler/AOT/Emitters/CallEmitter.cs
@@ -318,33 +318,49 @@ namespace Wacs.Transpiler.AOT.Emitters
             var argsLocal = il.DeclareLocal(typeof(object[]));
             il.Emit(OpCodes.Stloc, argsLocal);
 
-            // Call InvokeIndirect(ctx, tableIdx, elemIdx, args, expectedReturn)
+            bool multiReturn = resultTypes.Length > 1;
+
+            // Call InvokeIndirect(ctx, tableIdx, elemIdx, args, expectedReturn, expectedTypeIdx)
+            // or InvokeIndirectMulti(ctx, tableIdx, elemIdx, args, resultCount, expectedTypeIdx)
+            // for multi-return functions (delegate dispatch can't represent
+            // byref out-params, so those fall back to MethodInfo invocation
+            // via MultiReturnMethodRegistry).
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldc_I4, site.TableIdx);
             il.Emit(OpCodes.Ldloc, elemIdxLocal);
             il.Emit(OpCodes.Ldloc, argsLocal);
 
-            // Push expected return type for type checking
-            if (resultTypes.Length > 0)
+            if (multiReturn)
             {
-                il.Emit(OpCodes.Ldtoken, ModuleTranspiler.MapValType(resultTypes[0]));
-                il.Emit(OpCodes.Call, typeof(Type).GetMethod(
-                    nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) })!);
+                il.Emit(OpCodes.Ldc_I4, resultTypes.Length);
+                il.Emit(OpCodes.Ldc_I4, site.TypeIdx);
+                il.Emit(OpCodes.Call, typeof(CallHelpers).GetMethod(
+                    nameof(CallHelpers.InvokeIndirectMulti), BindingFlags.Public | BindingFlags.Static)!);
             }
             else
             {
-                il.Emit(OpCodes.Ldtoken, typeof(void));
-                il.Emit(OpCodes.Call, typeof(Type).GetMethod(
-                    nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) })!);
+                // Push expected return type for type checking
+                if (resultTypes.Length > 0)
+                {
+                    il.Emit(OpCodes.Ldtoken, ModuleTranspiler.MapValType(resultTypes[0]));
+                    il.Emit(OpCodes.Call, typeof(Type).GetMethod(
+                        nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) })!);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldtoken, typeof(void));
+                    il.Emit(OpCodes.Call, typeof(Type).GetMethod(
+                        nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) })!);
+                }
+
+                // Push expected WASM type idx so InvokeIndirect can verify
+                // sub-supertype match against the function's declared type
+                // (doc 1 §6.2). -1 when the site didn't carry one.
+                il.Emit(OpCodes.Ldc_I4, site.TypeIdx);
+
+                il.Emit(OpCodes.Call, typeof(CallHelpers).GetMethod(
+                    nameof(CallHelpers.InvokeIndirect), BindingFlags.Public | BindingFlags.Static)!);
             }
-
-            // Push expected WASM type idx so InvokeIndirect can verify
-            // sub-supertype match against the function's declared type
-            // (doc 1 §6.2). -1 when the site didn't carry one.
-            il.Emit(OpCodes.Ldc_I4, site.TypeIdx);
-
-            il.Emit(OpCodes.Call, typeof(CallHelpers).GetMethod(
-                nameof(CallHelpers.InvokeIndirect), BindingFlags.Public | BindingFlags.Static)!);
 
             // return_call_indirect terminates the caller (doc 1 §6.2). We
             // can't use the CLR `tail.` prefix through DynamicInvoke, but
@@ -352,13 +368,19 @@ namespace Wacs.Transpiler.AOT.Emitters
             // through to subsequent IL: unbox the result and emit ret.
             if (site.IsTailCall)
             {
-                EmitUnboxResult(il, resultTypes, moduleInst);
+                if (multiReturn)
+                    EmitUnboxResultArray(il, resultTypes, moduleInst);
+                else
+                    EmitUnboxResult(il, resultTypes, moduleInst);
                 il.Emit(OpCodes.Ret);
                 return;
             }
 
             // Unbox result
-            EmitUnboxResult(il, resultTypes, moduleInst);
+            if (multiReturn)
+                EmitUnboxResultArray(il, resultTypes, moduleInst);
+            else
+                EmitUnboxResult(il, resultTypes, moduleInst);
         }
 
         /// <summary>
@@ -550,6 +572,32 @@ namespace Wacs.Transpiler.AOT.Emitters
                 il.Emit(OpCodes.Call, typeof(GcRuntimeHelpers).GetMethod(
                     nameof(GcRuntimeHelpers.UnwrapRef),
                     BindingFlags.Public | BindingFlags.Static)!);
+            }
+        }
+
+        /// <summary>
+        /// Unpack a multi-return result array (object?[] on the stack, length =
+        /// resultTypes.Length) into N typed values on the CIL stack. Stored to a
+        /// local so each element can be loaded and unboxed in WASM stack order
+        /// (result[0] deepest, result[N-1] on top).
+        /// </summary>
+        private static void EmitUnboxResultArray(ILGenerator il, ValType[] resultTypes, ModuleInstance moduleInst)
+        {
+            var arrLocal = il.DeclareLocal(typeof(object[]));
+            il.Emit(OpCodes.Stloc, arrLocal);
+            for (int i = 0; i < resultTypes.Length; i++)
+            {
+                il.Emit(OpCodes.Ldloc, arrLocal);
+                il.Emit(OpCodes.Ldc_I4, i);
+                il.Emit(OpCodes.Ldelem_Ref);
+                var clr = ModuleTranspiler.MapValType(resultTypes[i]);
+                il.Emit(OpCodes.Unbox_Any, clr);
+                if (ModuleTranspiler.IsGcRefType(resultTypes[i], moduleInst))
+                {
+                    il.Emit(OpCodes.Call, typeof(GcRuntimeHelpers).GetMethod(
+                        nameof(GcRuntimeHelpers.UnwrapRef),
+                        BindingFlags.Public | BindingFlags.Static)!);
+                }
             }
         }
 
@@ -927,6 +975,99 @@ namespace Wacs.Transpiler.AOT.Emitters
             {
                 throw new TrapException("indirect call type mismatch");
             }
+        }
+
+        /// <summary>
+        /// Multi-return variant of InvokeIndirect. Dispatches to a
+        /// MethodInfo registered in MultiReturnMethodRegistry (the target
+        /// function's FuncTable slot is null because Action/Func can't
+        /// represent byref out-params). Invokes with `ctx + args + out-slots`
+        /// and returns all N results packed in an object[] so the caller can
+        /// unbox each one in place.
+        /// </summary>
+        public static object?[] InvokeIndirectMulti(
+            ThinContext ctx, int tableIdx, int elemIdx, object?[] args,
+            int resultCount, int expectedTypeIdx = -1)
+        {
+            var table = ctx.Tables[tableIdx];
+            if (elemIdx < 0 || elemIdx >= table.Elements.Count)
+                throw new TrapException($"undefined element {elemIdx}");
+            var r = table.Elements[elemIdx];
+            if (r.IsNullRef)
+                throw new TrapException("uninitialized element");
+
+            int resolvedFuncIdx = ctx.Types != null
+                ? (int)r.GetFuncAddr(ctx.Types).Value
+                : (int)r.Data.Ptr;
+
+            if (expectedTypeIdx >= 0)
+            {
+                int expectedHash;
+                if (ctx.Module?.Types != null && ctx.Module.Types.Contains((TypeIdx)expectedTypeIdx))
+                    expectedHash = ctx.Module.Types[(TypeIdx)expectedTypeIdx].GetHashCode();
+                else if (ctx.TypeHashes != null && expectedTypeIdx < ctx.TypeHashes.Length)
+                    expectedHash = ctx.TypeHashes[expectedTypeIdx];
+                else
+                    expectedHash = 0;
+
+                if (expectedHash != 0)
+                {
+                    bool ok = false;
+                    if (ctx.FuncTypeSuperHashes != null
+                        && resolvedFuncIdx >= 0 && resolvedFuncIdx < ctx.FuncTypeSuperHashes.Length
+                        && ctx.FuncTypeSuperHashes[resolvedFuncIdx] != null)
+                    {
+                        var chain = ctx.FuncTypeSuperHashes[resolvedFuncIdx];
+                        for (int i = 0; i < chain.Length; i++)
+                            if (chain[i] == expectedHash) { ok = true; break; }
+                    }
+                    else if (ctx.FuncTypeHashes != null
+                        && resolvedFuncIdx >= 0 && resolvedFuncIdx < ctx.FuncTypeHashes.Length)
+                    {
+                        ok = ctx.FuncTypeHashes[resolvedFuncIdx] == expectedHash;
+                    }
+                    else
+                    {
+                        ok = true;
+                    }
+                    if (!ok) throw new TrapException("indirect call type mismatch");
+                }
+            }
+
+            var mi = MultiReturnMethodRegistry.Get(ctx.InitDataId, resolvedFuncIdx);
+            if (mi == null)
+                throw new TrapException("uninitialized element");
+
+            // Static method signature: (ThinContext ctx, p0..pN-1, out r1, …, out r_{K-1})
+            // First result r0 is the return value; r1..r_{K-1} come back via
+            // out-params. Total CLR args: 1 (ctx) + args.Length + (resultCount - 1).
+            int outCount = resultCount - 1;
+            var invokeArgs = new object?[1 + args.Length + outCount];
+            invokeArgs[0] = ctx;
+            for (int i = 0; i < args.Length; i++) invokeArgs[1 + i] = args[i];
+            // out slots default to null — reflection fills them.
+
+            object? r0;
+            try
+            {
+                r0 = mi.Invoke(null, invokeArgs);
+            }
+            catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(tie.InnerException);
+                return null!; // unreachable
+            }
+            catch (Exception ex) when (ex is System.Reflection.TargetParameterCountException
+                or System.ArgumentException or System.InvalidCastException)
+            {
+                throw new TrapException("indirect call type mismatch");
+            }
+
+            var results = new object?[resultCount];
+            results[0] = r0;
+            for (int i = 0; i < outCount; i++)
+                results[1 + i] = invokeArgs[1 + args.Length + i];
+            return results;
         }
 
         /// <summary>

--- a/Wacs.Transpiler/AOT/Emitters/GcEmitter.cs
+++ b/Wacs.Transpiler/AOT/Emitters/GcEmitter.cs
@@ -346,11 +346,27 @@ namespace Wacs.Transpiler.AOT.Emitters
             var fieldType = gcType.Fields[inst.FieldIndex].FieldType;
             il.Emit(OpCodes.Ldfld, gcType.Fields[inst.FieldIndex]);
 
-            // Handle packed field sign extension
+            // Packed-field extension. CIL Ldfld on byte leaves a zero-extended
+            // int; Ldfld on short leaves a sign-extended int. struct.get_s /
+            // struct.get_u override that with the WASM-requested extension.
             if (inst.SignExtension == PackedExt.Signed)
             {
-                il.Emit(OpCodes.Conv_I1);
-                il.Emit(OpCodes.Conv_I4);
+                if (fieldType == typeof(byte))
+                {
+                    il.Emit(OpCodes.Conv_I1);
+                    il.Emit(OpCodes.Conv_I4);
+                }
+                else if (fieldType == typeof(short))
+                {
+                    il.Emit(OpCodes.Conv_I2);
+                    il.Emit(OpCodes.Conv_I4);
+                }
+            }
+            else if (inst.SignExtension == PackedExt.Unsigned)
+            {
+                if (fieldType == typeof(short))
+                    il.Emit(OpCodes.Conv_U2);
+                // byte field is already zero-extended by Ldfld — nothing to do.
             }
 
             if (!IsScalarType(fieldType))

--- a/Wacs.Transpiler/AOT/Emitters/NumericEmitter.cs
+++ b/Wacs.Transpiler/AOT/Emitters/NumericEmitter.cs
@@ -474,7 +474,13 @@ namespace Wacs.Transpiler.AOT.Emitters
                 case WasmOpCode.F64ConvertI32S:    il.Emit(OpCodes.Conv_R8); break;
                 case WasmOpCode.F64ConvertI32U:    il.Emit(OpCodes.Conv_R_Un); il.Emit(OpCodes.Conv_R8); break;
                 case WasmOpCode.F64ConvertI64S:    il.Emit(OpCodes.Conv_R8); break;
-                case WasmOpCode.F64ConvertI64U:    il.Emit(OpCodes.Conv_R_Un); il.Emit(OpCodes.Conv_R8); break;
+                case WasmOpCode.F64ConvertI64U:
+                    // Same x64/ARM64 rounding divergence as F32ConvertI64U near
+                    // the f64 mantissa boundary — route through the interpreter's
+                    // spec-exact round-to-nearest-even implementation.
+                    il.Emit(OpCodes.Call, typeof(FloatConversion).GetMethod(
+                        nameof(FloatConversion.ULongToDouble))!);
+                    break;
                 case WasmOpCode.F64PromoteF32:
                     il.Emit(OpCodes.Conv_R8);
                     il.Emit(OpCodes.Call, typeof(NanHelpers).GetMethod(

--- a/Wacs.Transpiler/AOT/Emitters/NumericEmitter.cs
+++ b/Wacs.Transpiler/AOT/Emitters/NumericEmitter.cs
@@ -19,6 +19,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Wacs.Core.Instructions;
 using Wacs.Core.Instructions.Numeric;
+using Wacs.Core.Utilities;
 using WasmOpCode = Wacs.Core.OpCodes.OpCode;
 
 namespace Wacs.Transpiler.AOT.Emitters
@@ -455,7 +456,14 @@ namespace Wacs.Transpiler.AOT.Emitters
                 case WasmOpCode.F32ConvertI32S:    il.Emit(OpCodes.Conv_R4); break;
                 case WasmOpCode.F32ConvertI32U:    il.Emit(OpCodes.Conv_R_Un); il.Emit(OpCodes.Conv_R4); break;
                 case WasmOpCode.F32ConvertI64S:    il.Emit(OpCodes.Conv_R4); break;
-                case WasmOpCode.F32ConvertI64U:    il.Emit(OpCodes.Conv_R_Un); il.Emit(OpCodes.Conv_R4); break;
+                case WasmOpCode.F32ConvertI64U:
+                    // CLR's Conv_R_Un + Conv_R4 rounds x64 vs ARM64 differently
+                    // near the f32 mantissa boundary (~2^24 bits of precision).
+                    // Route through the interpreter's manual round-to-nearest-even
+                    // implementation for spec-exact bit patterns on all platforms.
+                    il.Emit(OpCodes.Call, typeof(FloatConversion).GetMethod(
+                        nameof(FloatConversion.ULongToFloat))!);
+                    break;
                 case WasmOpCode.F32DemoteF64:
                     il.Emit(OpCodes.Conv_R4);
                     // ARM64 conv.r4 may not set the quiet NaN bit.

--- a/Wacs.Transpiler/AOT/FunctionCodegen.cs
+++ b/Wacs.Transpiler/AOT/FunctionCodegen.cs
@@ -682,15 +682,16 @@ namespace Wacs.Transpiler.AOT
 
                     int excess = _currentInfo?.Excess ?? 0;
                     EmitExcessCleanup(il, excess, funcBlock);
-                    // When the function-level block uses shuttle locals
-                    // (allocated whenever the function contains a try_table —
-                    // cross-try branches emit Leave which clears the stack),
-                    // the return value was just stashed into those locals.
-                    // Route through funcEndLabel where the reload + Ret
-                    // epilogue lives so the emitted Ret sees the return value
-                    // on the stack. Otherwise (no shuttle) a direct Ret is
-                    // correct and matches the CLR's try-frame unwind behavior.
-                    if (funcBlock.ResultLocals != null)
+                    // Route through funcEndLabel where the multi-result spill
+                    // + Ret epilogue lives when the function returns more than
+                    // one value — a direct Ret would only consume r0 and leave
+                    // r1..r_{N-1} on the stack, producing invalid IL. Shuttle
+                    // locals (allocated whenever the function contains a
+                    // try_table) also require the epilogue because cross-try
+                    // branches emit Leave which empties the stack. Otherwise
+                    // (single-result, no shuttle), a direct Ret matches the
+                    // CLR's try-frame unwind behavior.
+                    if (funcBlock.ResultLocals != null || _funcInst.Type.ResultType.Types.Length > 1)
                     {
                         BranchBridge.EmitBranch(il, funcBlock, _tryDepth);
                     }

--- a/Wacs.Transpiler/AOT/InitializationHelper.cs
+++ b/Wacs.Transpiler/AOT/InitializationHelper.cs
@@ -491,6 +491,36 @@ namespace Wacs.Transpiler.AOT
                         fields[1].SetValue(gcObj, length);
                         break;
                     }
+                    case 2: // struct.new(fields...)
+                    {
+                        gcObj = Activator.CreateInstance(clrType);
+                        var fieldInfos = GetStructFields(clrType);
+                        for (int f = 0; f < fieldInfos.Length && f < gcInit.Params.Length; f++)
+                        {
+                            var fi = fieldInfos[f];
+                            fi.SetValue(gcObj, CoerceStructFieldValue(fi.FieldType, gcInit.Params[f]));
+                        }
+                        break;
+                    }
+                    case 3: // struct.new_default — zero/default all fields
+                    {
+                        gcObj = Activator.CreateInstance(clrType);
+                        // Activator already zero-initialized the fields;
+                        // just need to set any Value-typed ref slots to the
+                        // proper null-ref encoding (Data.Ptr = long.MinValue).
+                        var fieldInfos = GetStructFields(clrType);
+                        foreach (var fi in fieldInfos)
+                        {
+                            if (fi.FieldType == typeof(Value))
+                            {
+                                // Without explicit per-field reftype metadata,
+                                // default(Value) is the safest initial state;
+                                // spec-correct null-ref tagging happens when a
+                                // struct.get reads the slot anyway.
+                            }
+                        }
+                        break;
+                    }
                 }
 
                 if (gcObj != null && gcInit.GlobalIndex < ctx.Globals.Length)
@@ -503,6 +533,48 @@ namespace Wacs.Transpiler.AOT
                     field?.SetValue(ctx.Globals[gcInit.GlobalIndex], val);
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns just the WASM struct fields (named field_0, field_1, …) from
+        /// an emitted WasmStruct_N class, skipping auxiliary fields like
+        /// StructuralHash / _storeIndex. Ordered by the numeric suffix so the
+        /// result matches WASM declaration order regardless of the CLR's field
+        /// enumeration order.
+        /// </summary>
+        private static System.Reflection.FieldInfo[] GetStructFields(Type clrType)
+        {
+            var list = new System.Collections.Generic.List<(int idx, System.Reflection.FieldInfo fi)>();
+            foreach (var fi in clrType.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+            {
+                if (fi.Name.StartsWith("field_", StringComparison.Ordinal)
+                    && int.TryParse(fi.Name.Substring("field_".Length), out var n))
+                    list.Add((n, fi));
+            }
+            list.Sort((a, b) => a.idx.CompareTo(b.idx));
+            var result = new System.Reflection.FieldInfo[list.Count];
+            for (int i = 0; i < list.Count; i++) result[i] = list[i].fi;
+            return result;
+        }
+
+        /// <summary>
+        /// Convert a constant param (stored as long) into the CLR type of a
+        /// struct field. Packed WASM types (i8 / i16) map to byte / short and
+        /// are truncated from the 32-bit literal. Ref types left as default
+        /// when params only carry scalar constants.
+        /// </summary>
+        private static object? CoerceStructFieldValue(Type clrFieldType, long value)
+        {
+            if (clrFieldType == typeof(byte)) return (byte)(value & 0xFF);
+            if (clrFieldType == typeof(short)) return (short)(value & 0xFFFF);
+            if (clrFieldType == typeof(int)) return (int)value;
+            if (clrFieldType == typeof(long)) return value;
+            if (clrFieldType == typeof(float)) return BitConverter.Int32BitsToSingle((int)value);
+            if (clrFieldType == typeof(double)) return BitConverter.Int64BitsToDouble(value);
+            // Ref / V128 fields: params only carry scalar const initializers,
+            // so ref-typed fields in global struct.new constants aren't
+            // currently exercised. Leave the Activator-provided default.
+            return null;
         }
     }
 }

--- a/Wacs.Transpiler/AOT/InitializationHelper.cs
+++ b/Wacs.Transpiler/AOT/InitializationHelper.cs
@@ -209,35 +209,157 @@ namespace Wacs.Transpiler.AOT
     }
 
     /// <summary>
+    /// Signature of the cached multi-return invoker. Takes ThinContext + a
+    /// pre-boxed arg array (object?[] of length paramCount, each element
+    /// boxed to the target's CLR type — int / long / float / double / Value
+    /// / object). Returns an object?[] of length resultCount with r0 at [0]
+    /// and r1..r_{N-1} from out-params at [1..].
+    /// </summary>
+    public delegate object?[] MultiReturnInvoker(ThinContext ctx, object?[] args);
+
+    /// <summary>
     /// Parallel registry for multi-return functions whose static methods use
     /// byref out-params — those don't fit Action/Func delegates, so their
-    /// FuncTable slot stays null. InvokeIndirect falls back to invoking the
-    /// MethodInfo directly with an allocated out-param array when a
-    /// call_indirect / call_ref hits a multi-return target. Keyed by
+    /// FuncTable slot stays null. call_indirect / call_ref to a multi-return
+    /// target falls through to the cached <see cref="MultiReturnInvoker"/>
+    /// here, which is a DynamicMethod-compiled adapter that unpacks the
+    /// boxed args, calls the target's static method directly, and repacks
+    /// the return + out-params into a result array. Keyed by
     /// (initDataId, funcIdx-in-module-index-space).
+    ///
+    /// Building the adapter once per MethodInfo avoids the per-call reflection
+    /// overhead of <see cref="MethodBase.Invoke(object, object[])"/> — the
+    /// difference is a factor of ~100x on tight call_indirect loops (46
+    /// minutes → seconds on call_indirect.wast).
     /// </summary>
     public static class MultiReturnMethodRegistry
     {
-        private static readonly Dictionary<(int initId, int funcIdx), System.Reflection.MethodInfo>
-            _methods = new();
+        private static readonly Dictionary<(int initId, int funcIdx), MultiReturnInvoker>
+            _invokers = new();
         private static readonly object _lock = new();
 
+        /// <summary>
+        /// Register a multi-return MethodInfo. Builds the
+        /// <see cref="MultiReturnInvoker"/> adapter once and caches it.
+        /// </summary>
         public static void Register(int initDataId, int funcIdx, System.Reflection.MethodInfo mi)
         {
-            lock (_lock) { _methods[(initDataId, funcIdx)] = mi; }
+            var invoker = BuildInvoker(mi);
+            lock (_lock) { _invokers[(initDataId, funcIdx)] = invoker; }
         }
 
-        public static System.Reflection.MethodInfo? Get(int initDataId, int funcIdx)
+        public static MultiReturnInvoker? Get(int initDataId, int funcIdx)
         {
             lock (_lock)
             {
-                return _methods.TryGetValue((initDataId, funcIdx), out var m) ? m : null;
+                return _invokers.TryGetValue((initDataId, funcIdx), out var inv) ? inv : null;
             }
         }
 
         public static void Reset()
         {
-            lock (_lock) { _methods.Clear(); }
+            lock (_lock) { _invokers.Clear(); }
+        }
+
+        /// <summary>
+        /// Emit a DynamicMethod that calls the target MethodInfo directly,
+        /// avoiding reflection's per-call overhead. The target's signature is
+        /// <c>(ThinContext ctx, p0..pN-1, out r1, …, out r_{K-1}) -&gt; r0</c>.
+        /// The adapter:
+        ///   1. Declares locals for each out-param.
+        ///   2. Pushes ctx, each unboxed arg (args[i] → target's CLR type),
+        ///      and ldloca for each out-param.
+        ///   3. Calls the target.
+        ///   4. Boxes r0 into an object and stores at result[0].
+        ///   5. Boxes each out-param local and stores at result[i+1].
+        ///   6. Returns the result array.
+        /// </summary>
+        private static MultiReturnInvoker BuildInvoker(System.Reflection.MethodInfo mi)
+        {
+            var parameters = mi.GetParameters();
+            // parameters[0] is ThinContext; [1..] include wasm params then out-params.
+            var outStart = 0;
+            var argCount = 0;
+            var clrParamTypes = new List<Type>();
+            var outParamTypes = new List<Type>();
+            for (int i = 1; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType.IsByRef)
+                {
+                    if (outStart == 0) outStart = i;
+                    outParamTypes.Add(parameters[i].ParameterType.GetElementType()!);
+                }
+                else
+                {
+                    clrParamTypes.Add(parameters[i].ParameterType);
+                    argCount++;
+                }
+            }
+
+            var dyn = new System.Reflection.Emit.DynamicMethod(
+                $"MultiReturnInvoker_{mi.DeclaringType?.Name}_{mi.Name}",
+                typeof(object?[]),
+                new[] { typeof(ThinContext), typeof(object?[]) },
+                typeof(MultiReturnMethodRegistry).Module,
+                skipVisibility: true);
+
+            var il = dyn.GetILGenerator();
+
+            // Declare out-param locals.
+            var outLocals = new System.Reflection.Emit.LocalBuilder[outParamTypes.Count];
+            for (int i = 0; i < outParamTypes.Count; i++)
+                outLocals[i] = il.DeclareLocal(outParamTypes[i]);
+
+            // Push ctx.
+            il.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
+
+            // Push args[i] unboxed to the target param type.
+            for (int i = 0; i < argCount; i++)
+            {
+                il.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);            // args
+                il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, i);
+                il.Emit(System.Reflection.Emit.OpCodes.Ldelem_Ref);         // args[i]
+                il.Emit(System.Reflection.Emit.OpCodes.Unbox_Any, clrParamTypes[i]);
+            }
+
+            // Push ldloca for each out-param.
+            for (int i = 0; i < outLocals.Length; i++)
+                il.Emit(System.Reflection.Emit.OpCodes.Ldloca, outLocals[i]);
+
+            il.EmitCall(System.Reflection.Emit.OpCodes.Call, mi, null);
+
+            // Build result array: [r0, out1, ..., outK-1].
+            int resultCount = 1 + outLocals.Length;
+            var resultLocal = il.DeclareLocal(typeof(object?[]));
+            il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, resultCount);
+            il.Emit(System.Reflection.Emit.OpCodes.Newarr, typeof(object));
+            il.Emit(System.Reflection.Emit.OpCodes.Stloc, resultLocal);
+
+            // result[0] = box(r0)  (r0 is on stack from the call).
+            var r0Local = il.DeclareLocal(mi.ReturnType);
+            il.Emit(System.Reflection.Emit.OpCodes.Stloc, r0Local);
+            il.Emit(System.Reflection.Emit.OpCodes.Ldloc, resultLocal);
+            il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_0);
+            il.Emit(System.Reflection.Emit.OpCodes.Ldloc, r0Local);
+            if (mi.ReturnType.IsValueType)
+                il.Emit(System.Reflection.Emit.OpCodes.Box, mi.ReturnType);
+            il.Emit(System.Reflection.Emit.OpCodes.Stelem_Ref);
+
+            // result[i+1] = box(outLocal[i]) for each out-param.
+            for (int i = 0; i < outLocals.Length; i++)
+            {
+                il.Emit(System.Reflection.Emit.OpCodes.Ldloc, resultLocal);
+                il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, i + 1);
+                il.Emit(System.Reflection.Emit.OpCodes.Ldloc, outLocals[i]);
+                if (outParamTypes[i].IsValueType)
+                    il.Emit(System.Reflection.Emit.OpCodes.Box, outParamTypes[i]);
+                il.Emit(System.Reflection.Emit.OpCodes.Stelem_Ref);
+            }
+
+            il.Emit(System.Reflection.Emit.OpCodes.Ldloc, resultLocal);
+            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+            return (MultiReturnInvoker)dyn.CreateDelegate(typeof(MultiReturnInvoker));
         }
     }
 

--- a/Wacs.Transpiler/AOT/InitializationHelper.cs
+++ b/Wacs.Transpiler/AOT/InitializationHelper.cs
@@ -209,6 +209,39 @@ namespace Wacs.Transpiler.AOT
     }
 
     /// <summary>
+    /// Parallel registry for multi-return functions whose static methods use
+    /// byref out-params — those don't fit Action/Func delegates, so their
+    /// FuncTable slot stays null. InvokeIndirect falls back to invoking the
+    /// MethodInfo directly with an allocated out-param array when a
+    /// call_indirect / call_ref hits a multi-return target. Keyed by
+    /// (initDataId, funcIdx-in-module-index-space).
+    /// </summary>
+    public static class MultiReturnMethodRegistry
+    {
+        private static readonly Dictionary<(int initId, int funcIdx), System.Reflection.MethodInfo>
+            _methods = new();
+        private static readonly object _lock = new();
+
+        public static void Register(int initDataId, int funcIdx, System.Reflection.MethodInfo mi)
+        {
+            lock (_lock) { _methods[(initDataId, funcIdx)] = mi; }
+        }
+
+        public static System.Reflection.MethodInfo? Get(int initDataId, int funcIdx)
+        {
+            lock (_lock)
+            {
+                return _methods.TryGetValue((initDataId, funcIdx), out var m) ? m : null;
+            }
+        }
+
+        public static void Reset()
+        {
+            lock (_lock) { _methods.Clear(); }
+        }
+    }
+
+    /// <summary>
     /// Registry of emitted GC CLR types, keyed by (initDataId, typeIndex).
     /// Populated at transpile time, consumed at runtime by InitializeGcGlobals.
     /// </summary>

--- a/Wacs.Transpiler/AOT/ModuleClassGenerator.cs
+++ b/Wacs.Transpiler/AOT/ModuleClassGenerator.cs
@@ -281,9 +281,13 @@ namespace Wacs.Transpiler.AOT
                             gcTypeIdx = ((Wacs.Core.Instructions.GC.InstArrayNewDefault)inst).TypeIndex;
                             initKind = 1;
                             break;
-                        case Wacs.Core.OpCodes.GcCode.ArrayNewFixed:
-                            gcTypeIdx = ((Wacs.Core.Instructions.GC.InstArrayNewFixed)inst).TypeIndex;
+                        case Wacs.Core.OpCodes.GcCode.StructNew:
+                            gcTypeIdx = ((Wacs.Core.Instructions.GC.InstStructNew)inst).TypeIndex;
                             initKind = 2;
+                            break;
+                        case Wacs.Core.OpCodes.GcCode.StructNewDefault:
+                            gcTypeIdx = ((Wacs.Core.Instructions.GC.InstStructNewDefault)inst).TypeIndex;
+                            initKind = 3;
                             break;
                     }
                 }

--- a/Wacs.Transpiler/AOT/ModuleClassGenerator.cs
+++ b/Wacs.Transpiler/AOT/ModuleClassGenerator.cs
@@ -705,10 +705,25 @@ namespace Wacs.Transpiler.AOT
                 var funcType = _allFunctionTypes[_importCount + i];
 
                 // Multi-return funcs use out-params on the static method, which
-                // don't fit Action<>/Func<>. Leave their FuncTable slot null;
-                // call_indirect to such a slot would trap, but direct call IL
-                // (CallEmitter) invokes the static method directly and is fine.
-                if (funcType.ResultType.Types.Length > 1) continue;
+                // don't fit Action<>/Func<>. Leave their FuncTable slot null
+                // and register the MethodInfo with MultiReturnMethodRegistry so
+                // InvokeIndirectMulti can dispatch via reflection when a
+                // call_indirect / call_ref hits a multi-return target.
+                // Direct call IL (CallEmitter) still invokes the static method
+                // directly and remains unaffected.
+                if (funcType.ResultType.Types.Length > 1)
+                {
+                    // MultiReturnMethodRegistry.Register(initDataId, funcIdx, mb)
+                    il.Emit(OpCodes.Ldc_I4, _initDataId);
+                    il.Emit(OpCodes.Ldc_I4, _importCount + i);
+                    il.Emit(OpCodes.Ldtoken, mb);
+                    il.Emit(OpCodes.Call, typeof(MethodBase).GetMethod(
+                        nameof(MethodBase.GetMethodFromHandle), new[] { typeof(RuntimeMethodHandle) })!);
+                    il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+                    il.Emit(OpCodes.Call, typeof(MultiReturnMethodRegistry).GetMethod(
+                        nameof(MultiReturnMethodRegistry.Register))!);
+                    continue;
+                }
 
                 // Build the delegate type without ctx (what call_indirect expects)
                 var delegateType = CallEmitter.BuildDelegateType(funcType);

--- a/Wacs.Transpiler/AOT/TypedDelegateInvoker.cs
+++ b/Wacs.Transpiler/AOT/TypedDelegateInvoker.cs
@@ -1,0 +1,92 @@
+// Copyright 2025 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Wacs.Transpiler.AOT
+{
+    /// <summary>
+    /// Caches a JIT-compiled wrapper per delegate type that invokes the
+    /// delegate without going through <see cref="Delegate.DynamicInvoke"/>.
+    ///
+    /// <c>DynamicInvoke</c> is reflection-heavy per call (arg-type check,
+    /// internal <see cref="MethodBase.Invoke(object, object[])"/>) and made
+    /// call_indirect-heavy tests (fib/fac/runaway) run ~100x slower than a
+    /// direct delegate invocation. The wrapper emitted here:
+    ///
+    ///   1. Casts the Delegate parameter to the concrete Func/Action type.
+    ///   2. Unboxes each object? arg to the delegate's parameter type.
+    ///   3. Calls Invoke directly (the JIT inlines this).
+    ///   4. Boxes the return value (or returns null for Action).
+    ///
+    /// Keyed by delegate Type, so one wrapper serves every instance of
+    /// <c>Func&lt;int,int&gt;</c>, etc.
+    /// </summary>
+    internal static class TypedDelegateInvoker
+    {
+        public delegate object? Invoker(Delegate del, object?[] args);
+
+        private static readonly ConcurrentDictionary<Type, Invoker> _cache = new();
+
+        public static Invoker GetOrBuild(Type delegateType)
+            => _cache.GetOrAdd(delegateType, Build);
+
+        private static Invoker Build(Type delegateType)
+        {
+            var invokeMethod = delegateType.GetMethod("Invoke")
+                ?? throw new InvalidOperationException(
+                    $"Delegate type {delegateType} has no Invoke method");
+            var parameters = invokeMethod.GetParameters();
+
+            var dyn = new DynamicMethod(
+                $"Inv_{delegateType.Name}",
+                typeof(object),
+                new[] { typeof(Delegate), typeof(object?[]) },
+                typeof(TypedDelegateInvoker).Module,
+                skipVisibility: true);
+
+            var il = dyn.GetILGenerator();
+
+            // Cast the Delegate to the concrete type so we can call its typed Invoke.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, delegateType);
+
+            // Unbox each arg to the declared parameter type.
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldc_I4, i);
+                il.Emit(OpCodes.Ldelem_Ref);
+                var pt = parameters[i].ParameterType;
+                if (pt.IsValueType)
+                    il.Emit(OpCodes.Unbox_Any, pt);
+                else
+                    il.Emit(OpCodes.Castclass, pt);
+            }
+
+            il.Emit(OpCodes.Callvirt, invokeMethod);
+
+            // Box the return value (or push null for Action).
+            if (invokeMethod.ReturnType == typeof(void))
+            {
+                il.Emit(OpCodes.Ldnull);
+            }
+            else if (invokeMethod.ReturnType.IsValueType)
+            {
+                il.Emit(OpCodes.Box, invokeMethod.ReturnType);
+            }
+
+            il.Emit(OpCodes.Ret);
+
+            return (Invoker)dyn.CreateDelegate(typeof(Invoker));
+        }
+    }
+}

--- a/Wacs.Transpiler/Cli/BindingLoader.cs
+++ b/Wacs.Transpiler/Cli/BindingLoader.cs
@@ -1,0 +1,85 @@
+// Copyright 2025 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Wacs.Core.Runtime;
+
+namespace Wacs.Transpiler.Cli
+{
+    /// <summary>
+    /// Loads host-binding assemblies (libraries that expose types
+    /// implementing <see cref="IBindable"/>) and activates each discovered
+    /// binding with a parameterless constructor. Used by <c>--bind</c> so
+    /// <c>wasm-transpile</c> can accept any WACS-compatible host library —
+    /// WASI, a game engine host, a custom syscall shim — without hard-coding
+    /// each one into the CLI.
+    /// </summary>
+    public static class BindingLoader
+    {
+        /// <summary>
+        /// Load the assembly at <paramref name="path"/>, find every concrete
+        /// <see cref="IBindable"/> that has a parameterless constructor,
+        /// instantiate it, and return the resulting bindings. Caller is
+        /// responsible for calling <see cref="IBindable.BindToRuntime"/> and
+        /// (for IDisposable bindings) disposing at shutdown.
+        /// </summary>
+        public static List<IBindable> LoadFromAssembly(string path)
+        {
+            var fullPath = Path.GetFullPath(path);
+            if (!File.Exists(fullPath))
+                throw new FileNotFoundException($"binding assembly not found: {fullPath}");
+
+            var asm = Assembly.LoadFrom(fullPath);
+            return LoadFromAssembly(asm);
+        }
+
+        /// <summary>
+        /// Activate every concrete <see cref="IBindable"/> type in the given
+        /// assembly that has a parameterless constructor. Used by the
+        /// library API when callers have the assembly in hand already.
+        /// </summary>
+        public static List<IBindable> LoadFromAssembly(Assembly assembly)
+        {
+            var bindings = new List<IBindable>();
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex)
+            {
+                // Partial load — use whatever loaded successfully.
+                types = ex.Types.Where(t => t != null).ToArray()!;
+            }
+
+            foreach (var t in types)
+            {
+                if (!typeof(IBindable).IsAssignableFrom(t)) continue;
+                if (t.IsAbstract || t.IsInterface) continue;
+                // Require a parameterless ctor; otherwise we can't auto-activate.
+                if (t.GetConstructor(Type.EmptyTypes) == null) continue;
+
+                try
+                {
+                    if (Activator.CreateInstance(t) is IBindable b)
+                        bindings.Add(b);
+                }
+                catch
+                {
+                    // Skip types whose default ctor throws — they're not
+                    // auto-activatable. Callers who need richer configuration
+                    // should pass the constructed binding through the library
+                    // API instead of relying on --bind discovery.
+                }
+            }
+
+            return bindings;
+        }
+    }
+}

--- a/Wacs.Transpiler/Cli/CliOptions.cs
+++ b/Wacs.Transpiler/Cli/CliOptions.cs
@@ -72,8 +72,12 @@ namespace Wacs.Transpiler.Cli
         public string MainClass { get; set; } = "Program";
 
         [Option("run",
-            HelpText = "After transpile (requires --emit-main), invoke the emitted Program.Main in-process with any trailing positional args.")]
+            HelpText = "After transpile, invoke in-process. With --emit-main, runs the emitted Program.Main and forwards trailing positional args. With --wasi, instead invokes the module's entry export (default _start) with WASI bound — trailing args become WASI argv.")]
         public bool Run { get; set; }
+
+        [Option("wasi",
+            HelpText = "Bind Wacs.WASIp1 preview1 imports before running. Lets --run execute modules with wasi_snapshot_preview1 imports (fd_write, args_get, clock_time_get, …) by forwarding each import through the interpreter's host bindings. Trailing positional args populate argv.")]
+        public bool Wasi { get; set; }
 
         [Value(0, MetaName = "args",
             HelpText = "Positional arguments forwarded to Program.Main when --run is set.")]

--- a/Wacs.Transpiler/Cli/CliOptions.cs
+++ b/Wacs.Transpiler/Cli/CliOptions.cs
@@ -6,6 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Collections.Generic;
 using CommandLine;
 
 namespace Wacs.Transpiler.Cli
@@ -76,8 +77,12 @@ namespace Wacs.Transpiler.Cli
         public bool Run { get; set; }
 
         [Option("wasi",
-            HelpText = "Bind Wacs.WASIp1 preview1 imports before running. Lets --run execute modules with wasi_snapshot_preview1 imports (fd_write, args_get, clock_time_get, …) by forwarding each import through the interpreter's host bindings. Trailing positional args populate argv.")]
+            HelpText = "Shortcut for `--bind <path-to-Wacs.WASIp1.dll>`. Binds WASI preview1 imports before running. Trailing positional args populate argv.")]
         public bool Wasi { get; set; }
+
+        [Option("bind", Separator = ',',
+            HelpText = "Path(s) to assemblies containing IBindable host libraries. The transpiler reflects each assembly, activates every concrete IBindable type with a parameterless ctor, and wires them into the runtime before transpilation. Repeat or comma-separate for multiple assemblies. Works with any library following the IBindable pattern (WASI, custom game hosts, etc.).")]
+        public IEnumerable<string> Bind { get; set; } = System.Array.Empty<string>();
 
         [Value(0, MetaName = "args",
             HelpText = "Positional arguments forwarded to Program.Main when --run is set.")]

--- a/Wacs.Transpiler/Cli/HostedRunner.cs
+++ b/Wacs.Transpiler/Cli/HostedRunner.cs
@@ -7,9 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Wacs.Core;
@@ -18,47 +16,36 @@ using Wacs.Core.Runtime.Types;
 using Wacs.Core.Types;
 using Wacs.Core.Types.Defs;
 using Wacs.Transpiler.AOT;
-using Wacs.WASIp1;
 
 namespace Wacs.Transpiler.Cli
 {
     /// <summary>
-    /// Wires WASI preview1 imports into a transpiled module and invokes an
-    /// entry-point export in-process.
+    /// Runs a transpiled WASM module in-process with any number of
+    /// <see cref="IBindable"/> host libraries wired into the runtime —
+    /// WASI, a game-engine host, a custom syscall shim, whatever the caller
+    /// passes in. The runtime owns the host bindings; an ImportDispatcher
+    /// proxy implements the transpiler's generated IImports by forwarding
+    /// each method call through <c>runtime.CreateStackInvoker</c> for the
+    /// matching bound host (mixed mode: AOT code, interpreter imports).
     ///
-    /// The WASI host functions are bound to the interpreter's WasmRuntime
-    /// (standard WASIp1 bindings), then an ImportDispatcher proxy implements
-    /// the transpiler's generated IImports interface by forwarding each
-    /// method call through <c>runtime.CreateStackInvoker</c> — mixed mode:
-    /// transpiled code calls interpreter for imports.
-    ///
-    /// Shared MemoryInstance between the transpiled ctx and the interpreter
-    /// moduleInst is handled by the linker so WASI's fd_write / args_get /
-    /// etc. see the same bytes the transpiled module reads and writes.
+    /// The transpiled module's linear memory is swapped for the interpreter's
+    /// <see cref="MemoryInstance"/> (<c>Store[moduleInst.MemAddrs[i]]</c>) so
+    /// host functions that read <c>ctx.DefaultMemory</c> (e.g. WASI's
+    /// <c>fd_write</c>, <c>args_get</c>) see the exact same bytes the AOT
+    /// code is reading and writing.
     /// </summary>
-    public static class WasiRunner
+    public static class HostedRunner
     {
-        public static WasiConfiguration BuildDefaultConfiguration(IEnumerable<string> programArgs)
-        {
-            return new WasiConfiguration
-            {
-                StandardInput = Console.OpenStandardInput(),
-                StandardOutput = Console.OpenStandardOutput(),
-                StandardError = Console.OpenStandardError(),
-                Arguments = programArgs.ToList(),
-                EnvironmentVariables = Environment.GetEnvironmentVariables()
-                    .Cast<DictionaryEntry>()
-                    .ToDictionary(de => de.Key.ToString()!,
-                                  de => de.Value?.ToString() ?? string.Empty),
-                HostRootDirectory = Directory.GetCurrentDirectory(),
-            };
-        }
-
         /// <summary>
-        /// After the module has been instantiated + transpiled with WASI
-        /// host functions already bound to the runtime, construct the Module
-        /// class with an IImports proxy that forwards to the runtime's
-        /// bound hosts, then invoke the named export.
+        /// Instantiate the transpiled Module class against the given
+        /// interpreter moduleInst + runtime, share memory, and invoke the
+        /// named export.
+        ///
+        /// Callers are expected to have bound any host libraries to the
+        /// runtime BEFORE calling <see cref="WasmRuntime.InstantiateModule"/>.
+        /// <see cref="BindingLoader"/> handles the <c>--bind</c> CLI case;
+        /// hand-wired hosts can just call <c>host.BindToRuntime(runtime)</c>
+        /// themselves.
         /// </summary>
         public static int Run(
             TranspilationResult result,
@@ -69,7 +56,7 @@ namespace Wacs.Transpiler.Cli
         {
             if (result.ModuleClass == null)
             {
-                Console.Error.WriteLine("error: --wasi: transpiler produced no Module class");
+                Console.Error.WriteLine("error: host run: transpiler produced no Module class");
                 return 1;
             }
 
@@ -79,7 +66,7 @@ namespace Wacs.Transpiler.Cli
                 importsProxy = BuildImportsProxy(result, runtime, moduleInst);
                 if (importsProxy == null)
                 {
-                    Console.Error.WriteLine("error: --wasi: could not build IImports proxy");
+                    Console.Error.WriteLine("error: host run: could not build IImports proxy");
                     return 1;
                 }
             }
@@ -93,26 +80,16 @@ namespace Wacs.Transpiler.Cli
             }
             catch (TargetInvocationException tie)
             {
-                Console.Error.WriteLine($"error: --wasi: module ctor threw: {tie.InnerException?.Message ?? tie.Message}");
+                Console.Error.WriteLine($"error: host run: module ctor threw: {tie.InnerException?.Message ?? tie.Message}");
                 return 1;
             }
 
             if (module == null)
             {
-                Console.Error.WriteLine("error: --wasi: Activator.CreateInstance returned null");
+                Console.Error.WriteLine("error: host run: Activator.CreateInstance returned null");
                 return 1;
             }
 
-            // Share MemoryInstance between the transpiled ctx and the
-            // interpreter moduleInst so WASI host functions (which write via
-            // ctx.DefaultMemory = Store[Frame.Module.MemAddrs[0]]) and the
-            // transpiled code see the same bytes. InitializationHelper
-            // allocated a fresh MemoryInstance per ctx.Memories slot; swap it
-            // for the one already sitting in the runtime's Store. Data
-            // segments are already copied into both — interpreter applied
-            // them at InstantiateModule time, the transpiler applied them
-            // during its own init — but only the interpreter's copy matters
-            // after this patch since the fresh allocation gets collected.
             ShareMemoriesWithRuntime(module, result, runtime, moduleInst);
 
             var method = FindExportMethod(result, exportName);
@@ -120,7 +97,7 @@ namespace Wacs.Transpiler.Cli
             {
                 var available = string.Join(", ", result.ExportMethods.Select(m => "\"" + m.WasmName + "\""));
                 Console.Error.WriteLine(
-                    $"error: --wasi: export '{exportName}' not found; available: [{available}]");
+                    $"error: host run: export '{exportName}' not found; available: [{available}]");
                 return 1;
             }
 
@@ -136,14 +113,23 @@ namespace Wacs.Transpiler.Cli
             catch (TargetInvocationException tie)
             {
                 var inner = tie.InnerException;
-                if (inner is WasiExitException exit) return exit.ExitCode;
-                Console.Error.WriteLine($"error: --wasi: {inner?.GetType().Name}: {inner?.Message ?? tie.Message}");
+                Console.Error.WriteLine($"error: host run: {inner?.GetType().Name}: {inner?.Message ?? tie.Message}");
                 if (verbose && inner != null)
                     Console.Error.WriteLine(inner.StackTrace);
                 return 1;
             }
         }
 
+        /// <summary>
+        /// Share <see cref="MemoryInstance"/> between the transpiled ctx and
+        /// the interpreter moduleInst. The generated Module ctor's
+        /// InitializationHelper allocated fresh memories and copied data
+        /// segments into them; swap each slot for the one sitting in the
+        /// runtime Store so host imports (reading via ctx.DefaultMemory) and
+        /// the AOT code see the same bytes. The interpreter's
+        /// InstantiateModule already copied data segments into its
+        /// MemoryInstance, so after the swap no bytes are lost.
+        /// </summary>
         private static void ShareMemoriesWithRuntime(
             object module, TranspilationResult result,
             WasmRuntime runtime, ModuleInstance moduleInst)
@@ -171,8 +157,6 @@ namespace Wacs.Transpiler.Cli
             var export = result.ExportMethods.FirstOrDefault(m =>
                 m.WasmName == exportName || m.Name == exportName);
             if (export == null || result.ModuleClass == null) return null;
-            // Exports are public instance methods on the Module class; look up
-            // by the CLR-sanitized name (export.Name).
             return result.ModuleClass.GetMethod(
                 export.Name,
                 BindingFlags.Public | BindingFlags.Instance);
@@ -182,10 +166,6 @@ namespace Wacs.Transpiler.Cli
         {
             var ps = method.GetParameters();
             var args = new object?[ps.Length];
-            // WASI entry points (`_start`) take no args; other zero-arg exports
-            // (`start`, `main` etc.) are fine too. Anything with params here
-            // uses default values — caller should use --emit-main for typed
-            // entry points that need CLI-parsed args.
             for (int i = 0; i < ps.Length; i++)
                 args[i] = ps[i].ParameterType.IsValueType
                     ? Activator.CreateInstance(ps[i].ParameterType)
@@ -196,9 +176,9 @@ namespace Wacs.Transpiler.Cli
         /// <summary>
         /// Build an IImports proxy whose methods forward each call through
         /// the interpreter's stack invoker for the matching bound host
-        /// function. Same shape as the test harness's BuildImportsProxy
-        /// (see Wacs.Transpiler.Test/AotSpecTests.cs) but for WASI only —
-        /// no cross-module wrapper lookup needed.
+        /// function. Host bindings must already be registered on the runtime
+        /// (any <see cref="IBindable"/> host library does this via its
+        /// BindToRuntime implementation).
         /// </summary>
         private static object? BuildImportsProxy(
             TranspilationResult result, WasmRuntime runtime, ModuleInstance moduleInst)
@@ -211,8 +191,6 @@ namespace Wacs.Transpiler.Cli
                 var importName = importMethod.Name;
                 var funcType = importMethod.WasmType;
 
-                // Find the matching import in the module repr so we can look
-                // up the bound host function by (module, entity).
                 Wacs.Core.Module.Import? matched = null;
                 foreach (var imp in moduleInst.Repr.Imports)
                 {
@@ -225,13 +203,12 @@ namespace Wacs.Transpiler.Cli
 
                 if (matched == null)
                 {
-                    handlers[importName] = _ => null; // unknown; return default
+                    handlers[importName] = _ => null;
                     continue;
                 }
 
                 var capturedImport = matched;
                 var capturedFuncType = funcType;
-                // CreateStackInvoker doesn't change per-call — cache it.
                 Delegates.StackFunc? cachedInvoker = null;
                 handlers[importName] = args =>
                 {
@@ -243,13 +220,11 @@ namespace Wacs.Transpiler.Cli
                         cachedInvoker = runtime.CreateStackInvoker(addr);
                     }
 
-                    // WASI host functions read ctx.DefaultMemory =
-                    // Store[Frame.Module.MemAddrs[0]]. When invoked from our
-                    // proxy (no prior WASM caller frame), Frame is the sentinel
-                    // NullFrame and DefaultMemory dereferences null. Temporarily
-                    // set Frame to one bound to moduleInst — the same module
-                    // the transpiled code represents — so WASI reads the shared
-                    // interpreter memory. We restore the prior Frame after.
+                    // Host functions that read ctx.DefaultMemory need a Frame
+                    // whose Module is moduleInst. Invoking a bound host via
+                    // CreateStackInvoker standalone leaves Frame = NullFrame,
+                    // which NREs on MemAddrs[0]. Temporarily set Frame, then
+                    // restore after the call.
                     var ctx = runtime.ExecContext;
                     var savedFrame = ctx.Frame;
                     var frame = ctx.ReserveFrame(moduleInst, capturedFuncType.ResultType.Arity);
@@ -274,7 +249,7 @@ namespace Wacs.Transpiler.Cli
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"error: --wasi: proxy creation failed: {ex.Message}");
+                Console.Error.WriteLine($"error: host run: proxy creation failed: {ex.Message}");
                 return null;
             }
         }
@@ -306,13 +281,5 @@ namespace Wacs.Transpiler.Cli
             ValType.F64 => val.Data.Float64,
             _ => (object)val,
         };
-
-        /// <summary>
-        /// Signaled by WASI's proc_exit — let the CLI exit with the requested
-        /// code rather than propagating the exception. (Wacs.WASIp1 throws a
-        /// specific exception type; fall back to any exception named
-        /// "WasiExitException" / "ProcExit" to stay tolerant of renames.)
-        /// </summary>
-        private class WasiExitException : Exception { public int ExitCode; }
     }
 }

--- a/Wacs.Transpiler/Cli/ImportDispatcher.cs
+++ b/Wacs.Transpiler/Cli/ImportDispatcher.cs
@@ -1,0 +1,61 @@
+// Copyright 2025 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Wacs.Transpiler.Cli
+{
+    /// <summary>
+    /// DispatchProxy that implements a generated IImports interface by
+    /// routing each import method call to a handler registered by name.
+    /// Used by <see cref="WasiRunner"/> to bridge transpiled-module imports
+    /// to the interpreter's bound WASI host functions.
+    /// </summary>
+    public class ImportDispatcher : DispatchProxy
+    {
+        private readonly Dictionary<string, Func<object?[], object?>> _handlers = new();
+
+        public void Register(string methodName, Func<object?[], object?> handler)
+        {
+            _handlers[methodName] = handler;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod == null) return null;
+            if (_handlers.TryGetValue(targetMethod.Name, out var handler))
+                return handler(args ?? Array.Empty<object?>());
+
+            if (targetMethod.ReturnType == typeof(void)) return null;
+            if (targetMethod.ReturnType.IsValueType)
+                return Activator.CreateInstance(targetMethod.ReturnType);
+            return null;
+        }
+
+        /// <summary>
+        /// Create a proxy implementing the given IImports interface type,
+        /// backed by an ImportDispatcher with the given handlers.
+        /// </summary>
+        public static object Create(Type importsInterface, Dictionary<string, Func<object?[], object?>> handlers)
+        {
+            var createMethod = typeof(DispatchProxy)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .First(m => m.Name == "Create" && m.GetGenericArguments().Length == 2)
+                .MakeGenericMethod(importsInterface, typeof(ImportDispatcher));
+
+            var proxy = createMethod.Invoke(null, null)!;
+            var dispatcher = (ImportDispatcher)proxy;
+            foreach (var kv in handlers)
+                dispatcher.Register(kv.Key, kv.Value);
+            return proxy;
+        }
+    }
+}

--- a/Wacs.Transpiler/Cli/Program.cs
+++ b/Wacs.Transpiler/Cli/Program.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using CommandLine;
 using Wacs.Core;
 using Wacs.Core.Runtime;
@@ -53,9 +54,10 @@ namespace Wacs.Transpiler.Cli
                 return ExitUsage;
             }
 
-            if (opts.Run && !opts.EmitMain && !opts.Wasi)
+            bool hasHostBindings = opts.Wasi || opts.Bind.Any();
+            if (opts.Run && !opts.EmitMain && !hasHostBindings)
             {
-                Console.Error.WriteLine("error: --run requires --emit-main or --wasi");
+                Console.Error.WriteLine("error: --run requires --emit-main, --wasi, or --bind");
                 return ExitUsage;
             }
 
@@ -90,30 +92,53 @@ namespace Wacs.Transpiler.Cli
             Module module;
             WasmRuntime runtime;
             ModuleInstance moduleInst;
-            Wasi? wasi = null;
+            var hostBindings = new List<IBindable>();
+            var disposables = new List<IDisposable>();
             try
             {
                 using var fileStream = new FileStream(input, FileMode.Open, FileAccess.Read);
                 module = BinaryModuleParser.ParseWasm(fileStream);
                 runtime = new WasmRuntime();
 
-                // Bind WASI preview1 host functions before instantiation so the
-                // module's imports resolve to Wacs.WASIp1 bindings.
+                // --wasi is a shortcut that reuses the --bind machinery with
+                // a curated WASI argv. Otherwise, load the assemblies named
+                // by --bind, activate every IBindable with a parameterless
+                // ctor, and hand them to the runtime.
                 if (opts.Wasi)
                 {
-                    var argList = new List<string> { Path.GetFileName(input) };
-                    argList.AddRange(opts.Args);
-                    var config = WasiRunner.BuildDefaultConfiguration(argList);
-                    wasi = new Wasi(config);
-                    wasi.BindToRuntime(runtime);
+                    // Use the CLI-derived argv (wasm filename as argv[0],
+                    // then positional --run trailing args) instead of the
+                    // process-wide GetCommandLineArgs() that
+                    // Wasi.DefaultConfiguration() picks up.
+                    var wasiCfg = Wasi.DefaultConfiguration();
+                    wasiCfg.Arguments = new List<string> { Path.GetFileName(input) };
+                    wasiCfg.Arguments.AddRange(opts.Args);
+                    var wasiBinding = new Wasi(wasiCfg);
+                    hostBindings.Add(wasiBinding);
+                    disposables.Add(wasiBinding);
                 }
+
+                foreach (var asmPath in opts.Bind)
+                {
+                    var loaded = BindingLoader.LoadFromAssembly(asmPath);
+                    foreach (var b in loaded)
+                    {
+                        hostBindings.Add(b);
+                        if (b is IDisposable d) disposables.Add(d);
+                    }
+                    if (opts.Verbose)
+                        Console.WriteLine($"bind          {asmPath} → {loaded.Count} binding(s)");
+                }
+
+                foreach (var b in hostBindings)
+                    b.BindToRuntime(runtime);
 
                 moduleInst = runtime.InstantiateModule(module);
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"error: failed to parse/instantiate module: {ex.Message}");
-                wasi?.Dispose();
+                foreach (var d in disposables) d.Dispose();
                 return ExitTranspileFailure;
             }
 
@@ -154,8 +179,8 @@ namespace Wacs.Transpiler.Cli
             int runExit = ExitOk;
             if (opts.Run)
             {
-                if (opts.Wasi)
-                    runExit = WasiRunner.Run(result, runtime, moduleInst, opts.EntryPoint, opts.Verbose);
+                if (hasHostBindings)
+                    runExit = HostedRunner.Run(result, runtime, moduleInst, opts.EntryPoint, opts.Verbose);
                 else
                     runExit = InvokeEmittedMain(programType!, opts);
             }
@@ -193,7 +218,7 @@ namespace Wacs.Transpiler.Cli
                 Console.WriteLine($"wrote {output} ({result.TranspiledCount} functions, {timer.ElapsedMilliseconds}ms)");
             }
 
-            wasi?.Dispose();
+            foreach (var d in disposables) d.Dispose();
             return runExit;
         }
 

--- a/Wacs.Transpiler/Cli/Program.cs
+++ b/Wacs.Transpiler/Cli/Program.cs
@@ -7,6 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using CommandLine;
@@ -14,6 +15,7 @@ using Wacs.Core;
 using Wacs.Core.Runtime;
 using Wacs.Core.Runtime.Types;
 using Wacs.Transpiler.AOT;
+using Wacs.WASIp1;
 
 namespace Wacs.Transpiler.Cli
 {
@@ -51,9 +53,9 @@ namespace Wacs.Transpiler.Cli
                 return ExitUsage;
             }
 
-            if (opts.Run && !opts.EmitMain)
+            if (opts.Run && !opts.EmitMain && !opts.Wasi)
             {
-                Console.Error.WriteLine("error: --run requires --emit-main");
+                Console.Error.WriteLine("error: --run requires --emit-main or --wasi");
                 return ExitUsage;
             }
 
@@ -88,16 +90,30 @@ namespace Wacs.Transpiler.Cli
             Module module;
             WasmRuntime runtime;
             ModuleInstance moduleInst;
+            Wasi? wasi = null;
             try
             {
                 using var fileStream = new FileStream(input, FileMode.Open, FileAccess.Read);
                 module = BinaryModuleParser.ParseWasm(fileStream);
                 runtime = new WasmRuntime();
+
+                // Bind WASI preview1 host functions before instantiation so the
+                // module's imports resolve to Wacs.WASIp1 bindings.
+                if (opts.Wasi)
+                {
+                    var argList = new List<string> { Path.GetFileName(input) };
+                    argList.AddRange(opts.Args);
+                    var config = WasiRunner.BuildDefaultConfiguration(argList);
+                    wasi = new Wasi(config);
+                    wasi.BindToRuntime(runtime);
+                }
+
                 moduleInst = runtime.InstantiateModule(module);
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"error: failed to parse/instantiate module: {ex.Message}");
+                wasi?.Dispose();
                 return ExitTranspileFailure;
             }
 
@@ -137,7 +153,12 @@ namespace Wacs.Transpiler.Cli
             // interfere with reflective dispatch on the live types.
             int runExit = ExitOk;
             if (opts.Run)
-                runExit = InvokeEmittedMain(programType!, opts);
+            {
+                if (opts.Wasi)
+                    runExit = WasiRunner.Run(result, runtime, moduleInst, opts.EntryPoint, opts.Verbose);
+                else
+                    runExit = InvokeEmittedMain(programType!, opts);
+            }
 
             try
             {
@@ -172,6 +193,7 @@ namespace Wacs.Transpiler.Cli
                 Console.WriteLine($"wrote {output} ({result.TranspiledCount} functions, {timer.ElapsedMilliseconds}ms)");
             }
 
+            wasi?.Dispose();
             return runExit;
         }
 

--- a/Wacs.Transpiler/Cli/WasiRunner.cs
+++ b/Wacs.Transpiler/Cli/WasiRunner.cs
@@ -1,0 +1,318 @@
+// Copyright 2025 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
+using Wacs.Core.Types.Defs;
+using Wacs.Transpiler.AOT;
+using Wacs.WASIp1;
+
+namespace Wacs.Transpiler.Cli
+{
+    /// <summary>
+    /// Wires WASI preview1 imports into a transpiled module and invokes an
+    /// entry-point export in-process.
+    ///
+    /// The WASI host functions are bound to the interpreter's WasmRuntime
+    /// (standard WASIp1 bindings), then an ImportDispatcher proxy implements
+    /// the transpiler's generated IImports interface by forwarding each
+    /// method call through <c>runtime.CreateStackInvoker</c> — mixed mode:
+    /// transpiled code calls interpreter for imports.
+    ///
+    /// Shared MemoryInstance between the transpiled ctx and the interpreter
+    /// moduleInst is handled by the linker so WASI's fd_write / args_get /
+    /// etc. see the same bytes the transpiled module reads and writes.
+    /// </summary>
+    public static class WasiRunner
+    {
+        public static WasiConfiguration BuildDefaultConfiguration(IEnumerable<string> programArgs)
+        {
+            return new WasiConfiguration
+            {
+                StandardInput = Console.OpenStandardInput(),
+                StandardOutput = Console.OpenStandardOutput(),
+                StandardError = Console.OpenStandardError(),
+                Arguments = programArgs.ToList(),
+                EnvironmentVariables = Environment.GetEnvironmentVariables()
+                    .Cast<DictionaryEntry>()
+                    .ToDictionary(de => de.Key.ToString()!,
+                                  de => de.Value?.ToString() ?? string.Empty),
+                HostRootDirectory = Directory.GetCurrentDirectory(),
+            };
+        }
+
+        /// <summary>
+        /// After the module has been instantiated + transpiled with WASI
+        /// host functions already bound to the runtime, construct the Module
+        /// class with an IImports proxy that forwards to the runtime's
+        /// bound hosts, then invoke the named export.
+        /// </summary>
+        public static int Run(
+            TranspilationResult result,
+            WasmRuntime runtime,
+            ModuleInstance moduleInst,
+            string exportName,
+            bool verbose)
+        {
+            if (result.ModuleClass == null)
+            {
+                Console.Error.WriteLine("error: --wasi: transpiler produced no Module class");
+                return 1;
+            }
+
+            object? importsProxy = null;
+            if (result.ImportsInterface != null)
+            {
+                importsProxy = BuildImportsProxy(result, runtime, moduleInst);
+                if (importsProxy == null)
+                {
+                    Console.Error.WriteLine("error: --wasi: could not build IImports proxy");
+                    return 1;
+                }
+            }
+
+            object? module;
+            try
+            {
+                module = importsProxy != null
+                    ? Activator.CreateInstance(result.ModuleClass, importsProxy)
+                    : Activator.CreateInstance(result.ModuleClass);
+            }
+            catch (TargetInvocationException tie)
+            {
+                Console.Error.WriteLine($"error: --wasi: module ctor threw: {tie.InnerException?.Message ?? tie.Message}");
+                return 1;
+            }
+
+            if (module == null)
+            {
+                Console.Error.WriteLine("error: --wasi: Activator.CreateInstance returned null");
+                return 1;
+            }
+
+            // Share MemoryInstance between the transpiled ctx and the
+            // interpreter moduleInst so WASI host functions (which write via
+            // ctx.DefaultMemory = Store[Frame.Module.MemAddrs[0]]) and the
+            // transpiled code see the same bytes. InitializationHelper
+            // allocated a fresh MemoryInstance per ctx.Memories slot; swap it
+            // for the one already sitting in the runtime's Store. Data
+            // segments are already copied into both — interpreter applied
+            // them at InstantiateModule time, the transpiler applied them
+            // during its own init — but only the interpreter's copy matters
+            // after this patch since the fresh allocation gets collected.
+            ShareMemoriesWithRuntime(module, result, runtime, moduleInst);
+
+            var method = FindExportMethod(result, exportName);
+            if (method == null)
+            {
+                var available = string.Join(", ", result.ExportMethods.Select(m => "\"" + m.WasmName + "\""));
+                Console.Error.WriteLine(
+                    $"error: --wasi: export '{exportName}' not found; available: [{available}]");
+                return 1;
+            }
+
+            if (verbose)
+                Console.WriteLine($"run           {result.ModuleClass.FullName}.{method.Name}()");
+
+            try
+            {
+                var rv = method.Invoke(module, BuildArgs(method));
+                if (rv is int exitCode) return exitCode;
+                return 0;
+            }
+            catch (TargetInvocationException tie)
+            {
+                var inner = tie.InnerException;
+                if (inner is WasiExitException exit) return exit.ExitCode;
+                Console.Error.WriteLine($"error: --wasi: {inner?.GetType().Name}: {inner?.Message ?? tie.Message}");
+                if (verbose && inner != null)
+                    Console.Error.WriteLine(inner.StackTrace);
+                return 1;
+            }
+        }
+
+        private static void ShareMemoriesWithRuntime(
+            object module, TranspilationResult result,
+            WasmRuntime runtime, ModuleInstance moduleInst)
+        {
+            if (result.ModuleClass == null) return;
+            var ctxField = result.ModuleClass.GetField(
+                "_ctx", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (ctxField == null) return;
+            var ctx = ctxField.GetValue(module) as ThinContext;
+            if (ctx == null) return;
+
+            var store = runtime.RuntimeStore;
+            for (int i = 0; i < ctx.Memories.Length; i++)
+            {
+                var idx = (MemIdx)(uint)i;
+                if (!moduleInst.MemAddrs.Contains(idx)) break;
+                var memAddr = moduleInst.MemAddrs[idx];
+                if (store.Contains(memAddr))
+                    ctx.Memories[i] = store[memAddr];
+            }
+        }
+
+        private static MethodInfo? FindExportMethod(TranspilationResult result, string exportName)
+        {
+            var export = result.ExportMethods.FirstOrDefault(m =>
+                m.WasmName == exportName || m.Name == exportName);
+            if (export == null || result.ModuleClass == null) return null;
+            // Exports are public instance methods on the Module class; look up
+            // by the CLR-sanitized name (export.Name).
+            return result.ModuleClass.GetMethod(
+                export.Name,
+                BindingFlags.Public | BindingFlags.Instance);
+        }
+
+        private static object?[] BuildArgs(MethodInfo method)
+        {
+            var ps = method.GetParameters();
+            var args = new object?[ps.Length];
+            // WASI entry points (`_start`) take no args; other zero-arg exports
+            // (`start`, `main` etc.) are fine too. Anything with params here
+            // uses default values — caller should use --emit-main for typed
+            // entry points that need CLI-parsed args.
+            for (int i = 0; i < ps.Length; i++)
+                args[i] = ps[i].ParameterType.IsValueType
+                    ? Activator.CreateInstance(ps[i].ParameterType)
+                    : null;
+            return args;
+        }
+
+        /// <summary>
+        /// Build an IImports proxy whose methods forward each call through
+        /// the interpreter's stack invoker for the matching bound host
+        /// function. Same shape as the test harness's BuildImportsProxy
+        /// (see Wacs.Transpiler.Test/AotSpecTests.cs) but for WASI only —
+        /// no cross-module wrapper lookup needed.
+        /// </summary>
+        private static object? BuildImportsProxy(
+            TranspilationResult result, WasmRuntime runtime, ModuleInstance moduleInst)
+        {
+            if (result.ImportsInterface == null) return null;
+
+            var handlers = new Dictionary<string, Func<object?[], object?>>();
+            foreach (var importMethod in result.ImportMethods)
+            {
+                var importName = importMethod.Name;
+                var funcType = importMethod.WasmType;
+
+                // Find the matching import in the module repr so we can look
+                // up the bound host function by (module, entity).
+                Wacs.Core.Module.Import? matched = null;
+                foreach (var imp in moduleInst.Repr.Imports)
+                {
+                    if (imp.Desc is not Wacs.Core.Module.ImportDesc.FuncDesc) continue;
+                    var expected = InterfaceGenerator.SanitizeName($"{imp.ModuleName}_{imp.Name}");
+                    if (expected != importName) continue;
+                    matched = imp;
+                    break;
+                }
+
+                if (matched == null)
+                {
+                    handlers[importName] = _ => null; // unknown; return default
+                    continue;
+                }
+
+                var capturedImport = matched;
+                var capturedFuncType = funcType;
+                // CreateStackInvoker doesn't change per-call — cache it.
+                Delegates.StackFunc? cachedInvoker = null;
+                handlers[importName] = args =>
+                {
+                    if (cachedInvoker == null)
+                    {
+                        if (!runtime.TryGetExportedFunction(
+                                (capturedImport.ModuleName, capturedImport.Name), out var addr))
+                            return null;
+                        cachedInvoker = runtime.CreateStackInvoker(addr);
+                    }
+
+                    // WASI host functions read ctx.DefaultMemory =
+                    // Store[Frame.Module.MemAddrs[0]]. When invoked from our
+                    // proxy (no prior WASM caller frame), Frame is the sentinel
+                    // NullFrame and DefaultMemory dereferences null. Temporarily
+                    // set Frame to one bound to moduleInst — the same module
+                    // the transpiled code represents — so WASI reads the shared
+                    // interpreter memory. We restore the prior Frame after.
+                    var ctx = runtime.ExecContext;
+                    var savedFrame = ctx.Frame;
+                    var frame = ctx.ReserveFrame(moduleInst, capturedFuncType.ResultType.Arity);
+                    ctx.Frame = frame;
+                    try
+                    {
+                        var valueArgs = ConvertArgsToValues(args);
+                        var results = cachedInvoker(valueArgs);
+                        if (results.Length == 0) return null;
+                        return ConvertValueToClr(results[0], capturedFuncType.ResultType.Types[0]);
+                    }
+                    finally
+                    {
+                        ctx.Frame = savedFrame;
+                    }
+                };
+            }
+
+            try
+            {
+                return ImportDispatcher.Create(result.ImportsInterface, handlers);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"error: --wasi: proxy creation failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static Value[] ConvertArgsToValues(object?[]? args)
+        {
+            if (args == null) return Array.Empty<Value>();
+            var values = new Value[args.Length];
+            for (int i = 0; i < args.Length; i++)
+            {
+                values[i] = args[i] switch
+                {
+                    Value v => v,
+                    int iv => new Value(iv),
+                    long lv => new Value(lv),
+                    float fv => new Value(fv),
+                    double dv => new Value(dv),
+                    _ => default,
+                };
+            }
+            return values;
+        }
+
+        private static object? ConvertValueToClr(Value val, ValType type) => type switch
+        {
+            ValType.I32 => val.Data.Int32,
+            ValType.I64 => val.Data.Int64,
+            ValType.F32 => val.Data.Float32,
+            ValType.F64 => val.Data.Float64,
+            _ => (object)val,
+        };
+
+        /// <summary>
+        /// Signaled by WASI's proc_exit — let the CLI exit with the requested
+        /// code rather than propagating the exception. (Wacs.WASIp1 throws a
+        /// specific exception type; fall back to any exception named
+        /// "WasiExitException" / "ProcExit" to stay tolerant of renames.)
+        /// </summary>
+        private class WasiExitException : Exception { public int ExitCode; }
+    }
+}

--- a/Wacs.Transpiler/README.md
+++ b/Wacs.Transpiler/README.md
@@ -4,23 +4,23 @@ An ahead-of-time transpiler that compiles WebAssembly modules to .NET
 assemblies (`.dll`), built on top of [WACS](https://www.nuget.org/packages/WACS).
 Ships as the `wasm-transpile` .NET CLI tool.
 
-The generated assembly passes 469/473 on the WebAssembly 3.0 spec test
-suite — the same suite WACS is spec-complete against — but runs natively
-via the CLR's JIT instead of the interpreter's expression-tree dispatch.
-(The four remaining cases are narrow multi-return / GC-coercion gaps
-called out in the v0.1 preview limitations below.)
+The generated assembly is spec-equivalent to the WACS interpreter —
+473/473 on the WebAssembly 3.0 spec test suite, verified on both macOS
+ARM64 and Linux x64 — but runs natively via the CLR's JIT instead of
+the interpreter's expression-tree dispatch.
 
-> **v0.1 preview**: the saved `.dll` currently depends on process-local
-> init state and is intended for programmatic (same-process) use and
-> inspection — cross-process standalone execution lands in v0.2. See
-> [Known Limitations](#v01-preview-known-limitations).
+> **v0.1 known limitation**: the saved `.dll` currently depends on
+> process-local init state and is intended for programmatic
+> (same-process) use and inspection — cross-process standalone
+> execution lands in v0.2. See
+> [Known Limitations](#v01-known-limitations).
 
 ## Installation
 
 Install the CLI tool globally:
 
 ```bash
-dotnet tool install -g WACS.Transpiler --prerelease
+dotnet tool install -g WACS.Transpiler
 ```
 
 Verify:
@@ -65,7 +65,7 @@ wasm-transpile -i add.wasm -o add.dll --emit-main --entry-point add
 # now load + call Program.Main reflectively, or wrap in a dotnet host
 ```
 
-v0.1-preview constraints:
+v0.1 `--emit-main` constraints:
 - Module must have no imports.
 - The export named by `--entry-point` (default `_start`) must take scalar
   `i32`/`i64`/`f32`/`f64` params and return void or a single scalar.
@@ -121,7 +121,7 @@ var result = addMethod!.Invoke(module, new object[] { 2, 3 });
 Console.WriteLine(result);  // 5
 ```
 
-## v0.1-preview Known Limitations
+## v0.1 Known Limitations
 
 - **Cross-process execution of the saved `.dll` is not yet supported.** The
   emitted assembly depends on runtime state (a per-process

--- a/Wacs.Transpiler/README.md
+++ b/Wacs.Transpiler/README.md
@@ -70,10 +70,60 @@ v0.1 `--emit-main` constraints:
 - The export named by `--entry-point` (default `_start`) must take scalar
   `i32`/`i64`/`f32`/`f64` params and return void or a single scalar.
 
+### `--wasi`: transpile and run WASI preview1 modules
+
+For modules that import `wasi_snapshot_preview1` (anything compiled
+against a C/Rust/Go/Zig `wasi-libc` / `wasi` target), use `--wasi` to
+bind `WACS.WASIp1` before transpilation and invoke an entry-point
+export in-process. Trailing positional args become WASI `argv`.
+
+```bash
+wasm-transpile -i coremark.wasm \
+  -o coremark.dll \
+  --wasi \
+  --entry-point _start \
+  --run 1 1 1 1
+```
+
+What happens:
+1. Before instantiation, `Wacs.WASIp1.Wasi` is constructed with a
+   default configuration (stdio attached, host env inherited,
+   `Directory.GetCurrentDirectory()` as the root) and bound to the
+   interpreter's `WasmRuntime`.
+2. The module is transpiled with its WASI imports resolved against
+   those bindings.
+3. A `DispatchProxy` implementing the generated `IImports` interface
+   forwards every import method call through the interpreter's
+   `runtime.CreateStackInvoker`, so WASI syscalls go through the
+   exact same `wasi-libc`-compatible handlers used by `Wacs.Console`.
+4. The transpiled module's `ctx.Memories[0]` is swapped for the
+   interpreter's `MemoryInstance` so `fd_write` / `args_get` /
+   `clock_time_get` see the same bytes the AOT code is reading and
+   writing.
+5. The named export (default `_start`) is invoked directly on the
+   generated Module class.
+
+`--wasi` can be used with or without `--emit-main`. Without it, the
+module executes immediately in-process. With it, the emitted
+`Program.Main` is built too — but `--run` still goes through the
+WASI path.
+
+### Other framework libraries
+
+`--wasi` is a special case of a more general pattern: bind host
+functions to the runtime before transpilation. For custom host
+bindings (not WASI), use the library path below with your own
+`BindHostFunction` calls and build an `ImportDispatcher` proxy the
+same way `Wacs.Transpiler.Cli.WasiRunner` does. The CLI's `--wasi`
+flag covers the WASI-only case; anything richer is a library
+integration.
+
 ## Library Usage
 
 The tool is also a library — use `ModuleTranspiler` directly to drive
-transpilation from your own code:
+transpilation from your own code.
+
+### No imports
 
 ```csharp
 using System.IO;
@@ -96,6 +146,82 @@ dynamic instance = System.Activator.CreateInstance(moduleType)!;
 
 // …or persist to disk:
 result.SaveAssembly("module.dll");
+```
+
+### Custom host imports (`env.sayc`, game bindings, etc.)
+
+Host imports are bound to the runtime *before* `InstantiateModule`
+exactly like the interpreter path. The transpiler's generated Module
+class takes an `IImports` proxy in its constructor; `DispatchProxy`
+is the cleanest way to build one that forwards to your bound hosts:
+
+```csharp
+using System.Reflection;
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Transpiler.AOT;
+
+var runtime = new WasmRuntime();
+
+// 1. Bind your host functions (same API as Wacs.Core interpreter use).
+runtime.BindHostFunction<System.Action<char>>(("env", "sayc"), ch =>
+    System.Console.Write(ch));
+
+// 2. Instantiate through the interpreter so imports resolve.
+using var stream = new FileStream("hello.wasm", FileMode.Open);
+var wasm = BinaryModuleParser.ParseWasm(stream);
+var moduleInst = runtime.InstantiateModule(wasm);
+
+// 3. Transpile.
+var result = new ModuleTranspiler("MyApp", new TranspilerOptions())
+    .Transpile(moduleInst, runtime);
+
+// 4. Build an IImports proxy that forwards each method call to the
+// corresponding runtime.CreateStackInvoker. See the Wacs.Transpiler
+// source for the full ImportDispatcher / WasiRunner pattern — it's
+// ~100 lines and fully reusable for non-WASI hosts.
+object importsProxy = BuildImportsProxy(result, runtime, moduleInst);
+
+// 5. Instantiate the Module class. The generated ctor takes IImports.
+dynamic instance = System.Activator.CreateInstance(
+    result.ModuleClass!, importsProxy)!;
+
+// 6. Invoke an export (name = WASM export name, sanitized to a CLR
+// identifier).
+instance.main();
+```
+
+See [`Wacs.Transpiler/Cli/WasiRunner.cs`](Cli/WasiRunner.cs) for the
+full proxy implementation, including the memory-sharing hack
+(`ctx.Memories[i] = runtime.RuntimeStore[moduleInst.MemAddrs[i]]`) that
+hosts which read linear memory need.
+
+### WASI modules
+
+Skip the custom proxy work when the imports are pure WASI preview1 —
+`Wacs.Transpiler.Cli.WasiRunner` already does the binding + proxy +
+memory-sharing + entry-point dispatch end-to-end:
+
+```csharp
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Transpiler.AOT;
+using Wacs.Transpiler.Cli;
+using Wacs.WASIp1;
+
+var runtime = new WasmRuntime();
+var argv = new[] { "coremark.wasm", "1", "1", "1", "1" };
+using var wasi = new Wasi(WasiRunner.BuildDefaultConfiguration(argv));
+wasi.BindToRuntime(runtime);
+
+using var fs = new FileStream("coremark.wasm", FileMode.Open);
+var wasm = BinaryModuleParser.ParseWasm(fs);
+var moduleInst = runtime.InstantiateModule(wasm);
+
+var result = new ModuleTranspiler().Transpile(moduleInst, runtime);
+
+int exit = WasiRunner.Run(result, runtime, moduleInst,
+    exportName: "_start", verbose: false);
 ```
 
 The `TranspilationResult` also exposes `ExportMethods`, `ImportMethods`,

--- a/Wacs.Transpiler/README.md
+++ b/Wacs.Transpiler/README.md
@@ -70,12 +70,54 @@ v0.1 `--emit-main` constraints:
 - The export named by `--entry-point` (default `_start`) must take scalar
   `i32`/`i64`/`f32`/`f64` params and return void or a single scalar.
 
-### `--wasi`: transpile and run WASI preview1 modules
+### `--bind`: link against any WACS host library
+
+The transpiler can link against any assembly that exposes host
+bindings through the `Wacs.Core.Runtime.IBindable` interface:
+
+```csharp
+// In your library:
+public class MyGameHost : IBindable {
+    public void BindToRuntime(WasmRuntime runtime) {
+        runtime.BindHostFunction<Action<int>>(("env", "play_sound"), id => /*…*/);
+        runtime.BindHostFunction<Func<int,int>>(("env", "random_up_to"), n => /*…*/);
+    }
+}
+```
+
+Build the library (a standard .NET assembly), then pass it to
+`wasm-transpile` with `--bind`:
+
+```bash
+wasm-transpile -i game.wasm \
+  -o game.dll \
+  --bind ./MyGameHost.dll \
+  --entry-point _start \
+  --run
+```
+
+The transpiler loads the assembly, reflects every concrete `IBindable`
+with a parameterless constructor, activates each one, and wires them
+into the runtime before instantiating the module. Repeat or
+comma-separate `--bind` for multiple assemblies — WASI, a scripting
+shim, and a telemetry sink can all be linked in at once.
+
+Constraints for auto-discovery:
+- Each binding class needs a **parameterless constructor**. Bindings
+  that require configuration should either provide sensible defaults
+  in the parameterless ctor (`Wacs.WASIp1.Wasi()` does this) or be
+  driven from the library API below.
+- `IBindable`s that also implement `IDisposable` are disposed after
+  the run. Good for file handles, network sockets, etc.
+- The transpiler itself doesn't care which CLR-side types the host
+  uses — match what `runtime.BindHostFunction<TDelegate>` accepts.
+
+### `--wasi`: shortcut for WASI preview1
 
 For modules that import `wasi_snapshot_preview1` (anything compiled
-against a C/Rust/Go/Zig `wasi-libc` / `wasi` target), use `--wasi` to
-bind `WACS.WASIp1` before transpilation and invoke an entry-point
-export in-process. Trailing positional args become WASI `argv`.
+against a C/Rust/Go/Zig `wasi-libc` / `wasi` target), `--wasi` is a
+shortcut that's equivalent to `--bind <path-to-Wacs.WASIp1.dll>` with
+the CLI's trailing positional args exposed as WASI `argv`.
 
 ```bash
 wasm-transpile -i coremark.wasm \
@@ -88,10 +130,9 @@ wasm-transpile -i coremark.wasm \
 What happens:
 1. Before instantiation, `Wacs.WASIp1.Wasi` is constructed with a
    default configuration (stdio attached, host env inherited,
-   `Directory.GetCurrentDirectory()` as the root) and bound to the
-   interpreter's `WasmRuntime`.
-2. The module is transpiled with its WASI imports resolved against
-   those bindings.
+   `Directory.GetCurrentDirectory()` as the root, argv =
+   `[wasm-filename, …trailing-args]`) and bound to the runtime.
+2. The module is transpiled with its WASI imports resolved.
 3. A `DispatchProxy` implementing the generated `IImports` interface
    forwards every import method call through the interpreter's
    `runtime.CreateStackInvoker`, so WASI syscalls go through the
@@ -103,20 +144,10 @@ What happens:
 5. The named export (default `_start`) is invoked directly on the
    generated Module class.
 
-`--wasi` can be used with or without `--emit-main`. Without it, the
-module executes immediately in-process. With it, the emitted
-`Program.Main` is built too — but `--run` still goes through the
-WASI path.
-
-### Other framework libraries
-
-`--wasi` is a special case of a more general pattern: bind host
-functions to the runtime before transpilation. For custom host
-bindings (not WASI), use the library path below with your own
-`BindHostFunction` calls and build an `ImportDispatcher` proxy the
-same way `Wacs.Transpiler.Cli.WasiRunner` does. The CLI's `--wasi`
-flag covers the WASI-only case; anything richer is a library
-integration.
+`--wasi` and `--bind` can be combined (e.g. WASI + a custom
+telemetry host), and both work with or without `--emit-main`. When
+`--emit-main` is also set, the emitted `Program.Main` is built but
+`--run` still goes through the hosted path.
 
 ## Library Usage
 

--- a/Wacs.Transpiler/Wacs.Transpiler.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.csproj
@@ -13,7 +13,7 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler</PackageId>
         <Title>WACS Transpiler</Title>
-        <Version>0.1.0-preview.1</Version>
+        <Version>0.1.0</Version>
         <AssemblyVersion>0.1.0</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2025 Kelvin Nishikawa</Copyright>

--- a/Wacs.Transpiler/Wacs.Transpiler.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.csproj
@@ -42,6 +42,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Wacs.Core\Wacs.Core.csproj" />
+        <ProjectReference Include="..\Wacs.WASIp1\Wacs.WASIp1.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Wacs.Transpiler/docs/06-cli-howto.md
+++ b/Wacs.Transpiler/docs/06-cli-howto.md
@@ -134,7 +134,40 @@ var main = asm.GetType("Program")!.GetMethod("Main")!;
 main.Invoke(null, new object?[] { new[] { "2", "3" } }); // prints 5
 ```
 
-## 5. Known limitations (v0.1)
+## 5. `--wasi`: WASI preview1 modules
+
+For modules with `wasi_snapshot_preview1` imports (anything built
+against `wasi-libc`: C / Rust / Go / Zig targeting `wasm32-wasi`),
+`--wasi` binds `WACS.WASIp1` before transpilation and invokes the
+entry-point export in-process. Trailing positional args become WASI
+`argv`.
+
+```bash
+wasm-transpile -i coremark.wasm \
+  -o coremark.dll \
+  --wasi \
+  --entry-point _start \
+  --run 1 1 1 1
+```
+
+What you get:
+- `fd_write`, `args_get`, `args_sizes_get`, `clock_time_get`,
+  `proc_exit`, etc. are all routed to `Wacs.WASIp1`'s implementations
+  through the interpreter's host bindings.
+- The transpiled module's linear memory is swapped for the one the
+  interpreter owns, so WASI syscalls and AOT reads/writes share bytes.
+- Standard I/O is attached to the host process. The current working
+  directory is passed as the WASI root, with no preopened directories
+  by default — bind them yourself via the library API if you need
+  filesystem access.
+
+You can combine `--wasi` with `--emit-main` (the emitted `Main` is
+built but `--run` still goes through the WASI path). For custom host
+imports outside WASI, skip `--wasi` and drive transpilation from the
+library API — see the *Custom host imports* example in the package
+README.
+
+## 6. Known limitations (v0.1)
 
 See the package README's *Known Limitations* section for the full list.
 The two that matter most for this walkthrough:
@@ -146,8 +179,9 @@ The two that matter most for this walkthrough:
   embedded into the assembly yet. v0.2 will serialize init data into an
   assembly resource so the .dll becomes self-contained.
 - `--emit-main` currently supports **zero-import modules** with
-  **scalar i32/i64/f32/f64** params and a void or scalar result. WASI
-  modules, ref-typed params, and v128 params are follow-ups.
+  **scalar i32/i64/f32/f64** params and a void or scalar result. Use
+  `--wasi` for WASI modules; ref-typed params and `v128` params are
+  follow-ups.
 
 If either of these blocks your use case, please open an issue at
 <https://github.com/kelnishi/WACS>.

--- a/Wacs.Transpiler/docs/06-cli-howto.md
+++ b/Wacs.Transpiler/docs/06-cli-howto.md
@@ -6,7 +6,7 @@ doc in the series.
 
 This is a step-by-step walkthrough of installing the `wasm-transpile`
 CLI, transpiling a `.wasm` module into a .NET assembly, invoking it
-programmatically, and (within v0.1-preview's limits) using
+programmatically, and (within v0.1's limits) using
 `--emit-main` to bundle a host entry point into the output.
 
 ---
@@ -14,7 +14,7 @@ programmatically, and (within v0.1-preview's limits) using
 ## 1. Install
 
 ```bash
-dotnet tool install -g WACS.Transpiler --prerelease
+dotnet tool install -g WACS.Transpiler
 ```
 
 Confirm the command is on PATH:
@@ -134,7 +134,7 @@ var main = asm.GetType("Program")!.GetMethod("Main")!;
 main.Invoke(null, new object?[] { new[] { "2", "3" } }); // prints 5
 ```
 
-## 5. Known limitations (v0.1-preview)
+## 5. Known limitations (v0.1)
 
 See the package README's *Known Limitations* section for the full list.
 The two that matter most for this walkthrough:

--- a/Wacs.WASIp1/Wasi.cs
+++ b/Wacs.WASIp1/Wasi.cs
@@ -15,11 +15,13 @@
 //  */
 
 using System;
+using System.IO;
+using System.Linq;
 using Wacs.Core.Runtime;
 
 namespace Wacs.WASIp1
 {
-    public class Wasi : IDisposable
+    public class Wasi : IBindable, IDisposable
     {
         private readonly Clock _clock;
         private readonly WasiConfiguration _config;
@@ -32,6 +34,15 @@ namespace Wacs.WASIp1
         private readonly Sock _sock;
         private readonly State _state;
 
+        /// <summary>
+        /// Standard-defaults ctor for host discovery via <see cref="IBindable"/>.
+        /// Attaches stdio to the current process, inherits host environment
+        /// variables, and treats the process's current directory as the WASI
+        /// root with no preopens. Callers that need a tighter configuration
+        /// should use <see cref="Wasi(WasiConfiguration)"/> directly.
+        /// </summary>
+        public Wasi() : this(DefaultConfiguration()) { }
+
         public Wasi(WasiConfiguration config)
         {
             _config = config;
@@ -43,6 +54,29 @@ namespace Wacs.WASIp1
             _random = new Random();
             _sock = new Sock(_state);
             _fs = new FileSystem(config, _state);
+        }
+
+        /// <summary>
+        /// Standard-defaults WASI configuration — stdio attached to the
+        /// current process, host environment variables inherited, and the
+        /// process's current directory as the WASI root. No preopened
+        /// directories; callers that need filesystem access should extend
+        /// <see cref="WasiConfiguration.PreopenedDirectories"/>.
+        /// </summary>
+        public static WasiConfiguration DefaultConfiguration()
+        {
+            return new WasiConfiguration
+            {
+                StandardInput = Console.OpenStandardInput(),
+                StandardOutput = Console.OpenStandardOutput(),
+                StandardError = Console.OpenStandardError(),
+                Arguments = Environment.GetCommandLineArgs().Skip(1).ToList(),
+                EnvironmentVariables = Environment.GetEnvironmentVariables()
+                    .Cast<System.Collections.DictionaryEntry>()
+                    .ToDictionary(de => de.Key.ToString()!,
+                                  de => de.Value?.ToString() ?? string.Empty),
+                HostRootDirectory = Directory.GetCurrentDirectory(),
+            };
         }
 
         public void BindToRuntime(WasmRuntime runtime)


### PR DESCRIPTION
Follow-up to #64. Closes all five known v0.1-preview spec gaps — 473/473 green on both macOS ARM64 and Linux x64 (verified under `docker --platform linux/amd64`) — and graduates the package from \`0.1.0-preview.1\` to \`0.1.0\`.

## What's fixed

| wast | root cause | commit |
|---|---|---|
| func.wast | Multi-result \`return\` emitted a direct CIL \`Ret\`, leaving r1..r_{N-1} on the stack. Routed through \`funcEndLabel\` so \`EmitMultiResultReturn\` spills into byref out-params first. | fbc2adb |
| conversions.wast (f32) | \`f32.convert_i64_u\` via CLR's \`Conv_R_Un + Conv_R4\` rounds x64 vs ARM64 differently near the f32 mantissa boundary. Routed through \`FloatConversion.ULongToFloat\` for spec-exact RTNE. | 8f2e675 |
| conversions.wast (f64) | Same story for \`f64.convert_i64_u\` near the f64 boundary; uses \`FloatConversion.ULongToDouble\`. | afecac1 |
| gc/struct.wast | \`TryParseGcGlobalInit\` didn't recognize \`struct.new\` / \`struct.new_default\`, so globals typed \`(ref \$s)\` fell back to the value-based evaluator and stored a scalar that later round-tripped as a \`HostExternRef\`. Also: \`struct.get_u\` on i16 was returning sign-extended values. Added struct.new dispatch + correct Conv_I2/Conv_U2 by packed-field type. | 290686b |
| if.wast (as-select-last) | \`CilValidator.Reset\` cleared *all* known stack types whenever count != height, so pre-if \`[int, int]\` got clobbered to \`[object, object]\` when the body entered at height 2. A trailing \`select\` then dispatched \`SelectObject\` on int operands — invalid IL. Reset now truncates from the top (count > height) or pads with placeholders (count < height), preserving bottom types. | 684cd60 |
| call_indirect.wast (multi-return) | Multi-return static methods use byref out-params that don't fit \`Action\`/\`Func\`, so their FuncTable slot was null and \`EmitUnboxResult\` only decoded r0. Added \`MultiReturnMethodRegistry\` keyed by \`(initDataId, funcIdx)\`, \`CallHelpers.InvokeIndirectMulti\` that reflects into the MethodInfo with out-slots, and \`EmitUnboxResultArray\` that unpacks the N-element result array onto the CIL stack in WASM stack order. | a7ac5b1 |

## Version bump

- \`Wacs.Transpiler.csproj\` Version \`0.1.0-preview.1\` → \`0.1.0\`.
- CHANGELOG entry rewritten as **WACS.Transpiler [0.1.0] First release**, claiming 473/473 verified on both macOS ARM64 and Linux x64.
- READMEs: \`(preview)\` subheader removed, \`--prerelease\` install hint dropped, \`v0.1-preview known limitations\` → \`v0.1 known limitations\` (sole remaining item is cross-process \`.dll\` execution, still tracked for v0.2).

No changes to Wacs.Core — version stays at 0.8.0, already on main.

## Release sequence (post-merge)

\`git tag WACS-Transpiler-v0.1.0 <merge-sha> && git push origin WACS-Transpiler-v0.1.0\` — the existing NuGet workflow publishes from the merge commit.

## Test plan

- [x] Local (macOS ARM64): Spec 486/486, Transpiler 473/473, allowlist empty.
- [x] Docker linux/amd64 (x64): Transpiler 473/473, allowlist empty.
- [ ] CI (ubuntu-latest): confirm 473/473 across both test projects.
- [ ] Post-merge: push \`WACS-Transpiler-v0.1.0\` tag; confirm the Transpiler matrix row publishes to nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)