### PR TITLE
Wacs.Console: unify --super across poly + switch runtimes (drop --switch_super)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ dotnet run --project Wacs.Console -c Release -- --super Wacs.Console/Data/corema
 dotnet run --project Wacs.Console -c Release -- --switch Wacs.Console/Data/coremark.wasm
 
 # Switch runtime + bytecode-stream super-instruction fuser
-dotnet run --project Wacs.Console -c Release -- --switch --switch_super Wacs.Console/Data/coremark.wasm
+dotnet run --project Wacs.Console -c Release -- --switch --super Wacs.Console/Data/coremark.wasm
 
 # AOT transpile to .NET IL and run through the JITted code (-t alias: --aot)
 dotnet run --project Wacs.Console -c Release -- -t Wacs.Console/Data/coremark.wasm
@@ -418,9 +418,8 @@ dotnet run --project Wacs.Console -c Release -- -i fib Wacs.Bench/fib.wasm 10
 | Flag | Effect |
 |---|---|
 | *(none)* | Polymorphic virtual-dispatch interpreter. Baseline, canonical. |
-| `--super` | Polymorphic + block-level super-instruction rewriter. |
+| `--super` | Enable super-instruction fusion on whichever runtime ends up executing — the polymorphic block-level rewriter, and (when paired with `--switch`) the switch runtime's bytecode-stream fuser. |
 | `--switch` | Source-generated monolithic-switch interpreter. Build-time code generation (Roslyn) + `System.Runtime.CompilerServices.Unsafe` intrinsics — see note below. |
-| `--switch_super` | (Requires `--switch`.) Additionally run the bytecode-stream fuser. |
 | `-t`, `--transpiler`, `--aot` | AOT transpile the **WASM module** to .NET IL and run the generated code. Requires `Reflection.Emit` at runtime — see note below. |
 | `--aot_simd {scalar,intrinsics,interpreter}` | SIMD strategy for the AOT path. |
 | `--aot_save <path>` | Persist the transpiled assembly to disk. |
@@ -432,11 +431,11 @@ dotnet run --project Wacs.Console -c Release -- -i fib Wacs.Bench/fib.wasm 10
 
 | Mode | CoreMark (iter/s) | Relative |
 |---|---:|---:|
-| polymorphic | 276 | 1.00× |
-| `--super` | 328 | 1.19× |
-| `--switch` | 349 | 1.27× |
-| `--switch --switch_super` | 382 | 1.38× |
-| `-t` (AOT) | **17 651** | **64×** |
+| polymorphic | 274 | 1.00× |
+| `--super` | 337 | 1.23× |
+| `--switch` | 358 | 1.31× |
+| `--switch --super` | 385 | 1.40× |
+| `-t` (AOT) | **17 552** | **64×** |
 
 The AOT path emits ordinary .NET methods that the CLR JIT optimizes as
 native code, so the ~64× jump over the fastest interpreter mode is the
@@ -485,8 +484,7 @@ interpreter's host-function machinery.
 > Both the polymorphic (default) and the polymorphic-super (`--super`)
 > modes are pure managed code with no source-gen and no Unsafe usage —
 > pick those if you need the most conservative surface. Expect ~25–40%
-> lower throughput vs `--switch --switch_super` on compute-bound
-> workloads.
+> lower throughput vs `--switch --super` on compute-bound workloads.
 
 ## Roadmap
 

--- a/Wacs.Console/CommandLineOptions.cs
+++ b/Wacs.Console/CommandLineOptions.cs
@@ -75,14 +75,11 @@ namespace Wacs.Console
         [Option('t', "transpiler", HelpText = "Ahead-of-time transpile the module to .NET IL and run through the transpiled code (CLR JIT-native speed). Imports wired through the interpreter for mixed-mode execution. Alias of --aot.", Default = false)]
         public bool Transpile { get; set; }
 
-        [Option("super", HelpText = "Enable interpreter super-instruction rewriting (block-level expression fusion). Applies to the polymorphic dispatcher only.", Default = false)]
+        [Option("super", HelpText = "Enable super-instruction fusion. Applies to both the polymorphic runtime (block-level expression rewriter) and, when combined with --switch, the switch runtime's bytecode-stream fuser.", Default = false)]
         public bool SuperInstructions { get; set; }
 
         [Option("switch", HelpText = "Use the source-generated monolithic switch runtime (faster, AOT-safe).", Default = false)]
         public bool UseSwitch { get; set; }
-
-        [Option("switch_super", HelpText = "When --switch is set, enable the bytecode-stream super-instruction fuser.", Default = false)]
-        public bool SwitchSuperInstructions { get; set; }
 
         [Option("aot", HelpText = "Alias of --transpiler: AOT transpile the module and run through the transpiled code.", Default = false)]
         public bool Aot { get; set; }

--- a/Wacs.Console/Program.cs
+++ b/Wacs.Console/Program.cs
@@ -225,17 +225,22 @@ namespace Wacs.Console
             if (opts.LogProg)
                 System.Console.Error.WriteLine($"Instantiating Module {moduleName}");
 
-            // Interpreter super-instructions (polymorphic path only).
-            if (opts.SuperInstructions)
-                runtime.SuperInstruction = true;
-
-            // Switch runtime opt-in. Flag must be set BEFORE InstantiateModule —
-            // phase N eagerly compiles every module-owned function at link time
-            // when this is true; flipping post-instantiate is unsupported.
+            // --super routes to whichever fuser belongs to the active
+            // runtime: the polymorphic block-level rewriter rewrites the
+            // instruction tree into Wacs.Core.Instructions.SuperInstruction
+            // types that the switch-runtime's BytecodeCompiler can't
+            // consume, so the two are mutually exclusive. --switch takes
+            // precedence: when present, --super enables the switch
+            // runtime's bytecode-stream fuser; otherwise it enables the
+            // polymorphic tree rewriter.
             if (opts.UseSwitch)
             {
                 runtime.UseSwitchRuntime = true;
-                runtime.ExecContext.Attributes.UseSwitchSuperInstructions = opts.SwitchSuperInstructions;
+                runtime.ExecContext.Attributes.UseSwitchSuperInstructions = opts.SuperInstructions;
+            }
+            else if (opts.SuperInstructions)
+            {
+                runtime.SuperInstruction = true;
             }
 
             //Validation normally happens after instantiation, but you can skip it if you did it after parsing, or you're like super confident.


### PR DESCRIPTION
## Summary

Collapses `--super` + `--switch_super` into a single `--super` flag that dispatches to whichever runtime is active. Before, `--super` only affected the polymorphic runtime (tree rewriter producing `InstCompound*` types), `--switch_super` only affected the switch runtime (bytecode-stream fuser), and combining them tripped an `InvalidCastException` because the poly rewriter's output isn't consumable by the switch compiler.

After:

- `--super` alone → polymorphic tree rewriter.
- `--switch --super` → switch runtime + bytecode-stream fuser (poly rewriter bypassed).
- `--switch` alone → switch runtime with no fusion.
- `--switch_super` removed (now an unknown option).

One knob, correct for every combination. README's flag cheatsheet and perf table updated in the same commit.

## Sampled CoreMark numbers (M3 Max)

| Mode | iter/s |
|---|---:|
| polymorphic | 274 |
| `--super` | 337 |
| `--switch` | 358 |
| `--switch --super` | 385 |
| `-t` (AOT) | 17 552 |

## Test plan

- [x] All five mode combinations run CoreMark to completion with the expected throughput.
- [x] `--switch_super` is rejected with an "unknown option" error.
- [ ] Reviewer: confirm no downstream scripts depend on `--switch_super`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)