### PR TITLE
nuget.yml: switch to Trusted Publishing via GitHub OIDC

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      # Required for NuGet Trusted Publishing via GitHub OIDC.
+      id-token: write
+      contents: read
     strategy:
       matrix:
         include:
@@ -56,9 +60,16 @@ jobs:
         if: env.build == 'true'
         run: dotnet pack ${{ matrix.path }} --configuration Release --no-build -o output
 
+      - name: NuGet Trusted Publishing login
+        if: env.build == 'true'
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: kelnishi
+
       - name: Push to NuGet
         if: env.build == 'true'
-        run: dotnet nuget push "output/*.nupkg" --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "output/*.nupkg" --skip-duplicate --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
       - name: Push to GitHub Packages
         if: env.build == 'true'


### PR DESCRIPTION
Drop the long-lived \`NUGET_API_KEY\` secret in favor of NuGet Trusted Publishing — each workflow run exchanges its GitHub OIDC token for a short-lived (~30 min) nuget.org API key via \`NuGet/login@v1\`.

## Before this can publish

Each package on nuget.org needs a trusted-publisher registration pointing at this workflow:

- https://www.nuget.org/packages/WACS → Manage Package → Trusted Publishing → Add
- https://www.nuget.org/packages/WACS.WASIp1 → same
- For WACS.Transpiler (not yet published): Account → Trusted Publishers → Add for the reserved \`WACS.*\` namespace.

Registration fields:
- **Publisher**: GitHub Actions
- **Owner**: \`kelnishi\`
- **Repository**: \`WACS\`
- **Workflow filename**: \`nuget.yml\`
- **Environment**: *(leave blank)*

## After merge — re-run the Core 0.8.0 publish

The existing \`WACS-v0.8.0\` tag still points at the merge commit. To trigger a fresh publish run that uses the new workflow, delete and re-push:

\`\`\`
git push origin :refs/tags/WACS-v0.8.0
git tag -d WACS-v0.8.0
git tag WACS-v0.8.0 1932495
git push origin WACS-v0.8.0
\`\`\`

Once Core lands on nuget.org, tag and push \`WACS-Transpiler-v0.1.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)