### PR TITLE
nuget.yml: restore packages:write permission

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -14,6 +14,10 @@ jobs:
       # Required for NuGet Trusted Publishing via GitHub OIDC.
       id-token: write
       contents: read
+      # Required for `dotnet nuget push` to GitHub Packages — an explicit
+      # `permissions:` block drops the default `packages: write` that
+      # GITHUB_TOKEN would otherwise carry.
+      packages: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Small follow-up to #66. When I added an explicit `permissions:` block to nuget.yml to enable Trusted Publishing (`id-token: write`), GitHub dropped the default `packages: write` that `GITHUB_TOKEN` would otherwise carry. The nuget.org Trusted Publishing push worked fine (Core 0.8.0 is published), but the secondary `Push to GitHub Packages` step got a 403 Forbidden. Restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)