### PR TITLE
nuget.yml: also publish WACS.Transpiler.Lib on WACS-Transpiler-v* tags

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -26,6 +26,9 @@ jobs:
           - path: Wacs.Transpiler
             package_name: WACS.Transpiler
             tag_prefix: WACS-Transpiler-v
+          - path: Wacs.Transpiler.Lib
+            package_name: WACS.Transpiler.Lib
+            tag_prefix: WACS-Transpiler-v
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Follow-up to #71. The v0.2 transpiler split added a new package (`WACS.Transpiler.Lib`) that the NuGet publish workflow doesn't know about — tagging `WACS-Transpiler-v0.2.0` as-is would push the CLI tool to nuget.org but leave the library package orphan.

Adds `Wacs.Transpiler.Lib` to the publish matrix with the same `WACS-Transpiler-v` tag prefix, so a single v0.2.0 tag fans out into two publish jobs and both `.nupkg`s land on nuget.org.

## Test plan

- [ ] Merge, then tag `WACS-Transpiler-v0.2.0` — verify both `WACS.Transpiler` and `WACS.Transpiler.Lib` appear on nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)