### PR TITLE
nuget.yml: drop GitHub Packages publish; nuget.org is canonical

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -14,10 +14,6 @@ jobs:
       # Required for NuGet Trusted Publishing via GitHub OIDC.
       id-token: write
       contents: read
-      # Required for `dotnet nuget push` to GitHub Packages — an explicit
-      # `permissions:` block drops the default `packages: write` that
-      # GITHUB_TOKEN would otherwise carry.
-      packages: write
     strategy:
       matrix:
         include:
@@ -74,7 +70,3 @@ jobs:
       - name: Push to NuGet
         if: env.build == 'true'
         run: dotnet nuget push "output/*.nupkg" --skip-duplicate --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-
-      - name: Push to GitHub Packages
-        if: env.build == 'true'
-        run: dotnet nuget push "output/*.nupkg" --skip-duplicate --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 ![wasm wast spec](https://github.com/kelnishi/WACS/actions/workflows/ci.yml/badge.svg?branch=main) 
 ![Platform](https://img.shields.io/badge/platform-.NET%20Standard%202.1-blue)
 [![License](https://img.shields.io/github/license/kelnishi/WACS)](LICENSE)
-[![NuGet](https://img.shields.io/nuget/v/WACS)](https://www.nuget.org/packages/WACS)
-[![Downloads](https://img.shields.io/nuget/dt/WACS)](https://www.nuget.org/packages/WACS)
-[![NuGet (Transpiler)](https://img.shields.io/nuget/vpre/WACS.Transpiler?label=WACS.Transpiler)](https://www.nuget.org/packages/WACS.Transpiler)
+[![NuGet](https://img.shields.io/nuget/v/WACS?label=WACS)](https://www.nuget.org/packages/WACS)
+[![NuGet (WASIp1)](https://img.shields.io/nuget/v/WACS.WASIp1?label=WACS.WASIp1)](https://www.nuget.org/packages/WACS.WASIp1)
+[![NuGet (Transpiler)](https://img.shields.io/nuget/v/WACS.Transpiler?label=WACS.Transpiler)](https://www.nuget.org/packages/WACS.Transpiler)
+[![Downloads](https://img.shields.io/nuget/dt/WACS?label=WACS%20downloads)](https://www.nuget.org/packages/WACS)
 
 ## Overview
 Latest changes: [0.8.0](https://github.com/kelnishi/WACS/tree/main/CHANGELOG.md)


### PR DESCRIPTION
The repo's sidebar \"Packages\" section only surfaces the GitHub Packages registry (there's no way to point it at nuget.org), and we don't actually want the mirror — nuget.org is the canonical distribution channel via Trusted Publishing. Drop the secondary push step so the sidebar can be hidden cleanly via the repo About settings.

Also:
- Removes \`packages: write\` from the job permissions (no longer needed).
- Adds a \`WACS.WASIp1\` badge to the root README alongside WACS and WACS.Transpiler.
- Bumps the \`WACS.Transpiler\` badge from \`vpre\` (pre-release) to \`v\` (stable) now that 0.1.0 is out.

## Follow-up (your side)

1. On <https://github.com/kelnishi/WACS> → About (pencil icon) → uncheck **Packages** to hide the sidebar entry.
2. Optionally delete the already-published GitHub Packages entries at <https://github.com/users/kelnishi/packages?repo_name=WACS> (purely cosmetic — they won't get new versions either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)