### PR TITLE
README: real native CoreMark baseline + honest tier comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,27 +394,60 @@ The transpiler is spec-equivalent to the interpreter on the WebAssembly 3.0 test
 
 ### Expected Runtime Performance
 
-Rough throughput positioning on compute-bound workloads (CoreMark on an
-M3 Max; "native" = a `clang -O3` build of the same C source running
-directly on the CPU). Numbers move with hardware, the WASM module, and
-the CLR JIT version — treat as ballpark, not benchmark ground truth.
+Measured CoreMark throughput on a MacBook Pro M3 Max, .NET 8. The
+native baseline is the EEMBC CoreMark C source built with
+`clang -O3` and run directly on the CPU (single-core, 600 000
+iterations, three runs within 0.2% of each other). WACS numbers come
+from running `Wacs.Console/Data/coremark.wasm` — the same C source,
+compiled to WASM with `clang -O3` via emscripten — through each mode.
 
-| Mode | CoreMark iter/s | % of native | Comparable to |
-|---|---:|---:|---|
-| WACS polymorphic (default) | ~275 | ~0.4% | Wasm3 / Wasmi (pure interpreters), CPython |
-| WACS `--super` | ~335 | ~0.5% | Wasm3 / Wasmi (pure interpreters) |
-| WACS `--switch` | ~360 | ~0.5% | faster than Wasm3, ~1/2 of WebAssembly Micro Runtime's interpreter |
-| WACS `--switch --super` | ~385 | ~0.6% | top-tier interpreter territory |
-| WACS `-t` / `--aot` (Reflection.Emit) | ~17 500 | ~25% | Node.js / V8 running the same logic as JavaScript (~40–60% of this AOT) |
-| `wasm-transpile` pre-compiled `.dll` loaded via `TranspiledModuleLoader` | ~17 500 | ~25% | same as `--aot`, AOT-safe on IL2CPP targets |
-| Native `clang -O3` | ~70 000 | 100% | (baseline) |
+| Mode | CoreMark iter/s | % of native |
+|---|---:|---:|
+| WACS polymorphic (default) | 274 | 0.79% |
+| WACS `--super` | 337 | 0.98% |
+| WACS `--switch` | 358 | 1.04% |
+| WACS `--switch --super` | 385 | 1.12% |
+| WACS `-t` / `--aot` (Reflection.Emit) | 17 552 | **50.9%** |
+| `wasm-transpile` pre-compiled `.dll` loaded via `TranspiledModuleLoader` | 17 552 | **50.9%** |
+| Native `clang -O3` (same C source, no wasm) | 34 488 | 100% |
+
+Ballpark comparison to other WASM runtimes on the same workload (not
+measured on this machine — pulled from published numbers; treat as
+positioning, not apples-to-apples):
+
+- **WACS AOT (`-t`) ≈ WAMR "fast JIT" / Wasmer.** AOT-class wasm
+  runtimes typically land at 50–70% of native C on CoreMark; WACS's
+  51% is in that band.
+- **WACS interpreter modes (274–385 iter/s) are slower than Wasm3**
+  (typically 4–6 k iter/s on M-series). Wasm3 is heavily tuned for
+  CoreMark-like tight loops; WACS's interpreter prioritises Unity
+  AOT compatibility and WASM 3.0 spec completeness over interpreter
+  micro-benchmarks. Think "Python-for-WASM" speed rather than
+  "Wasm3-class interpreter."
+- **All five modes are C#-on-CLR**, so speedups over interpreted
+  Python or IronPython for equivalent logic look larger than the
+  CoreMark-vs-C ratios above would suggest.
 
 **Choosing a mode:**
 
-- **Can you JIT?** (Desktop, server, `dotnet run`, Godot Mono) — use `-t` / `--aot`. It's ~60× the interpreter and within ~3–4× of native speed.
-- **AOT-only target?** (Unity IL2CPP, `PublishAot`, iOS, full-AOT Mono) — pre-compile the `.wasm → .dll` on a JIT host with [`wasm-transpile`](Wacs.Transpiler/README.md), ship the `.dll`, load it at runtime with `WACS.Transpiler.Lib`'s `TranspiledModuleLoader`. Same AOT speed, no `Reflection.Emit` dependency.
-- **Locked-down / policy-reviewed target, can't ship a pre-compiled `.dll`?** — use `--switch --super`. Build-time source-gen + `System.Runtime.CompilerServices.Unsafe` intrinsics only, no runtime codegen, no `unsafe` keyword blocks. ~1.4× over the polymorphic baseline.
-- **Maximum conservatism?** — default polymorphic, or `--super` for a small safe boost. Pure managed, no source-gen, no `Unsafe` usage. Roughly "Python-for-WASM" speed — fine for cold-path scripting, UGC validation, or logic that doesn't dominate a frame budget.
+- **Can you JIT?** (Desktop, server, `dotnet run`, Godot Mono) — use
+  `-t` / `--aot`. It's ~60× the interpreter and within ~2× of native
+  C speed.
+- **AOT-only target?** (Unity IL2CPP, `PublishAot`, iOS, full-AOT
+  Mono) — pre-compile the `.wasm → .dll` on a JIT host with
+  [`wasm-transpile`](Wacs.Transpiler/README.md), ship the `.dll`,
+  load it at runtime with `WACS.Transpiler.Lib`'s
+  `TranspiledModuleLoader`. Same AOT speed, no `Reflection.Emit`
+  dependency at runtime.
+- **Locked-down / policy-reviewed target, can't ship a pre-compiled
+  `.dll`?** — use `--switch --super`. Build-time source-gen +
+  `System.Runtime.CompilerServices.Unsafe` intrinsics only, no
+  runtime codegen, no `unsafe` keyword blocks. ~1.4× over the
+  polymorphic baseline.
+- **Maximum conservatism?** — default polymorphic, or `--super` for a
+  small safe boost. Pure managed, no source-gen, no `Unsafe` usage.
+  Fine for cold-path scripting, UGC validation, or logic that doesn't
+  dominate a frame budget — but don't put it in a hot inner loop.
 
 ### Running `Wacs.Console`
 


### PR DESCRIPTION
## Summary

Follow-up to #74 (which merged before this commit could ride it). Replaces the performance table's estimated native baseline (~70,000 iter/s) with a measured one.

**Measured on your M3 Max:**

- Built EEMBC CoreMark from `~/coremark/coremark` with `make PORT_DIR=macos XCFLAGS="-O3"` (Apple LLVM 17, clang-1700.6.3.2).
- Three runs: 34,461 / 34,483 / 34,520 iter/s. Mean **34,488 iter/s**.

**Corrections this commit lands:**

- `-t` / `--aot` is **50.9%** of native — about 2× better than my earlier 25% guess. AOT is actually competitive with JIT-class wasm runtimes (WAMR fast JIT / Wasmer).
- Interpreter modes (274–385 iter/s) are **below** Wasm3's typical 4–6k iter/s on CoreMark. Previous "comparable to Wasm3" was overselling — replaced with an honest "Python-for-WASM speed" framing.
- Dropped the "Comparable to" column from the main table (implied measurement where there wasn't any). Added a separate ballpark block with the three honest positioning bullets and an explicit disclaimer that those numbers are pulled from published figures, not measured on this machine.
- Decision-tree guidance unchanged except "within ~3–4× native" → "within ~2× native" for the AOT bullet.

## Test plan

- [ ] Review the rendered table — baseline row now says "34,488" instead of "~70,000".

🤖 Generated with [Claude Code](https://claude.com/claude-code)