### PR TITLE
README: bump latest-changes pointer to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Downloads](https://img.shields.io/nuget/dt/WACS?label=WACS%20downloads)](https://www.nuget.org/packages/WACS)
 
 ## Overview
-Latest changes: [0.8.0](https://github.com/kelnishi/WACS/tree/main/CHANGELOG.md)
+Latest changes: [0.8.1](https://github.com/kelnishi/WACS/tree/main/CHANGELOG.md)
 
 **WACS** is a pure C# WebAssembly Interpreter for running WASM modules in .NET environments, including Godot and AOT environments like Unity's IL2CPP.
 


### PR DESCRIPTION
## Summary

- Trailing follow-up after #69 merged: the top-of-README "Latest changes" link was still pointing at `0.8.0`. Bumps to `0.8.1` to match the shipped `CHANGELOG.md` / `Wacs.Core.csproj` version.

## Test plan

- [x] Grep confirms only the link target changed.
- [ ] Reviewer: confirm the rendered README reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)