### PR TITLE
Threads proposal phase 1: polymorphic interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Harnessed results from [wasm-feature-detect](https://github.com/GoogleChromeLabs
 |[Exception handling](https://github.com/WebAssembly/exception-handling)|exceptions|✅|
 |[JS String Builtins](https://github.com/WebAssembly/js-string-builtins)||❌|
 |[Memory64](https://github.com/WebAssembly/memory64)|memory64|✅|
-|[Threads](https://github.com/webassembly/threads)|threads|❌|
+|[Threads](https://github.com/webassembly/threads)|threads|✅|
 |Phase 3|
 |[JS Promise Integration](https://github.com/WebAssembly/js-promise-integration)|jspi|<span title="Browser idiom, but conceptually supported">✳️</span>|
 |[Type Reflection for WebAssembly JavaScript API](https://github.com/WebAssembly/js-types)|type-reflection|<span title="Browser idioms, not directly supported">🌐</span>|

--- a/Spec.Test/Data/threads/atomic.wast
+++ b/Spec.Test/Data/threads/atomic.wast
@@ -1,0 +1,1018 @@
+;; atomic operations
+
+(module
+  (memory 1 1 shared)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+  (func (export "i32.atomic.load") (param $addr i32) (result i32) (i32.atomic.load (local.get $addr)))
+  (func (export "i64.atomic.load") (param $addr i32) (result i64) (i64.atomic.load (local.get $addr)))
+  (func (export "i32.atomic.load8_u") (param $addr i32) (result i32) (i32.atomic.load8_u (local.get $addr)))
+  (func (export "i32.atomic.load16_u") (param $addr i32) (result i32) (i32.atomic.load16_u (local.get $addr)))
+  (func (export "i64.atomic.load8_u") (param $addr i32) (result i64) (i64.atomic.load8_u (local.get $addr)))
+  (func (export "i64.atomic.load16_u") (param $addr i32) (result i64) (i64.atomic.load16_u (local.get $addr)))
+  (func (export "i64.atomic.load32_u") (param $addr i32) (result i64) (i64.atomic.load32_u (local.get $addr)))
+
+  (func (export "i32.atomic.store") (param $addr i32) (param $value i32) (i32.atomic.store (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store") (param $addr i32) (param $value i64) (i64.atomic.store (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.store8") (param $addr i32) (param $value i32) (i32.atomic.store8 (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.store16") (param $addr i32) (param $value i32) (i32.atomic.store16 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store8") (param $addr i32) (param $value i64) (i64.atomic.store8 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store16") (param $addr i32) (param $value i64) (i64.atomic.store16 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store32") (param $addr i32) (param $value i64) (i64.atomic.store32 (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.add") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.add (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.add") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.add (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.add_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.add_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.sub") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.sub (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.sub") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.sub (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.sub_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.and") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.and (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.and") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.and (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.and_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.and_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.or") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.or (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.or") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.or (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.or_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.or_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.xor") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xor (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.xor") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xor (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xor_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.xchg") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xchg (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.xchg") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xchg (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xchg_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw.cmpxchg (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw.cmpxchg (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i32.atomic.rmw8.cmpxchg_u") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw8.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i32.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw16.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw8.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw8.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw16.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw32.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw32.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+
+)
+
+;; *.atomic.load*
+
+(invoke "init" (i64.const 0x0706050403020100))
+
+(assert_return (invoke "i32.atomic.load" (i32.const 0)) (i32.const 0x03020100))
+(assert_return (invoke "i32.atomic.load" (i32.const 4)) (i32.const 0x07060504))
+
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0706050403020100))
+
+(assert_return (invoke "i32.atomic.load8_u" (i32.const 0)) (i32.const 0x00))
+(assert_return (invoke "i32.atomic.load8_u" (i32.const 5)) (i32.const 0x05))
+
+(assert_return (invoke "i32.atomic.load16_u" (i32.const 0)) (i32.const 0x0100))
+(assert_return (invoke "i32.atomic.load16_u" (i32.const 6)) (i32.const 0x0706))
+
+(assert_return (invoke "i64.atomic.load8_u" (i32.const 0)) (i64.const 0x00))
+(assert_return (invoke "i64.atomic.load8_u" (i32.const 5)) (i64.const 0x05))
+
+(assert_return (invoke "i64.atomic.load16_u" (i32.const 0)) (i64.const 0x0100))
+(assert_return (invoke "i64.atomic.load16_u" (i32.const 6)) (i64.const 0x0706))
+
+(assert_return (invoke "i64.atomic.load32_u" (i32.const 0)) (i64.const 0x03020100))
+(assert_return (invoke "i64.atomic.load32_u" (i32.const 4)) (i64.const 0x07060504))
+
+;; *.atomic.store*
+
+(invoke "init" (i64.const 0x0000000000000000))
+
+(assert_return (invoke "i32.atomic.store" (i32.const 0) (i32.const 0xffeeddcc)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x00000000ffeeddcc))
+
+(assert_return (invoke "i64.atomic.store" (i32.const 0) (i64.const 0x0123456789abcdef)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123456789abcdef))
+
+(assert_return (invoke "i32.atomic.store8" (i32.const 1) (i32.const 0x42)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123456789ab42ef))
+
+(assert_return (invoke "i32.atomic.store16" (i32.const 4) (i32.const 0x8844)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123884489ab42ef))
+
+(assert_return (invoke "i64.atomic.store8" (i32.const 1) (i64.const 0x99)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123884489ab99ef))
+
+(assert_return (invoke "i64.atomic.store16" (i32.const 4) (i64.const 0xcafe)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123cafe89ab99ef))
+
+(assert_return (invoke "i64.atomic.store32" (i32.const 4) (i64.const 0xdeadbeef)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0xdeadbeef89ab99ef))
+
+;; *.atomic.rmw*.add
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.add" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111123456789))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.add" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1212121213131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.add_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111de))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.add_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dc0f))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.add_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.add_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111d000))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.add_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbccb7f6))
+
+;; *.atomic.rmw*.sub
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.sub" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111fedcba99))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.sub" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x101010100f0f0f0f))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.sub_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111144))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.sub_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111114613))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.sub_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cf))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.sub_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111115222))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.sub_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111146556a2c))
+
+;; *.atomic.rmw*.and
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.and" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111110101010))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.and" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010100000000))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.and_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111101))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.and_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111110010))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.and_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111100))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.and_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111001))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.and_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111100110001))
+
+;; *.atomic.rmw*.or
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.or" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111113355779))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.or" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111113131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.or_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111dd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.or_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dbff))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.or_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.or_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111bfff))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.or_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbbbb7f5))
+
+;; *.atomic.rmw*.xor
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.xor" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111103254769))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.xor" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1010101013131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.xor_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111dc))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.xor_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dbef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.xor_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.xor_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111affe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.xor_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbaab7f4))
+
+;; *.atomic.rmw*.xchg
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.xchg" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111112345678))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.xchg" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010102020202))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.xchg_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.xchg_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.xchg_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.xchg_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.xchg_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+;; *.atomic.rmw*.cmpxchg (compare false)
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i32.const 0) (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i32.const 0) (i64.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0x11111111) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0x11111111) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+;; *.atomic.rmw*.cmpxchg (compare true)
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i32.const 0) (i32.const 0x11111111) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111112345678))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010102020202))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0x11) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0x1111) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0x11) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0x1111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0x11111111) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+
+;; unaligned accesses
+
+(assert_trap (invoke "i32.atomic.load" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.load16_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load16_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load32_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.store" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.store16" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store16" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store32" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.add" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.add" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.add_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.add_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.add_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.sub" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.sub" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.sub_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.sub_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.sub_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.and" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.and" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.and_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.and_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.and_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.or" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.or" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.or_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.or_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.or_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.xor" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.xor" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.xor_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.xor_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.xor_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.xchg" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.xchg" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.xchg_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.xchg_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.xchg_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.cmpxchg" (i32.const 1) (i32.const 0) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.cmpxchg" (i32.const 1) (i64.const 0)  (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 1) (i32.const 0) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 1) (i64.const 0) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 1) (i64.const 0) (i64.const 0)) "unaligned atomic")
+
+;; non-natural alignment
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.load") (param $addr i32) (result i32) (i32.atomic.load align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.load") (param $addr i32) (result i64) (i64.atomic.load align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.load16_u") (param $addr i32) (result i32) (i32.atomic.load16_u align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.load16_u") (param $addr i32) (result i64) (i64.atomic.load16_u align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.load32_u") (param $addr i32) (result i64) (i64.atomic.load32_u align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.store") (param $addr i32) (param $value i32) (i32.atomic.store align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.store") (param $addr i32) (param $value i64) (i64.atomic.store align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.store16") (param $addr i32) (param $value i32) (i32.atomic.store16 align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.store16") (param $addr i32) (param $value i64) (i64.atomic.store16 align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.store32") (param $addr i32) (param $value i64) (i64.atomic.store32 align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.add") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.add align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.add") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.add align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.add_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.add_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.add_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.sub") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.sub align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.sub") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.sub align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.sub_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.sub_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.sub_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.and") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.and align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.and") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.and align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.and_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.and_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.and_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.or") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.or align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.or") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.or align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.or_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.or_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.or_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.xor") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xor align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.xor") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xor align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xor_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xor_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xor_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.xchg") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xchg align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.xchg") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xchg align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xchg_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xchg_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xchg_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw.cmpxchg align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw.cmpxchg align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw16.cmpxchg_u align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw16.cmpxchg_u align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw32.cmpxchg_u align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+
+;; wait/notify
+(module
+  (memory 1 1 shared)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+  (func (export "memory.atomic.notify") (param $addr i32) (param $count i32) (result i32)
+      (memory.atomic.notify (local.get 0) (local.get 1)))
+  (func (export "memory.atomic.wait32") (param $addr i32) (param $expected i32) (param $timeout i64) (result i32)
+      (memory.atomic.wait32 (local.get 0) (local.get 1) (local.get 2)))
+  (func (export "memory.atomic.wait64") (param $addr i32) (param $expected i64) (param $timeout i64) (result i32)
+      (memory.atomic.wait64 (local.get 0) (local.get 1) (local.get 2)))
+)
+
+(invoke "init" (i64.const 0xffffffffffff))
+
+;; wait returns immediately if values do not match
+(assert_return (invoke "memory.atomic.wait32" (i32.const 0) (i32.const 0) (i64.const 0)) (i32.const 1))
+(assert_return (invoke "memory.atomic.wait64" (i32.const 0) (i64.const 0) (i64.const 0)) (i32.const 1))
+
+;; notify always returns
+(assert_return (invoke "memory.atomic.notify" (i32.const 0) (i32.const 0)) (i32.const 0))
+
+;; OOB wait and notify always trap
+(assert_trap (invoke "memory.atomic.wait32" (i32.const 65536) (i32.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait64" (i32.const 65536) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+
+;; in particular, notify always traps even if waking 0 threads
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65536) (i32.const 0)) "out of bounds memory access")
+
+;; similarly, unaligned wait and notify always trap
+(assert_trap (invoke "memory.atomic.wait32" (i32.const 65531) (i32.const 0) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "memory.atomic.wait64" (i32.const 65524) (i64.const 0) (i64.const 0)) "unaligned atomic")
+
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65531) (i32.const 0)) "unaligned atomic")
+
+;; atomic.wait traps on unshared memory even if it wouldn't block
+(module
+  (memory 1 1)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+  (func (export "memory.atomic.notify") (param $addr i32) (param $count i32) (result i32)
+      (memory.atomic.notify (local.get 0) (local.get 1)))
+  (func (export "memory.atomic.wait32") (param $addr i32) (param $expected i32) (param $timeout i64) (result i32)
+      (memory.atomic.wait32 (local.get 0) (local.get 1) (local.get 2)))
+  (func (export "memory.atomic.wait64") (param $addr i32) (param $expected i64) (param $timeout i64) (result i32)
+      (memory.atomic.wait64 (local.get 0) (local.get 1) (local.get 2)))
+)
+
+(invoke "init" (i64.const 0xffffffffffff))
+
+(assert_trap (invoke "memory.atomic.wait32" (i32.const 0) (i32.const 0) (i64.const 0)) "expected shared memory")
+(assert_trap (invoke "memory.atomic.wait64" (i32.const 0) (i64.const 0) (i64.const 0)) "expected shared memory")
+
+;; notify still works
+(assert_return (invoke "memory.atomic.notify" (i32.const 0) (i32.const 0)) (i32.const 0))
+
+;; OOB and unaligned notify still trap
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65536) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65531) (i32.const 0)) "unaligned atomic")
+
+;; unshared memory is OK
+(module
+  (memory 1 1)
+  (func (drop (memory.atomic.notify (i32.const 0) (i32.const 0))))
+  (func (drop (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const 0))))
+  (func (drop (memory.atomic.wait64 (i32.const 0) (i64.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.load (i32.const 0))))
+  (func (drop (i64.atomic.load (i32.const 0))))
+  (func (drop (i32.atomic.load16_u (i32.const 0))))
+  (func (drop (i64.atomic.load16_u (i32.const 0))))
+  (func (drop (i64.atomic.load32_u (i32.const 0))))
+  (func       (i32.atomic.store (i32.const 0) (i32.const 0)))
+  (func       (i64.atomic.store (i32.const 0) (i64.const 0)))
+  (func       (i32.atomic.store16 (i32.const 0) (i32.const 0)))
+  (func       (i64.atomic.store16 (i32.const 0) (i64.const 0)))
+  (func       (i64.atomic.store32 (i32.const 0) (i64.const 0)))
+  (func (drop (i32.atomic.rmw.add (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.add (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.sub (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.sub (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.and (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.and (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.or (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.or (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.xor (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.xor (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.xchg (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.xchg (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 0)  (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))
+)
+
+;; atomic.fence: no memory is ok
+(module
+  (func (export "fence") (atomic.fence))
+)
+
+(assert_return (invoke "fence"))
+
+;; Fails with no memory
+(assert_invalid (module (func (drop (memory.atomic.notify (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (memory.atomic.wait64 (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.load (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.load16_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load16_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load32_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func       (i32.atomic.store (i32.const 0) (i32.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i32.atomic.store16 (i32.const 0) (i32.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store16 (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store32 (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.add (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.add (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.sub (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.sub (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.and (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.and (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.or (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.or (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.xor (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.xor (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.xchg (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.xchg (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 0)  (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")

--- a/Wacs.Core.Test/AtomicInstructionTests.cs
+++ b/Wacs.Core.Test/AtomicInstructionTests.cs
@@ -1,0 +1,397 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Concurrency;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// End-to-end tests for the threads proposal in the polymorphic
+    /// interpreter. Exercises validation rules, per-family execution
+    /// semantics, and both <see cref="ConcurrencyPolicyMode"/> policies.
+    /// </summary>
+    public class AtomicInstructionTests
+    {
+        private static (WasmRuntime runtime, ModuleInstance inst) Build(string src,
+            IConcurrencyPolicy? policy = null, bool relaxSharedCheck = false)
+        {
+            var attrs = new RuntimeAttributes();
+            if (policy != null) attrs.ConcurrencyPolicy = policy;
+            attrs.RelaxAtomicSharedCheck = relaxSharedCheck;
+            var runtime = new WasmRuntime(attrs);
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            return (runtime, inst);
+        }
+
+        private static int InvokeI32(WasmRuntime runtime, string name, params Value[] args)
+        {
+            var addr = runtime.GetExportedFunction(("M", name));
+            var inv = runtime.CreateStackInvoker(addr);
+            var r = inv(args);
+            return (int)r[0];
+        }
+
+        private static long InvokeI64(WasmRuntime runtime, string name, params Value[] args)
+        {
+            var addr = runtime.GetExportedFunction(("M", name));
+            var inv = runtime.CreateStackInvoker(addr);
+            var r = inv(args);
+            return (long)r[0];
+        }
+
+        // ---- Validation -------------------------------------------------
+
+        [Fact]
+        public void Wrong_alignment_rejected()
+        {
+            // i32.atomic.load requires align=4 exactly. Specifying align=2
+            // (half of natural) must fail validation.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.atomic.load align=2))";
+            Assert.ThrowsAny<Exception>(() => Build(src));
+        }
+
+        [Fact]
+        public void Non_shared_memory_rejected_by_default()
+        {
+            // Atomic op on a non-shared memory must fail validation unless
+            // RelaxAtomicSharedCheck is true.
+            var src = @"
+                (module
+                  (memory 1 1)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.atomic.load align=4))";
+            Assert.ThrowsAny<Exception>(() => Build(src));
+        }
+
+        [Fact]
+        public void Non_shared_memory_accepted_with_relax_flag()
+        {
+            // Same module, but with RelaxAtomicSharedCheck enabled, parses.
+            var src = @"
+                (module
+                  (memory 1 1)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 99
+                    i32.atomic.store align=4
+                    i32.const 0
+                    i32.atomic.load align=4))";
+            var (rt, _) = Build(src, relaxSharedCheck: true);
+            Assert.Equal(99, InvokeI32(rt, "f"));
+        }
+
+        // ---- Load / store round-trip ------------------------------------
+
+        [Fact]
+        public void I32_load_store_round_trip()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 0x12345678
+                    i32.atomic.store align=4
+                    i32.const 0
+                    i32.atomic.load align=4))";
+            var (rt, _) = Build(src);
+            Assert.Equal(0x12345678, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void I64_load_store_round_trip()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i64)
+                    i32.const 8
+                    i64.const 0x0123456789ABCDEF
+                    i64.atomic.store align=8
+                    i32.const 8
+                    i64.atomic.load align=8))";
+            var (rt, _) = Build(src);
+            Assert.Equal(0x0123456789ABCDEFL, InvokeI64(rt, "f"));
+        }
+
+        [Fact]
+        public void Subword_load_store()
+        {
+            // Store byte 0xA5 at offset 7, read back as i32 zero-extended.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 7
+                    i32.const 0xA5
+                    i32.atomic.store8 align=1
+                    i32.const 7
+                    i32.atomic.load8_u align=1))";
+            var (rt, _) = Build(src);
+            Assert.Equal(0xA5, InvokeI32(rt, "f"));
+        }
+
+        // ---- RMW correctness --------------------------------------------
+
+        [Fact]
+        public void Rmw_add_returns_original_then_sum()
+        {
+            // Store 10, then rmw.add 5, then load. Return should be 15.
+            // The rmw op itself returns the original (10).
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""rmw"") (result i32)
+                    i32.const 0
+                    i32.const 10
+                    i32.atomic.store align=4
+                    i32.const 0
+                    i32.const 5
+                    i32.atomic.rmw.add align=4)
+                  (func (export ""load"") (result i32)
+                    i32.const 0
+                    i32.atomic.load align=4))";
+            var (rt, _) = Build(src);
+            Assert.Equal(10, InvokeI32(rt, "rmw"));  // original
+            Assert.Equal(15, InvokeI32(rt, "load")); // cell updated
+        }
+
+        [Fact]
+        public void Rmw_xchg_swaps_and_returns_old()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0 i32.const 7 i32.atomic.store align=4
+                    i32.const 0 i32.const 42 i32.atomic.rmw.xchg align=4))";
+            var (rt, _) = Build(src);
+            Assert.Equal(7, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void Subword_rmw_add_CAS_loop()
+        {
+            // Subword RMW goes through SubwordCas.Loop on the enclosing
+            // 32-bit word. Exercise it with rmw8.add_u.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""rmw"") (result i32)
+                    i32.const 3 i32.const 100 i32.atomic.store8 align=1
+                    i32.const 3 i32.const 56 i32.atomic.rmw8.add_u align=1))";
+            var (rt, _) = Build(src);
+            // Returns original (100). Cell is now 156.
+            Assert.Equal(100, InvokeI32(rt, "rmw"));
+        }
+
+        // ---- Cmpxchg ----------------------------------------------------
+
+        [Fact]
+        public void Cmpxchg_success_replaces_and_returns_original()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""cas"") (result i32)
+                    i32.const 0 i32.const 50 i32.atomic.store align=4
+                    i32.const 0 i32.const 50 i32.const 99 i32.atomic.rmw.cmpxchg align=4)
+                  (func (export ""load"") (result i32)
+                    i32.const 0 i32.atomic.load align=4))";
+            var (rt, _) = Build(src);
+            Assert.Equal(50, InvokeI32(rt, "cas"));   // original
+            Assert.Equal(99, InvokeI32(rt, "load"));  // replaced
+        }
+
+        [Fact]
+        public void Cmpxchg_mismatch_leaves_cell_unchanged()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""cas"") (result i32)
+                    i32.const 0 i32.const 50 i32.atomic.store align=4
+                    i32.const 0 i32.const 999 i32.const 99 i32.atomic.rmw.cmpxchg align=4)
+                  (func (export ""load"") (result i32)
+                    i32.const 0 i32.atomic.load align=4))";
+            var (rt, _) = Build(src);
+            Assert.Equal(50, InvokeI32(rt, "cas"));   // original (no match)
+            Assert.Equal(50, InvokeI32(rt, "load"));  // unchanged
+        }
+
+        // ---- Fence ------------------------------------------------------
+
+        [Fact]
+        public void Atomic_fence_is_executable()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    atomic.fence
+                    i32.const 42))";
+            var (rt, _) = Build(src);
+            Assert.Equal(42, InvokeI32(rt, "f"));
+        }
+
+        // ---- Wait / notify policy ---------------------------------------
+
+        [Fact]
+        public void NotSupported_wait_mismatch_returns_2()
+        {
+            // Cell holds 0; wait for expected=99 → not-equal (2).
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 99
+                    i64.const 0
+                    memory.atomic.wait32 align=4))";
+            var (rt, _) = Build(src, new NotSupportedPolicy());
+            Assert.Equal(2, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void NotSupported_wait_zero_timeout_returns_1()
+        {
+            // Matching value, timeout=0 → timed-out (1).
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 0
+                    i64.const 0
+                    memory.atomic.wait32 align=4))";
+            var (rt, _) = Build(src, new NotSupportedPolicy());
+            Assert.Equal(1, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void NotSupported_wait_infinite_timeout_traps()
+        {
+            // Matching value + infinite timeout → TrapException.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 0
+                    i64.const -1
+                    memory.atomic.wait32 align=4))";
+            var (rt, _) = Build(src, new NotSupportedPolicy());
+            Assert.ThrowsAny<TrapException>(() => InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void NotSupported_notify_returns_0()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 10
+                    memory.atomic.notify align=4))";
+            var (rt, _) = Build(src, new NotSupportedPolicy());
+            Assert.Equal(0, InvokeI32(rt, "f"));
+        }
+
+        // ---- HostDefined producer/consumer ------------------------------
+
+        [Fact]
+        public void HostDefined_wait_and_notify_rendezvous()
+        {
+            // Phase 1 does not support concurrent wasm execution in the
+            // same WasmRuntime (single ExecContext) — that's a phase 2
+            // follow-up. We exercise the policy directly against a
+            // standalone MemoryInstance, which is exactly what Execute
+            // would call through if the runtime were thread-local.
+            var memType = new Wacs.Core.Types.MemoryType(
+                new Wacs.Core.Types.Limits(Wacs.Core.Types.Defs.AddrType.I32, 1, 1, shared: true));
+            var mem = new MemoryInstance(memType);
+            mem.EnableConcurrentGrow();
+
+            var policy = new HostDefinedPolicy();
+
+            int waitResult = -1;
+            var waiter = new Thread(() =>
+            {
+                waitResult = policy.Wait32(mem, addr: 0, expected: 0, timeoutNs: -1);
+            });
+            waiter.Start();
+
+            // Give the waiter a moment to enqueue in the wait-slot.
+            Thread.Sleep(50);
+            int woken = policy.Notify(mem, addr: 0, maxWaiters: 1);
+
+            Assert.True(waiter.Join(TimeSpan.FromSeconds(2)),
+                "waiter did not wake within 2s");
+
+            Assert.Equal(1, woken);     // exactly one waiter notified
+            Assert.Equal(0, waitResult); // wait returned ok
+        }
+
+        [Fact]
+        public void HostDefined_notify_with_no_waiters_returns_zero()
+        {
+            var memType = new Wacs.Core.Types.MemoryType(
+                new Wacs.Core.Types.Limits(Wacs.Core.Types.Defs.AddrType.I32, 1, 1, shared: true));
+            var mem = new MemoryInstance(memType);
+            var policy = new HostDefinedPolicy();
+            Assert.Equal(0, policy.Notify(mem, 0, int.MaxValue));
+        }
+
+        [Fact]
+        public void HostDefined_wait_with_mismatched_expected_returns_2()
+        {
+            var memType = new Wacs.Core.Types.MemoryType(
+                new Wacs.Core.Types.Limits(Wacs.Core.Types.Defs.AddrType.I32, 1, 1, shared: true));
+            var mem = new MemoryInstance(memType);
+            mem.AtomicStoreInt32(0, 42);
+            var policy = new HostDefinedPolicy();
+            // Cell is 42 but we expect 99 → not-equal.
+            Assert.Equal(2, policy.Wait32(mem, 0, expected: 99, timeoutNs: 0));
+        }
+
+        [Fact]
+        public void HostDefined_wait_zero_timeout_times_out()
+        {
+            var memType = new Wacs.Core.Types.MemoryType(
+                new Wacs.Core.Types.Limits(Wacs.Core.Types.Defs.AddrType.I32, 1, 1, shared: true));
+            var mem = new MemoryInstance(memType);
+            var policy = new HostDefinedPolicy();
+            // Cell is 0, expected 0 (match), timeout 0 → timed-out immediately.
+            Assert.Equal(1, policy.Wait32(mem, 0, expected: 0, timeoutNs: 0));
+        }
+
+        // ---- Default policy selection -----------------------------------
+
+        [Fact]
+        public void Default_policy_on_non_Unity_is_HostDefined()
+        {
+            // Running the test suite outside Unity → HostDefined default.
+            var attrs = new RuntimeAttributes();
+            Assert.Equal(ConcurrencyPolicyMode.HostDefined, attrs.ConcurrencyPolicy.Mode);
+        }
+    }
+}

--- a/Wacs.Core.Test/SpecWastThreadsTests.cs
+++ b/Wacs.Core.Test/SpecWastThreadsTests.cs
@@ -1,0 +1,155 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System.IO;
+using System.Linq;
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Concurrency;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// Smoke + sample-based tests over the pinned threads-proposal
+    /// atomic.wast snapshot at <c>Spec.Test/Data/threads/atomic.wast</c>.
+    /// Upstream pin: WebAssembly/threads@f521d7b3.
+    /// <para>
+    /// Structure:
+    /// 1. Parse-the-whole-file smoke test (script parser round-trip).
+    /// 2. Instantiate the first module and invoke a representative sample
+    ///    of <c>(assert_return …)</c> cases — load/store, RMW, cmpxchg,
+    ///    subword — through the polymorphic runtime.
+    /// 3. Spot-check the spec's <c>(assert_invalid)</c> alignment cases
+    ///    by building the inner module and asserting validation fails.
+    /// </para>
+    /// </summary>
+    public class SpecWastThreadsTests
+    {
+        private static string FindWastFile()
+        {
+            var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "WACS.sln")))
+                dir = dir.Parent;
+            if (dir == null) return string.Empty;
+            return Path.Combine(dir.FullName, "Spec.Test", "Data", "threads", "atomic.wast");
+        }
+
+        [Fact]
+        public void Full_file_parses_as_sexpr()
+        {
+            var path = FindWastFile();
+            Assert.True(File.Exists(path), $"missing pinned snapshot: {path}");
+            var src = File.ReadAllText(path);
+            var top = SExprParser.Parse(src);
+            Assert.NotEmpty(top);
+            foreach (var node in top)
+                Assert.Equal(SExprKind.List, node.Kind);
+        }
+
+        [Fact]
+        public void Full_file_parses_through_script_parser()
+        {
+            var path = FindWastFile();
+            var src = File.ReadAllText(path);
+            var cmds = TextScriptParser.ParseWast(src);
+            Assert.NotNull(cmds);
+            // Should contain at least one Module command and many asserts.
+            Assert.NotEmpty(cmds);
+        }
+
+        [Fact]
+        public void Atomic_wast_first_module_runs_load_store()
+        {
+            // The first (module …) in the file defines a shared-memory
+            // module exporting helpers named "init", "i32.atomic.load",
+            // "i32.atomic.store", etc. Reach into the script, grab that
+            // module, and exercise a handful of the spec's assert_return
+            // cases.
+            var path = FindWastFile();
+            var src = File.ReadAllText(path);
+            var cmds = TextScriptParser.ParseWast(src);
+
+            var firstModuleCmd = cmds.OfType<ScriptModule>().First();
+            Assert.NotNull(firstModuleCmd.Module);
+            var module = firstModuleCmd.Module!;
+
+            var runtime = new WasmRuntime(new RuntimeAttributes
+            {
+                ConcurrencyPolicy = new NotSupportedPolicy()
+            });
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+
+            int InvokeI32(string name, params Value[] args)
+            {
+                var addr = runtime.GetExportedFunction(("M", name));
+                var inv = runtime.CreateStackInvoker(addr);
+                return (int)inv(args)[0];
+            }
+            long InvokeI64(string name, params Value[] args)
+            {
+                var addr = runtime.GetExportedFunction(("M", name));
+                var inv = runtime.CreateStackInvoker(addr);
+                return (long)inv(args)[0];
+            }
+            void InvokeVoid(string name, params Value[] args)
+            {
+                var addr = runtime.GetExportedFunction(("M", name));
+                var inv = runtime.CreateStackInvoker(addr);
+                inv(args);
+            }
+
+            // Per the spec file: (init 0x0706050403020100)
+            // then i32.atomic.load at addr 0 returns 0x03020100,
+            //      i32.atomic.load at addr 4 returns 0x07060504.
+            InvokeVoid("init", (long)0x0706050403020100L);
+            Assert.Equal(0x03020100, InvokeI32("i32.atomic.load", 0));
+            Assert.Equal(0x07060504, InvokeI32("i32.atomic.load", 4));
+
+            Assert.Equal(0x0706050403020100L, InvokeI64("i64.atomic.load", 0));
+            Assert.Equal(0x00, InvokeI32("i32.atomic.load8_u", 0));
+            Assert.Equal(0x05, InvokeI32("i32.atomic.load8_u", 5));
+            Assert.Equal(0x0100, InvokeI32("i32.atomic.load16_u", 0));
+            Assert.Equal(0x0706, InvokeI32("i32.atomic.load16_u", 6));
+
+            // Per the spec file, memory is re-init'd to zero before the
+            // store section.
+            InvokeVoid("init", 0L);
+            InvokeVoid("i32.atomic.store", 0, unchecked((int)0xffeeddcc));
+            Assert.Equal(unchecked((long)0x00000000ffeeddccL),
+                InvokeI64("i64.atomic.load", 0));
+
+            // i64 store replaces the whole cell.
+            InvokeVoid("i64.atomic.store", 0, unchecked((long)0x0123456789abcdefL));
+            Assert.Equal(unchecked((long)0x0123456789abcdefL),
+                InvokeI64("i64.atomic.load", 0));
+
+            // Subword store: i32.atomic.store8 at addr 1 writes 0x42
+            // over byte 1.
+            InvokeVoid("i32.atomic.store8", 1, 0x42);
+            Assert.Equal(unchecked((long)0x0123456789ab42efL),
+                InvokeI64("i64.atomic.load", 0));
+        }
+
+        [Fact]
+        public void Invalid_alignment_module_fails_validation()
+        {
+            // Mirrors the spec's (assert_invalid) cases: atomic ops with
+            // sub-natural alignment must fail validation. Build the inner
+            // module directly to assert the validator rejects it.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""bad"") (param $a i32) (result i32)
+                    local.get $a
+                    i32.atomic.load align=1))";
+            var module = TextModuleParser.ParseWat(src);
+            var runtime = new WasmRuntime();
+            Assert.ThrowsAny<System.Exception>(() => runtime.InstantiateModule(module));
+        }
+    }
+}

--- a/Wacs.Core.Test/TextInstructionTests.cs
+++ b/Wacs.Core.Test/TextInstructionTests.cs
@@ -300,8 +300,11 @@ namespace Wacs.Core.Test
         [Fact]
         public void Unknown_opcode_in_body_throws()
         {
+            // Made-up mnemonic — guard the not-a-real-opcode fallback.
+            // Previously used i32.atomic.load, which became a real
+            // opcode when threads phase 1 landed.
             Assert.Throws<NotSupportedException>(() =>
-                ParseWithFunc("i32.atomic.load"));
+                ParseWithFunc("i32.not_an_opcode"));
         }
 
         [Fact]

--- a/Wacs.Core/Instructions/Atomic/AtomicBase.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicBase.cs
@@ -1,0 +1,354 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.IO;
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Concurrency;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
+using Wacs.Core.Types.Defs;
+using Wacs.Core.Validation;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    /// <summary>
+    /// Shared base for every atomic memory op (load, store, rmw, cmpxchg).
+    /// Carries the <see cref="MemArg"/>, caches the resolved
+    /// <see cref="MemoryInstance"/> at link time, and enforces the two
+    /// atomics-specific validation rules that differ from non-atomic
+    /// memory ops:
+    /// <list type="number">
+    ///   <item><b>Exact natural alignment</b> — <c>memarg.align</c> must
+    ///   equal the access width in bytes (threads proposal §3.4). Non-atomic
+    ///   memory ops only require <c>align ≤ width</c>.</item>
+    ///   <item><b>Shared memory requirement</b> — the target memory must
+    ///   be declared <c>shared</c>. Strict by default; relaxable via
+    ///   <see cref="RuntimeAttributes.RelaxAtomicSharedCheck"/>.</item>
+    /// </list>
+    /// </summary>
+    public abstract class InstAtomicMemoryOp : InstructionBase, IComplexLinkBehavior
+    {
+        protected MemArg M;
+        /// <summary>Natural byte width of this op's access (1, 2, 4, or 8).</summary>
+        protected readonly int WidthBytes;
+        /// <summary>Cached at link time so Execute can skip the Store lookup.</summary>
+        protected MemoryInstance CachedMem = null!;
+
+        protected InstAtomicMemoryOp(ByteCode opcode, int widthBytes, int stackDiff)
+            : base(opcode, stackDiff)
+        {
+            WidthBytes = widthBytes;
+        }
+
+        public long MemOffset => M.Offset;
+        public int MemIndex => (int)M.M.Value;
+        public int AccessWidth => WidthBytes;
+
+        public int CalculateSize() => 1;
+        public int LinkStackDiff => StackDiff;
+
+        public override InstructionBase Parse(BinaryReader reader)
+        {
+            M = MemArg.Parse(reader);
+            return this;
+        }
+
+        public InstructionBase Immediate(MemArg m)
+        {
+            M = m;
+            return this;
+        }
+
+        public override void Validate(IWasmValidationContext context)
+        {
+            context.Assert(context.Mems.Contains(M.M),
+                "Instruction {0} failed with invalid context memory {1}.",
+                Op.GetMnemonic(), M.M.Value);
+
+            // Exact alignment — threads §3.4. Non-atomic ops use ≤, which
+            // hides the fact that Alignment.LinearSize() returns 0 when
+            // the log2 exponent is 0 (i.e. align=1). For atomics we need
+            // an exact match, so compare via the log2 form directly.
+            int expectedLog2 = WidthBytes switch
+            {
+                1 => 0, 2 => 1, 4 => 2, 8 => 3, _ => -1
+            };
+            context.Assert(M.Align.LogSize() == expectedLog2,
+                "Instruction {0} failed with non-natural alignment 2^{1} (expected exactly 2^{2} = {3} bytes).",
+                Op.GetMnemonic(), M.Align.LogSize(), expectedLog2, WidthBytes);
+
+            // Shared memory requirement. Strict by default; hosts may relax
+            // via RuntimeAttributes.RelaxAtomicSharedCheck for toolchains
+            // that emit atomics on non-shared memories.
+            if (!context.Attributes.RelaxAtomicSharedCheck)
+            {
+                var memType = context.Mems[M.M];
+                context.Assert(memType.Limits.Shared,
+                    "Instruction {0} requires a shared memory (memarg target {1} is not shared).",
+                    Op.GetMnemonic(), M.M.Value);
+            }
+
+            ValidateStack(context);
+        }
+
+        /// <summary>Subclass hook: consume/produce stack slots per op family.</summary>
+        protected abstract void ValidateStack(IWasmValidationContext context);
+
+        public override InstructionBase Link(ExecContext context, int pointer)
+        {
+            context.Assert(context.Frame.Module.MemAddrs.Contains(M.M),
+                $"Instruction {Op.GetMnemonic()} failed. Memory {M.M.Value} not in the module's MemAddrs.");
+            var a = context.Frame.Module.MemAddrs[M.M];
+            context.Assert(context.Store.Contains(a),
+                $"Instruction {Op.GetMnemonic()} failed. Memory {M.M.Value} missing from Store.");
+            CachedMem = context.Store[a];
+
+            // Enable concurrent-grow protection on this memory if the
+            // host has opted into concurrent execution. Single-threaded
+            // defaults never allocate the lock, so this is a no-op there.
+            if (context.ConcurrencyPolicy.Mode == ConcurrencyPolicyMode.HostDefined
+                && CachedMem.Type.Limits.Shared)
+            {
+                CachedMem.EnableConcurrentGrow();
+            }
+
+            return base.Link(context, pointer);
+        }
+
+        public override string RenderText(ExecContext? context) =>
+            $"{base.RenderText(context)}{M.ToWat(NaturalAlignBitWidth())}";
+
+        /// <summary>BitWidth form used by MemArg.ToWat to decide whether the
+        /// alignment annotation should be rendered. Maps the byte width.</summary>
+        private BitWidth NaturalAlignBitWidth() => WidthBytes switch
+        {
+            1 => BitWidth.U8,
+            2 => BitWidth.U16,
+            4 => BitWidth.U32,
+            8 => BitWidth.U64,
+            _ => BitWidth.None,
+        };
+
+        /// <summary>Bounds + alignment check. Returns the effective address.
+        /// Traps on out-of-bounds or unaligned access.</summary>
+        protected long CheckEa(long offset)
+        {
+            long ea = offset + M.Offset;
+            if (ea < 0)
+                throw new TrapException(
+                    $"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
+            if (ea + WidthBytes > CachedMem.Data.Length)
+                throw new TrapException(
+                    $"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthBytes} out of bounds ({CachedMem.Data.Length}).");
+            if ((ea & (WidthBytes - 1)) != 0)
+                throw new TrapException(
+                    $"Instruction {Op.GetMnemonic()} failed. Unaligned atomic access at {ea} (width {WidthBytes}).");
+            return ea;
+        }
+    }
+
+    /// <summary>
+    /// Base for atomic load variants. Pops an address, pushes the loaded
+    /// value. Subclasses override <see cref="DoLoad"/> to implement the
+    /// actual read + zero-extension pattern.
+    /// </summary>
+    public abstract class InstAtomicLoad : InstAtomicMemoryOp
+    {
+        /// <summary>Value-type of the *result* pushed on the stack (i32 or i64).</summary>
+        protected readonly ValType ResultType;
+
+        protected InstAtomicLoad(ByteCode opcode, ValType resultType, int widthBytes)
+            : base(opcode, widthBytes, 0) // pop addr (-1), push result (+1) = 0
+        {
+            ResultType = resultType;
+        }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopInt();           // -1
+            context.OpStack.PushType(ResultType); // +0
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            DoLoad(context, (int)ea);
+        }
+
+        /// <summary>Perform the atomic load and push onto the op stack.</summary>
+        protected abstract void DoLoad(ExecContext context, int ea);
+    }
+
+    /// <summary>Base for i32 atomic store variants. Pops a 32-bit value
+    /// then an address.</summary>
+    public abstract class InstAtomicStore32 : InstAtomicMemoryOp
+    {
+        protected InstAtomicStore32(ByteCode opcode, int widthBytes)
+            : base(opcode, widthBytes, -2)
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI32();
+            context.OpStack.PopInt();
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            int value = context.OpStack.PopI32();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            DoStore(CachedMem, (int)ea, value);
+        }
+
+        protected abstract void DoStore(MemoryInstance mem, int ea, int value);
+    }
+
+    /// <summary>Base for i64 atomic store variants. Pops a 64-bit value
+    /// then an address.</summary>
+    public abstract class InstAtomicStore64 : InstAtomicMemoryOp
+    {
+        protected InstAtomicStore64(ByteCode opcode, int widthBytes)
+            : base(opcode, widthBytes, -2)
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI64();
+            context.OpStack.PopInt();
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            long value = context.OpStack.PopI64();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            DoStore(CachedMem, (int)ea, value);
+        }
+
+        protected abstract void DoStore(MemoryInstance mem, int ea, long value);
+    }
+
+    /// <summary>
+    /// Base for atomic read-modify-write ops (add/sub/and/or/xor/xchg) on
+    /// i32 and sub-words of i32. Pops <c>(addr, arg)</c>, pushes the
+    /// original cell value (zero-extended for sub-words).
+    /// </summary>
+    public abstract class InstAtomicRmw32 : InstAtomicMemoryOp
+    {
+        protected InstAtomicRmw32(ByteCode opcode, int widthBytes)
+            : base(opcode, widthBytes, -1) // pop arg (-1), pop addr (-2), push result (+1) = -1
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI32();           // -1 (arg)
+            context.OpStack.PopInt();           // -2 (addr)
+            context.OpStack.PushI32();          // -1 (result)
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            int arg = context.OpStack.PopI32();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            int original = DoRmw(CachedMem, (int)ea, arg);
+            context.OpStack.PushI32(original);
+        }
+
+        /// <summary>Perform the op, return the original (pre-op) value
+        /// zero-extended to 32 bits.</summary>
+        protected abstract int DoRmw(MemoryInstance mem, int ea, int arg);
+    }
+
+    /// <summary>Base for atomic RMW ops on i64 and sub-words of i64.</summary>
+    public abstract class InstAtomicRmw64 : InstAtomicMemoryOp
+    {
+        protected InstAtomicRmw64(ByteCode opcode, int widthBytes)
+            : base(opcode, widthBytes, -1)
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI64();           // -1 (arg)
+            context.OpStack.PopInt();           // -2 (addr)
+            context.OpStack.PushI64();          // -1 (result)
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            long arg = context.OpStack.PopI64();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            long original = DoRmw(CachedMem, (int)ea, arg);
+            context.OpStack.PushI64(original);
+        }
+
+        protected abstract long DoRmw(MemoryInstance mem, int ea, long arg);
+    }
+
+    /// <summary>Base for atomic cmpxchg variants (i32 + subwords). Stack:
+    /// <c>(addr, expected, replacement) → original</c>.</summary>
+    public abstract class InstAtomicCmpxchg32 : InstAtomicMemoryOp
+    {
+        protected InstAtomicCmpxchg32(ByteCode opcode, int widthBytes)
+            : base(opcode, widthBytes, -2) // pop 3, push 1
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI32();           // replacement
+            context.OpStack.PopI32();           // expected
+            context.OpStack.PopInt();           // addr
+            context.OpStack.PushI32();          // result
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            int replacement = context.OpStack.PopI32();
+            int expected = context.OpStack.PopI32();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            int original = DoCmpxchg(CachedMem, (int)ea, expected, replacement);
+            context.OpStack.PushI32(original);
+        }
+
+        protected abstract int DoCmpxchg(MemoryInstance mem, int ea, int expected, int replacement);
+    }
+
+    /// <summary>Base for atomic cmpxchg on i64 + subwords.</summary>
+    public abstract class InstAtomicCmpxchg64 : InstAtomicMemoryOp
+    {
+        protected InstAtomicCmpxchg64(ByteCode opcode, int widthBytes)
+            : base(opcode, widthBytes, -2)
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI64();
+            context.OpStack.PopI64();
+            context.OpStack.PopInt();
+            context.OpStack.PushI64();
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            long replacement = context.OpStack.PopI64();
+            long expected = context.OpStack.PopI64();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            long original = DoCmpxchg(CachedMem, (int)ea, expected, replacement);
+            context.OpStack.PushI64(original);
+        }
+
+        protected abstract long DoCmpxchg(MemoryInstance mem, int ea, long expected, long replacement);
+    }
+}

--- a/Wacs.Core/Instructions/Atomic/AtomicCmpxchg.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicCmpxchg.cs
@@ -1,0 +1,65 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    // Atomic compare-and-swap. Stack: (addr, expected, replacement) → original.
+    // Returns the original cell value (zero-extended for sub-words).
+
+    public sealed class InstI32AtomicRmwCmpxchg : InstAtomicCmpxchg32
+    {
+        public InstI32AtomicRmwCmpxchg() : base((ByteCode)AtomCode.I32AtomicRmwCmpxchg, 4) {}
+        protected override int DoCmpxchg(MemoryInstance mem, int ea, int expected, int replacement) =>
+            mem.AtomicCompareExchangeInt32(ea, replacement, expected);
+    }
+
+    public sealed class InstI64AtomicRmwCmpxchg : InstAtomicCmpxchg64
+    {
+        public InstI64AtomicRmwCmpxchg() : base((ByteCode)AtomCode.I64AtomicRmwCmpxchg, 8) {}
+        protected override long DoCmpxchg(MemoryInstance mem, int ea, long expected, long replacement) =>
+            mem.AtomicCompareExchangeInt64(ea, replacement, expected);
+    }
+
+    public sealed class InstI32AtomicRmw8CmpxchgU : InstAtomicCmpxchg32
+    {
+        public InstI32AtomicRmw8CmpxchgU() : base((ByteCode)AtomCode.I32AtomicRmw8CmpxchgU, 1) {}
+        protected override int DoCmpxchg(MemoryInstance mem, int ea, int expected, int replacement) =>
+            SubwordCas.Cmpxchg(mem, ea, 1, expected, replacement);
+    }
+
+    public sealed class InstI32AtomicRmw16CmpxchgU : InstAtomicCmpxchg32
+    {
+        public InstI32AtomicRmw16CmpxchgU() : base((ByteCode)AtomCode.I32AtomicRmw16CmpxchgU, 2) {}
+        protected override int DoCmpxchg(MemoryInstance mem, int ea, int expected, int replacement) =>
+            SubwordCas.Cmpxchg(mem, ea, 2, expected, replacement);
+    }
+
+    public sealed class InstI64AtomicRmw8CmpxchgU : InstAtomicCmpxchg64
+    {
+        public InstI64AtomicRmw8CmpxchgU() : base((ByteCode)AtomCode.I64AtomicRmw8CmpxchgU, 1) {}
+        protected override long DoCmpxchg(MemoryInstance mem, int ea, long expected, long replacement) =>
+            (uint)SubwordCas.Cmpxchg(mem, ea, 1, (int)expected, (int)replacement);
+    }
+
+    public sealed class InstI64AtomicRmw16CmpxchgU : InstAtomicCmpxchg64
+    {
+        public InstI64AtomicRmw16CmpxchgU() : base((ByteCode)AtomCode.I64AtomicRmw16CmpxchgU, 2) {}
+        protected override long DoCmpxchg(MemoryInstance mem, int ea, long expected, long replacement) =>
+            (uint)SubwordCas.Cmpxchg(mem, ea, 2, (int)expected, (int)replacement);
+    }
+
+    public sealed class InstI64AtomicRmw32CmpxchgU : InstAtomicCmpxchg64
+    {
+        public InstI64AtomicRmw32CmpxchgU() : base((ByteCode)AtomCode.I64AtomicRmw32CmpxchgU, 4) {}
+        protected override long DoCmpxchg(MemoryInstance mem, int ea, long expected, long replacement) =>
+            (uint)mem.AtomicCompareExchangeInt32(ea, (int)replacement, (int)expected);
+    }
+}

--- a/Wacs.Core/Instructions/Atomic/AtomicFence.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicFence.cs
@@ -1,0 +1,42 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.IO;
+using System.Threading;
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime;
+using Wacs.Core.Validation;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    /// <summary>
+    /// <c>atomic.fence</c> — sequentially-consistent memory barrier.
+    /// Binary encoding carries a single reserved <c>0x00</c> byte (threads
+    /// proposal §5.4). No memarg, no operands, no result.
+    /// </summary>
+    public sealed class InstAtomicFence : InstructionBase
+    {
+        public InstAtomicFence() : base((ByteCode)AtomCode.AtomicFence) {}
+
+        public int CalculateSize() => 1;
+        public int LinkStackDiff => StackDiff;
+
+        public override InstructionBase Parse(BinaryReader reader)
+        {
+            byte reserved = reader.ReadByte();
+            if (reserved != 0x00)
+                throw new InvalidDataException(
+                    $"atomic.fence expects reserved zero byte, got 0x{reserved:X2}.");
+            return this;
+        }
+
+        public override void Validate(IWasmValidationContext context) { /* no-op */ }
+
+        public override void Execute(ExecContext context) => Interlocked.MemoryBarrier();
+    }
+}

--- a/Wacs.Core/Instructions/Atomic/AtomicLoadStore.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicLoadStore.cs
@@ -1,0 +1,143 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types.Defs;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    // Loads ──────────────────────────────────────────────────────────────
+    // i32/i64 full-width loads use the typed AtomicLoadInt32/Int64
+    // helpers on MemoryInstance (Volatile.Read / Interlocked.Read under
+    // the hood). Subword loads use Volatile.Read directly on a byte or
+    // short ref — aligned sub-word reads are atomic on all supported
+    // architectures, so no CAS loop is needed.
+
+    public sealed class InstI32AtomicLoad : InstAtomicLoad
+    {
+        public InstI32AtomicLoad() : base((ByteCode)AtomCode.I32AtomicLoad, ValType.I32, 4) {}
+        protected override void DoLoad(ExecContext context, int ea) =>
+            context.OpStack.PushI32(CachedMem.AtomicLoadInt32(ea));
+    }
+
+    public sealed class InstI64AtomicLoad : InstAtomicLoad
+    {
+        public InstI64AtomicLoad() : base((ByteCode)AtomCode.I64AtomicLoad, ValType.I64, 8) {}
+        protected override void DoLoad(ExecContext context, int ea) =>
+            context.OpStack.PushI64(CachedMem.AtomicLoadInt64(ea));
+    }
+
+    public sealed class InstI32AtomicLoad8U : InstAtomicLoad
+    {
+        public InstI32AtomicLoad8U() : base((ByteCode)AtomCode.I32AtomicLoad8U, ValType.I32, 1) {}
+        protected override void DoLoad(ExecContext context, int ea) =>
+            context.OpStack.PushU32(Volatile.Read(ref CachedMem.Data[ea]));
+    }
+
+    public sealed class InstI32AtomicLoad16U : InstAtomicLoad
+    {
+        public InstI32AtomicLoad16U() : base((ByteCode)AtomCode.I32AtomicLoad16U, ValType.I32, 2) {}
+        protected override void DoLoad(ExecContext context, int ea)
+        {
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref CachedMem.Data[ea]);
+            context.OpStack.PushU32(Volatile.Read(ref cell));
+        }
+    }
+
+    public sealed class InstI64AtomicLoad8U : InstAtomicLoad
+    {
+        public InstI64AtomicLoad8U() : base((ByteCode)AtomCode.I64AtomicLoad8U, ValType.I64, 1) {}
+        protected override void DoLoad(ExecContext context, int ea) =>
+            context.OpStack.PushU64(Volatile.Read(ref CachedMem.Data[ea]));
+    }
+
+    public sealed class InstI64AtomicLoad16U : InstAtomicLoad
+    {
+        public InstI64AtomicLoad16U() : base((ByteCode)AtomCode.I64AtomicLoad16U, ValType.I64, 2) {}
+        protected override void DoLoad(ExecContext context, int ea)
+        {
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref CachedMem.Data[ea]);
+            context.OpStack.PushU64(Volatile.Read(ref cell));
+        }
+    }
+
+    public sealed class InstI64AtomicLoad32U : InstAtomicLoad
+    {
+        public InstI64AtomicLoad32U() : base((ByteCode)AtomCode.I64AtomicLoad32U, ValType.I64, 4) {}
+        protected override void DoLoad(ExecContext context, int ea)
+        {
+            // Reuse the typed helper; widen to u64.
+            context.OpStack.PushU64((uint)CachedMem.AtomicLoadInt32(ea));
+        }
+    }
+
+    // Stores ─────────────────────────────────────────────────────────────
+    // Full-width stores go through MemoryInstance's Interlocked.Exchange
+    // (seq-cst, matching the threads proposal requirement). Subword
+    // stores use Volatile.Write on a byte/short ref — aligned subword
+    // writes are atomic on all supported architectures.
+
+    public sealed class InstI32AtomicStore : InstAtomicStore32
+    {
+        public InstI32AtomicStore() : base((ByteCode)AtomCode.I32AtomicStore, 4) {}
+        protected override void DoStore(MemoryInstance mem, int ea, int value) =>
+            mem.AtomicStoreInt32(ea, value);
+    }
+
+    public sealed class InstI64AtomicStore : InstAtomicStore64
+    {
+        public InstI64AtomicStore() : base((ByteCode)AtomCode.I64AtomicStore, 8) {}
+        protected override void DoStore(MemoryInstance mem, int ea, long value) =>
+            mem.AtomicStoreInt64(ea, value);
+    }
+
+    public sealed class InstI32AtomicStore8 : InstAtomicStore32
+    {
+        public InstI32AtomicStore8() : base((ByteCode)AtomCode.I32AtomicStore8, 1) {}
+        protected override void DoStore(MemoryInstance mem, int ea, int value) =>
+            Volatile.Write(ref mem.Data[ea], (byte)value);
+    }
+
+    public sealed class InstI32AtomicStore16 : InstAtomicStore32
+    {
+        public InstI32AtomicStore16() : base((ByteCode)AtomCode.I32AtomicStore16, 2) {}
+        protected override void DoStore(MemoryInstance mem, int ea, int value)
+        {
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            Volatile.Write(ref cell, (ushort)value);
+        }
+    }
+
+    public sealed class InstI64AtomicStore8 : InstAtomicStore64
+    {
+        public InstI64AtomicStore8() : base((ByteCode)AtomCode.I64AtomicStore8, 1) {}
+        protected override void DoStore(MemoryInstance mem, int ea, long value) =>
+            Volatile.Write(ref mem.Data[ea], (byte)value);
+    }
+
+    public sealed class InstI64AtomicStore16 : InstAtomicStore64
+    {
+        public InstI64AtomicStore16() : base((ByteCode)AtomCode.I64AtomicStore16, 2) {}
+        protected override void DoStore(MemoryInstance mem, int ea, long value)
+        {
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            Volatile.Write(ref cell, (ushort)value);
+        }
+    }
+
+    public sealed class InstI64AtomicStore32 : InstAtomicStore64
+    {
+        public InstI64AtomicStore32() : base((ByteCode)AtomCode.I64AtomicStore32, 4) {}
+        protected override void DoStore(MemoryInstance mem, int ea, long value) =>
+            mem.AtomicStoreInt32(ea, (int)value);
+    }
+}

--- a/Wacs.Core/Instructions/Atomic/AtomicRmw.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicRmw.cs
@@ -1,0 +1,397 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Runtime.CompilerServices;
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    // Read-modify-write atomics.
+    //
+    // Full-width (i32, i64) ops dispatch to the typed helpers on
+    // MemoryInstance, which wrap Interlocked.* (Add/And/Or/Exchange/
+    // CompareExchange, with #if NET8+ gating on Interlocked.And/Or and
+    // CAS loop fallback on netstandard2.1).
+    //
+    // Sub-word (8-bit, 16-bit) ops CAS-loop on the enclosing 32-bit
+    // word because .NET BCL does not expose sub-word Interlocked ops.
+    // Spec alignment rules guarantee the enclosing word is in-bounds
+    // and aligned.
+    //
+    // Naming: class names follow the AtomCode enum 1:1. File grouped
+    // by op family (add/sub/and/or/xor/xchg).
+
+    internal static class SubwordCas
+    {
+        /// <summary>
+        /// CAS loop on a sub-word within the enclosing 32-bit word.
+        /// Returns the original sub-word value zero-extended to int.
+        /// </summary>
+        /// <param name="mem">Target memory.</param>
+        /// <param name="ea">Byte-level effective address of the sub-word.</param>
+        /// <param name="byteWidth">1 or 2 bytes.</param>
+        /// <param name="apply">Transform applied to the old sub-word
+        /// value; returned new sub-word value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Loop(MemoryInstance mem, int ea, int byteWidth,
+            System.Func<int, int> apply)
+        {
+            int wordEa = ea & ~3;
+            int byteShift = (ea & 3) * 8;
+            int bitMask = byteWidth == 1 ? 0xFF : 0xFFFF;
+            int wordMask = bitMask << byteShift;
+
+            int old, newWord, oldSub;
+            do
+            {
+                old = mem.AtomicLoadInt32(wordEa);
+                oldSub = (old >> byteShift) & bitMask;
+                int newSub = apply(oldSub) & bitMask;
+                newWord = (old & ~wordMask) | (newSub << byteShift);
+            }
+            while (mem.AtomicCompareExchangeInt32(wordEa, newWord, old) != old);
+            return oldSub;
+        }
+
+        /// <summary>
+        /// Sub-word cmpxchg: atomically replace if current matches
+        /// expected. Returns original (zero-extended).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Cmpxchg(MemoryInstance mem, int ea, int byteWidth,
+            int expected, int replacement)
+        {
+            int wordEa = ea & ~3;
+            int byteShift = (ea & 3) * 8;
+            int bitMask = byteWidth == 1 ? 0xFF : 0xFFFF;
+            int wordMask = bitMask << byteShift;
+            int expMasked = expected & bitMask;
+            int repMasked = replacement & bitMask;
+
+            while (true)
+            {
+                int old = mem.AtomicLoadInt32(wordEa);
+                int oldSub = (old >> byteShift) & bitMask;
+                if (oldSub != expMasked) return oldSub;
+                int newWord = (old & ~wordMask) | (repMasked << byteShift);
+                if (mem.AtomicCompareExchangeInt32(wordEa, newWord, old) == old)
+                    return oldSub;
+                // Another writer beat us; retry.
+            }
+        }
+    }
+
+    // ─── Add ─────────────────────────────────────────────────────────
+    public sealed class InstI32AtomicRmwAdd : InstAtomicRmw32
+    {
+        public InstI32AtomicRmwAdd() : base((ByteCode)AtomCode.I32AtomicRmwAdd, 4) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            mem.AtomicAddInt32(ea, arg);
+    }
+
+    public sealed class InstI64AtomicRmwAdd : InstAtomicRmw64
+    {
+        public InstI64AtomicRmwAdd() : base((ByteCode)AtomCode.I64AtomicRmwAdd, 8) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            mem.AtomicAddInt64(ea, arg);
+    }
+
+    public sealed class InstI32AtomicRmw8AddU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw8AddU() : base((ByteCode)AtomCode.I32AtomicRmw8AddU, 1) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 1, old => old + arg);
+    }
+
+    public sealed class InstI32AtomicRmw16AddU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw16AddU() : base((ByteCode)AtomCode.I32AtomicRmw16AddU, 2) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 2, old => old + arg);
+    }
+
+    public sealed class InstI64AtomicRmw8AddU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw8AddU() : base((ByteCode)AtomCode.I64AtomicRmw8AddU, 1) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 1, old => old + (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw16AddU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw16AddU() : base((ByteCode)AtomCode.I64AtomicRmw16AddU, 2) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 2, old => old + (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw32AddU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw32AddU() : base((ByteCode)AtomCode.I64AtomicRmw32AddU, 4) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)mem.AtomicAddInt32(ea, (int)arg);
+    }
+
+    // ─── Sub ─────────────────────────────────────────────────────────
+    // sub = add(-arg). .NET Interlocked has no native Sub.
+
+    public sealed class InstI32AtomicRmwSub : InstAtomicRmw32
+    {
+        public InstI32AtomicRmwSub() : base((ByteCode)AtomCode.I32AtomicRmwSub, 4) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            mem.AtomicAddInt32(ea, -arg);
+    }
+
+    public sealed class InstI64AtomicRmwSub : InstAtomicRmw64
+    {
+        public InstI64AtomicRmwSub() : base((ByteCode)AtomCode.I64AtomicRmwSub, 8) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            mem.AtomicAddInt64(ea, -arg);
+    }
+
+    public sealed class InstI32AtomicRmw8SubU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw8SubU() : base((ByteCode)AtomCode.I32AtomicRmw8SubU, 1) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 1, old => old - arg);
+    }
+
+    public sealed class InstI32AtomicRmw16SubU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw16SubU() : base((ByteCode)AtomCode.I32AtomicRmw16SubU, 2) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 2, old => old - arg);
+    }
+
+    public sealed class InstI64AtomicRmw8SubU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw8SubU() : base((ByteCode)AtomCode.I64AtomicRmw8SubU, 1) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 1, old => old - (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw16SubU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw16SubU() : base((ByteCode)AtomCode.I64AtomicRmw16SubU, 2) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 2, old => old - (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw32SubU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw32SubU() : base((ByteCode)AtomCode.I64AtomicRmw32SubU, 4) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)mem.AtomicAddInt32(ea, (int)(-arg));
+    }
+
+    // ─── And ─────────────────────────────────────────────────────────
+    public sealed class InstI32AtomicRmwAnd : InstAtomicRmw32
+    {
+        public InstI32AtomicRmwAnd() : base((ByteCode)AtomCode.I32AtomicRmwAnd, 4) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            mem.AtomicAndInt32(ea, arg);
+    }
+
+    public sealed class InstI64AtomicRmwAnd : InstAtomicRmw64
+    {
+        public InstI64AtomicRmwAnd() : base((ByteCode)AtomCode.I64AtomicRmwAnd, 8) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            mem.AtomicAndInt64(ea, arg);
+    }
+
+    public sealed class InstI32AtomicRmw8AndU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw8AndU() : base((ByteCode)AtomCode.I32AtomicRmw8AndU, 1) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 1, old => old & arg);
+    }
+
+    public sealed class InstI32AtomicRmw16AndU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw16AndU() : base((ByteCode)AtomCode.I32AtomicRmw16AndU, 2) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 2, old => old & arg);
+    }
+
+    public sealed class InstI64AtomicRmw8AndU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw8AndU() : base((ByteCode)AtomCode.I64AtomicRmw8AndU, 1) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 1, old => old & (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw16AndU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw16AndU() : base((ByteCode)AtomCode.I64AtomicRmw16AndU, 2) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 2, old => old & (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw32AndU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw32AndU() : base((ByteCode)AtomCode.I64AtomicRmw32AndU, 4) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)mem.AtomicAndInt32(ea, (int)arg);
+    }
+
+    // ─── Or ──────────────────────────────────────────────────────────
+    public sealed class InstI32AtomicRmwOr : InstAtomicRmw32
+    {
+        public InstI32AtomicRmwOr() : base((ByteCode)AtomCode.I32AtomicRmwOr, 4) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            mem.AtomicOrInt32(ea, arg);
+    }
+
+    public sealed class InstI64AtomicRmwOr : InstAtomicRmw64
+    {
+        public InstI64AtomicRmwOr() : base((ByteCode)AtomCode.I64AtomicRmwOr, 8) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            mem.AtomicOrInt64(ea, arg);
+    }
+
+    public sealed class InstI32AtomicRmw8OrU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw8OrU() : base((ByteCode)AtomCode.I32AtomicRmw8OrU, 1) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 1, old => old | arg);
+    }
+
+    public sealed class InstI32AtomicRmw16OrU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw16OrU() : base((ByteCode)AtomCode.I32AtomicRmw16OrU, 2) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 2, old => old | arg);
+    }
+
+    public sealed class InstI64AtomicRmw8OrU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw8OrU() : base((ByteCode)AtomCode.I64AtomicRmw8OrU, 1) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 1, old => old | (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw16OrU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw16OrU() : base((ByteCode)AtomCode.I64AtomicRmw16OrU, 2) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 2, old => old | (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw32OrU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw32OrU() : base((ByteCode)AtomCode.I64AtomicRmw32OrU, 4) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)mem.AtomicOrInt32(ea, (int)arg);
+    }
+
+    // ─── Xor ─────────────────────────────────────────────────────────
+    public sealed class InstI32AtomicRmwXor : InstAtomicRmw32
+    {
+        public InstI32AtomicRmwXor() : base((ByteCode)AtomCode.I32AtomicRmwXor, 4) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            mem.AtomicXorInt32(ea, arg);
+    }
+
+    public sealed class InstI64AtomicRmwXor : InstAtomicRmw64
+    {
+        public InstI64AtomicRmwXor() : base((ByteCode)AtomCode.I64AtomicRmwXor, 8) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            mem.AtomicXorInt64(ea, arg);
+    }
+
+    public sealed class InstI32AtomicRmw8XorU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw8XorU() : base((ByteCode)AtomCode.I32AtomicRmw8XorU, 1) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 1, old => old ^ arg);
+    }
+
+    public sealed class InstI32AtomicRmw16XorU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw16XorU() : base((ByteCode)AtomCode.I32AtomicRmw16XorU, 2) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 2, old => old ^ arg);
+    }
+
+    public sealed class InstI64AtomicRmw8XorU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw8XorU() : base((ByteCode)AtomCode.I64AtomicRmw8XorU, 1) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 1, old => old ^ (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw16XorU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw16XorU() : base((ByteCode)AtomCode.I64AtomicRmw16XorU, 2) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)SubwordCas.Loop(mem, ea, 2, old => old ^ (int)arg);
+    }
+
+    public sealed class InstI64AtomicRmw32XorU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw32XorU() : base((ByteCode)AtomCode.I64AtomicRmw32XorU, 4) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)mem.AtomicXorInt32(ea, (int)arg);
+    }
+
+    // ─── Xchg ────────────────────────────────────────────────────────
+    public sealed class InstI32AtomicRmwXchg : InstAtomicRmw32
+    {
+        public InstI32AtomicRmwXchg() : base((ByteCode)AtomCode.I32AtomicRmwXchg, 4) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            mem.AtomicExchangeInt32(ea, arg);
+    }
+
+    public sealed class InstI64AtomicRmwXchg : InstAtomicRmw64
+    {
+        public InstI64AtomicRmwXchg() : base((ByteCode)AtomCode.I64AtomicRmwXchg, 8) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            mem.AtomicExchangeInt64(ea, arg);
+    }
+
+    public sealed class InstI32AtomicRmw8XchgU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw8XchgU() : base((ByteCode)AtomCode.I32AtomicRmw8XchgU, 1) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 1, _ => arg);
+    }
+
+    public sealed class InstI32AtomicRmw16XchgU : InstAtomicRmw32
+    {
+        public InstI32AtomicRmw16XchgU() : base((ByteCode)AtomCode.I32AtomicRmw16XchgU, 2) {}
+        protected override int DoRmw(MemoryInstance mem, int ea, int arg) =>
+            SubwordCas.Loop(mem, ea, 2, _ => arg);
+    }
+
+    public sealed class InstI64AtomicRmw8XchgU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw8XchgU() : base((ByteCode)AtomCode.I64AtomicRmw8XchgU, 1) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg)
+        {
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 1, _ => a);
+        }
+    }
+
+    public sealed class InstI64AtomicRmw16XchgU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw16XchgU() : base((ByteCode)AtomCode.I64AtomicRmw16XchgU, 2) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg)
+        {
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 2, _ => a);
+        }
+    }
+
+    public sealed class InstI64AtomicRmw32XchgU : InstAtomicRmw64
+    {
+        public InstI64AtomicRmw32XchgU() : base((ByteCode)AtomCode.I64AtomicRmw32XchgU, 4) {}
+        protected override long DoRmw(MemoryInstance mem, int ea, long arg) =>
+            (uint)mem.AtomicExchangeInt32(ea, (int)arg);
+    }
+}

--- a/Wacs.Core/Instructions/Atomic/AtomicWaitNotify.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicWaitNotify.cs
@@ -1,0 +1,102 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime;
+using Wacs.Core.Validation;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    /// <summary>
+    /// <c>memory.atomic.notify</c> — wake up to <c>count</c> waiters at
+    /// <c>(memory, addr)</c>. Pushes the number of waiters actually woken.
+    /// Stack: <c>(addr, count) → woken</c>.
+    /// </summary>
+    public sealed class InstMemoryAtomicNotify : InstAtomicMemoryOp
+    {
+        public InstMemoryAtomicNotify()
+            : base((ByteCode)AtomCode.MemoryAtomicNotify, widthBytes: 4, stackDiff: -1)
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI32();           // count
+            context.OpStack.PopInt();           // addr
+            context.OpStack.PushI32();          // woken
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            int count = context.OpStack.PopI32();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            int woken = context.ConcurrencyPolicy.Notify(CachedMem, ea, count);
+            context.OpStack.PushI32(woken);
+        }
+    }
+
+    /// <summary>
+    /// <c>memory.atomic.wait32</c> — block until the i32 cell at
+    /// <c>(memory, addr)</c> is notified or the timeout elapses.
+    /// Stack: <c>(addr, expected, timeoutNs) → result</c>.
+    /// Result: 0 = ok, 1 = timed-out, 2 = not-equal.
+    /// </summary>
+    public sealed class InstMemoryAtomicWait32 : InstAtomicMemoryOp
+    {
+        public InstMemoryAtomicWait32()
+            : base((ByteCode)AtomCode.MemoryAtomicWait32, widthBytes: 4, stackDiff: -2)
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI64();           // timeoutNs
+            context.OpStack.PopI32();           // expected
+            context.OpStack.PopInt();           // addr
+            context.OpStack.PushI32();          // result
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            long timeoutNs = context.OpStack.PopI64();
+            int expected = context.OpStack.PopI32();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            int result = context.ConcurrencyPolicy.Wait32(CachedMem, ea, expected, timeoutNs);
+            context.OpStack.PushI32(result);
+        }
+    }
+
+    /// <summary>
+    /// <c>memory.atomic.wait64</c> — i64 variant of wait32.
+    /// Stack: <c>(addr, expected, timeoutNs) → result</c>.
+    /// </summary>
+    public sealed class InstMemoryAtomicWait64 : InstAtomicMemoryOp
+    {
+        public InstMemoryAtomicWait64()
+            : base((ByteCode)AtomCode.MemoryAtomicWait64, widthBytes: 8, stackDiff: -2)
+        { }
+
+        protected override void ValidateStack(IWasmValidationContext context)
+        {
+            context.OpStack.PopI64();           // timeoutNs
+            context.OpStack.PopI64();           // expected
+            context.OpStack.PopInt();           // addr
+            context.OpStack.PushI32();          // result
+        }
+
+        public override void Execute(ExecContext context)
+        {
+            long timeoutNs = context.OpStack.PopI64();
+            long expected = context.OpStack.PopI64();
+            long offset = context.OpStack.PopAddr();
+            long ea = CheckEa(offset);
+            int result = context.ConcurrencyPolicy.Wait64(CachedMem, ea, expected, timeoutNs);
+            context.OpStack.PushI32(result);
+        }
+    }
+}

--- a/Wacs.Core/Instructions/SpecFactory/SpecFactoryFE.cs
+++ b/Wacs.Core/Instructions/SpecFactory/SpecFactoryFE.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Kelvin Nishikawa
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.IO;
+using Wacs.Core.Instructions.Atomic;
 using Wacs.Core.OpCodes;
 
 namespace Wacs.Core.Instructions
@@ -21,7 +22,95 @@ namespace Wacs.Core.Instructions
     {
         public static InstructionBase? CreateInstruction(AtomCode opcode) => opcode switch
         {
-            _ => throw new InvalidDataException($"Unsupported instruction {opcode.GetMnemonic()}. ByteCode: 0xFE{(byte)opcode:X2}")
+            // Blocking + fence primitives
+            AtomCode.MemoryAtomicNotify       => new InstMemoryAtomicNotify(),
+            AtomCode.MemoryAtomicWait32       => new InstMemoryAtomicWait32(),
+            AtomCode.MemoryAtomicWait64       => new InstMemoryAtomicWait64(),
+            AtomCode.AtomicFence              => new InstAtomicFence(),
+
+            // Loads
+            AtomCode.I32AtomicLoad            => new InstI32AtomicLoad(),
+            AtomCode.I64AtomicLoad            => new InstI64AtomicLoad(),
+            AtomCode.I32AtomicLoad8U          => new InstI32AtomicLoad8U(),
+            AtomCode.I32AtomicLoad16U         => new InstI32AtomicLoad16U(),
+            AtomCode.I64AtomicLoad8U          => new InstI64AtomicLoad8U(),
+            AtomCode.I64AtomicLoad16U         => new InstI64AtomicLoad16U(),
+            AtomCode.I64AtomicLoad32U         => new InstI64AtomicLoad32U(),
+
+            // Stores
+            AtomCode.I32AtomicStore           => new InstI32AtomicStore(),
+            AtomCode.I64AtomicStore           => new InstI64AtomicStore(),
+            AtomCode.I32AtomicStore8          => new InstI32AtomicStore8(),
+            AtomCode.I32AtomicStore16         => new InstI32AtomicStore16(),
+            AtomCode.I64AtomicStore8          => new InstI64AtomicStore8(),
+            AtomCode.I64AtomicStore16         => new InstI64AtomicStore16(),
+            AtomCode.I64AtomicStore32         => new InstI64AtomicStore32(),
+
+            // RMW add
+            AtomCode.I32AtomicRmwAdd          => new InstI32AtomicRmwAdd(),
+            AtomCode.I64AtomicRmwAdd          => new InstI64AtomicRmwAdd(),
+            AtomCode.I32AtomicRmw8AddU        => new InstI32AtomicRmw8AddU(),
+            AtomCode.I32AtomicRmw16AddU       => new InstI32AtomicRmw16AddU(),
+            AtomCode.I64AtomicRmw8AddU        => new InstI64AtomicRmw8AddU(),
+            AtomCode.I64AtomicRmw16AddU       => new InstI64AtomicRmw16AddU(),
+            AtomCode.I64AtomicRmw32AddU       => new InstI64AtomicRmw32AddU(),
+
+            // RMW sub
+            AtomCode.I32AtomicRmwSub          => new InstI32AtomicRmwSub(),
+            AtomCode.I64AtomicRmwSub          => new InstI64AtomicRmwSub(),
+            AtomCode.I32AtomicRmw8SubU        => new InstI32AtomicRmw8SubU(),
+            AtomCode.I32AtomicRmw16SubU       => new InstI32AtomicRmw16SubU(),
+            AtomCode.I64AtomicRmw8SubU        => new InstI64AtomicRmw8SubU(),
+            AtomCode.I64AtomicRmw16SubU       => new InstI64AtomicRmw16SubU(),
+            AtomCode.I64AtomicRmw32SubU       => new InstI64AtomicRmw32SubU(),
+
+            // RMW and
+            AtomCode.I32AtomicRmwAnd          => new InstI32AtomicRmwAnd(),
+            AtomCode.I64AtomicRmwAnd          => new InstI64AtomicRmwAnd(),
+            AtomCode.I32AtomicRmw8AndU        => new InstI32AtomicRmw8AndU(),
+            AtomCode.I32AtomicRmw16AndU       => new InstI32AtomicRmw16AndU(),
+            AtomCode.I64AtomicRmw8AndU        => new InstI64AtomicRmw8AndU(),
+            AtomCode.I64AtomicRmw16AndU       => new InstI64AtomicRmw16AndU(),
+            AtomCode.I64AtomicRmw32AndU       => new InstI64AtomicRmw32AndU(),
+
+            // RMW or
+            AtomCode.I32AtomicRmwOr           => new InstI32AtomicRmwOr(),
+            AtomCode.I64AtomicRmwOr           => new InstI64AtomicRmwOr(),
+            AtomCode.I32AtomicRmw8OrU         => new InstI32AtomicRmw8OrU(),
+            AtomCode.I32AtomicRmw16OrU        => new InstI32AtomicRmw16OrU(),
+            AtomCode.I64AtomicRmw8OrU         => new InstI64AtomicRmw8OrU(),
+            AtomCode.I64AtomicRmw16OrU        => new InstI64AtomicRmw16OrU(),
+            AtomCode.I64AtomicRmw32OrU        => new InstI64AtomicRmw32OrU(),
+
+            // RMW xor
+            AtomCode.I32AtomicRmwXor          => new InstI32AtomicRmwXor(),
+            AtomCode.I64AtomicRmwXor          => new InstI64AtomicRmwXor(),
+            AtomCode.I32AtomicRmw8XorU        => new InstI32AtomicRmw8XorU(),
+            AtomCode.I32AtomicRmw16XorU       => new InstI32AtomicRmw16XorU(),
+            AtomCode.I64AtomicRmw8XorU        => new InstI64AtomicRmw8XorU(),
+            AtomCode.I64AtomicRmw16XorU       => new InstI64AtomicRmw16XorU(),
+            AtomCode.I64AtomicRmw32XorU       => new InstI64AtomicRmw32XorU(),
+
+            // RMW xchg
+            AtomCode.I32AtomicRmwXchg         => new InstI32AtomicRmwXchg(),
+            AtomCode.I64AtomicRmwXchg         => new InstI64AtomicRmwXchg(),
+            AtomCode.I32AtomicRmw8XchgU       => new InstI32AtomicRmw8XchgU(),
+            AtomCode.I32AtomicRmw16XchgU      => new InstI32AtomicRmw16XchgU(),
+            AtomCode.I64AtomicRmw8XchgU       => new InstI64AtomicRmw8XchgU(),
+            AtomCode.I64AtomicRmw16XchgU      => new InstI64AtomicRmw16XchgU(),
+            AtomCode.I64AtomicRmw32XchgU      => new InstI64AtomicRmw32XchgU(),
+
+            // Cmpxchg
+            AtomCode.I32AtomicRmwCmpxchg      => new InstI32AtomicRmwCmpxchg(),
+            AtomCode.I64AtomicRmwCmpxchg      => new InstI64AtomicRmwCmpxchg(),
+            AtomCode.I32AtomicRmw8CmpxchgU    => new InstI32AtomicRmw8CmpxchgU(),
+            AtomCode.I32AtomicRmw16CmpxchgU   => new InstI32AtomicRmw16CmpxchgU(),
+            AtomCode.I64AtomicRmw8CmpxchgU    => new InstI64AtomicRmw8CmpxchgU(),
+            AtomCode.I64AtomicRmw16CmpxchgU   => new InstI64AtomicRmw16CmpxchgU(),
+            AtomCode.I64AtomicRmw32CmpxchgU   => new InstI64AtomicRmw32CmpxchgU(),
+
+            _ => throw new InvalidDataException(
+                $"Unsupported instruction {opcode.GetMnemonic()}. ByteCode: 0xFE{(byte)opcode:X2}")
         };
     }
 }

--- a/Wacs.Core/Modules/Module.cs
+++ b/Wacs.Core/Modules/Module.cs
@@ -40,7 +40,11 @@ namespace Wacs.Core
         }
 
         public ValidationResult Validate() => new ModuleValidator().Validate(this);
+        public ValidationResult Validate(Runtime.RuntimeAttributes attributes) =>
+            new ModuleValidator(attributes).Validate(this);
         public void ValidateAndThrow() => new ModuleValidator().ValidateAndThrow(this);
+        public void ValidateAndThrow(Runtime.RuntimeAttributes attributes) =>
+            new ModuleValidator(attributes).ValidateAndThrow(this);
     }
 
     /// <summary>

--- a/Wacs.Core/Runtime/Concurrency/ConcurrencyPolicyMode.cs
+++ b/Wacs.Core/Runtime/Concurrency/ConcurrencyPolicyMode.cs
@@ -1,0 +1,38 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+namespace Wacs.Core.Runtime.Concurrency
+{
+    /// <summary>
+    /// High-level classification of the active <see cref="IConcurrencyPolicy"/>.
+    /// The threads proposal does not standardize how hosts spawn wasm threads;
+    /// it only standardizes shared memory + atomic ops + wait/notify. This mode
+    /// lets callers introspect whether the runtime is configured to actually
+    /// block on <c>memory.atomic.wait*</c> and wake via <c>memory.atomic.notify</c>
+    /// (<see cref="HostDefined"/>), or to run single-threaded with
+    /// immediate-return wait semantics (<see cref="NotSupported"/>).
+    /// </summary>
+    public enum ConcurrencyPolicyMode : byte
+    {
+        /// <summary>
+        /// Single-threaded runtime. <c>atomic.wait</c> with a finite timeout
+        /// returns <c>timed-out</c> after the timeout elapses; with an
+        /// infinite timeout (&lt; 0) traps, since there is no one to notify.
+        /// <c>notify</c> is a no-op returning 0.
+        /// </summary>
+        NotSupported,
+
+        /// <summary>
+        /// Host has opted in to concurrent wasm execution. The runtime
+        /// maintains a wait-queue keyed on <c>(MemoryInstance, address)</c>
+        /// and blocks waiters until a matching <c>notify</c> fires or the
+        /// timeout elapses.
+        /// </summary>
+        HostDefined,
+    }
+}

--- a/Wacs.Core/Runtime/Concurrency/HostDefinedPolicy.cs
+++ b/Wacs.Core/Runtime/Concurrency/HostDefinedPolicy.cs
@@ -1,0 +1,152 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Runtime.Concurrency
+{
+    /// <summary>
+    /// Concurrency policy that actually blocks on <c>atomic.wait</c> and
+    /// wakes waiters on <c>atomic.notify</c>. Maintains a wait queue keyed
+    /// on <c>(MemoryInstance, address)</c> pairs, with waiters registered
+    /// via <see cref="ManualResetEventSlim"/>.
+    /// <para>
+    /// Thread-safety: the queue itself is a
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/>; per-slot waiter lists
+    /// are guarded by a small lock, so concurrent waits and notifies on the
+    /// same address are safe.
+    /// </para>
+    /// </summary>
+    public sealed class HostDefinedPolicy : IConcurrencyPolicy
+    {
+        public ConcurrencyPolicyMode Mode => ConcurrencyPolicyMode.HostDefined;
+
+        private readonly ConcurrentDictionary<WaitKey, WaitSlot> _slots =
+            new ConcurrentDictionary<WaitKey, WaitSlot>();
+
+        private readonly struct WaitKey : System.IEquatable<WaitKey>
+        {
+            public readonly MemoryInstance Mem;
+            public readonly long Addr;
+
+            public WaitKey(MemoryInstance mem, long addr) { Mem = mem; Addr = addr; }
+
+            public bool Equals(WaitKey other) =>
+                ReferenceEquals(Mem, other.Mem) && Addr == other.Addr;
+
+            public override bool Equals(object? obj) => obj is WaitKey k && Equals(k);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int h = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Mem);
+                    return (h * 397) ^ Addr.GetHashCode();
+                }
+            }
+        }
+
+        private sealed class Waiter
+        {
+            public readonly ManualResetEventSlim Event = new ManualResetEventSlim(false);
+            public bool Notified;
+        }
+
+        private sealed class WaitSlot
+        {
+            public readonly object Sync = new object();
+            public readonly List<Waiter> Waiters = new List<Waiter>();
+        }
+
+        public int Wait32(MemoryInstance mem, long addr, int expected, long timeoutNs)
+        {
+            // Re-check value under the slot's sync so that a notifier who
+            // holds the lock can't race past us between the equality
+            // check and our enqueue.
+            var key = new WaitKey(mem, addr);
+            var slot = _slots.GetOrAdd(key, _ => new WaitSlot());
+            var waiter = new Waiter();
+
+            int current;
+            lock (slot.Sync)
+            {
+                current = mem.AtomicLoadInt32((int)addr);
+                if (current != expected) return 2;
+                slot.Waiters.Add(waiter);
+            }
+
+            return WaitAndDequeue(slot, waiter, timeoutNs);
+        }
+
+        public int Wait64(MemoryInstance mem, long addr, long expected, long timeoutNs)
+        {
+            var key = new WaitKey(mem, addr);
+            var slot = _slots.GetOrAdd(key, _ => new WaitSlot());
+            var waiter = new Waiter();
+
+            long current;
+            lock (slot.Sync)
+            {
+                current = mem.AtomicLoadInt64((int)addr);
+                if (current != expected) return 2;
+                slot.Waiters.Add(waiter);
+            }
+
+            return WaitAndDequeue(slot, waiter, timeoutNs);
+        }
+
+        public int Notify(MemoryInstance mem, long addr, int maxWaiters)
+        {
+            var key = new WaitKey(mem, addr);
+            if (!_slots.TryGetValue(key, out var slot)) return 0;
+
+            int woken = 0;
+            lock (slot.Sync)
+            {
+                int take = maxWaiters < 0 || maxWaiters > slot.Waiters.Count
+                    ? slot.Waiters.Count : maxWaiters;
+                for (int i = 0; i < take; i++)
+                {
+                    var w = slot.Waiters[i];
+                    w.Notified = true;
+                    w.Event.Set();
+                    woken++;
+                }
+                if (take > 0) slot.Waiters.RemoveRange(0, take);
+            }
+            return woken;
+        }
+
+        private static int WaitAndDequeue(WaitSlot slot, Waiter waiter, long timeoutNs)
+        {
+            int timeoutMs;
+            if (timeoutNs < 0) timeoutMs = Timeout.Infinite;
+            else
+            {
+                long ms = timeoutNs / 1_000_000;
+                if (ms > int.MaxValue) ms = int.MaxValue;
+                timeoutMs = (int)ms;
+            }
+
+            bool signaled = waiter.Event.Wait(timeoutMs);
+
+            if (signaled && waiter.Notified) return 0; // ok
+
+            // Timed out OR spurious — remove ourselves from the queue if
+            // we weren't already dequeued by a concurrent notifier.
+            lock (slot.Sync)
+            {
+                if (!waiter.Notified) slot.Waiters.Remove(waiter);
+            }
+            return 1; // timed-out
+        }
+    }
+}

--- a/Wacs.Core/Runtime/Concurrency/IConcurrencyPolicy.cs
+++ b/Wacs.Core/Runtime/Concurrency/IConcurrencyPolicy.cs
@@ -1,0 +1,57 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Runtime.Concurrency
+{
+    /// <summary>
+    /// Backend for <c>memory.atomic.wait32</c>, <c>memory.atomic.wait64</c>,
+    /// and <c>memory.atomic.notify</c> from the WebAssembly threads proposal.
+    /// The runtime dispatches every wait/notify op through a single
+    /// <see cref="IConcurrencyPolicy"/> instance attached to
+    /// <see cref="RuntimeAttributes.ConcurrencyPolicy"/>.
+    /// <para>
+    /// Return-value conventions match the threads-proposal spec:
+    /// <list type="bullet">
+    ///   <item><c>Wait32</c>/<c>Wait64</c>: 0 = ok (notified), 1 = timed-out, 2 = not-equal.</item>
+    ///   <item><c>Notify</c>: count of waiters actually woken.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public interface IConcurrencyPolicy
+    {
+        ConcurrencyPolicyMode Mode { get; }
+
+        /// <summary>
+        /// Wait on a 32-bit value at <paramref name="addr"/> in
+        /// <paramref name="mem"/>. Returns 0 (ok), 1 (timed-out), or 2
+        /// (not-equal — current value did not match <paramref name="expected"/>).
+        /// </summary>
+        /// <param name="mem">Target memory; must be a shared memory.</param>
+        /// <param name="addr">Effective address (post-offset); must be
+        /// 4-byte aligned.</param>
+        /// <param name="expected">Value to compare against the current cell.</param>
+        /// <param name="timeoutNs">Timeout in nanoseconds. Negative means
+        /// infinite.</param>
+        int Wait32(MemoryInstance mem, long addr, int expected, long timeoutNs);
+
+        /// <summary>
+        /// Wait on a 64-bit value at <paramref name="addr"/>. Returns 0
+        /// (ok), 1 (timed-out), or 2 (not-equal).
+        /// </summary>
+        int Wait64(MemoryInstance mem, long addr, long expected, long timeoutNs);
+
+        /// <summary>
+        /// Notify up to <paramref name="maxWaiters"/> waiters at
+        /// <paramref name="addr"/>. Returns the number of waiters actually
+        /// woken.
+        /// </summary>
+        int Notify(MemoryInstance mem, long addr, int maxWaiters);
+    }
+}

--- a/Wacs.Core/Runtime/Concurrency/NotSupportedPolicy.cs
+++ b/Wacs.Core/Runtime/Concurrency/NotSupportedPolicy.cs
@@ -1,0 +1,67 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Threading;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Runtime.Concurrency
+{
+    /// <summary>
+    /// Single-threaded concurrency policy. Valid for Unity IL2CPP, WebGL,
+    /// and any host that has not opted into multi-threaded wasm execution.
+    /// <para>
+    /// Semantics follow the threads-proposal wait/notify spec as applied
+    /// to a single-thread host:
+    /// <list type="bullet">
+    ///   <item>Wait with mismatched current value → <c>not-equal</c> (2).</item>
+    ///   <item>Wait with matching value and finite timeout → blocks the
+    ///   calling thread via <see cref="Thread.Sleep(int)"/> for the
+    ///   timeout, returns <c>timed-out</c> (1). Since nobody else can
+    ///   notify, it is impossible to return <c>ok</c> under this policy.</item>
+    ///   <item>Wait with matching value and infinite timeout → traps.
+    ///   The wait would be a permanent deadlock; matches wasmtime / v8
+    ///   behavior when the main thread calls wait on non-shared memory.</item>
+    ///   <item>Notify → always 0 (no one to wake).</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public sealed class NotSupportedPolicy : IConcurrencyPolicy
+    {
+        public ConcurrencyPolicyMode Mode => ConcurrencyPolicyMode.NotSupported;
+
+        public int Wait32(MemoryInstance mem, long addr, int expected, long timeoutNs)
+        {
+            int current = mem.AtomicLoadInt32((int)addr);
+            if (current != expected) return 2; // not-equal
+            return BlockOrTrap(timeoutNs);
+        }
+
+        public int Wait64(MemoryInstance mem, long addr, long expected, long timeoutNs)
+        {
+            long current = mem.AtomicLoadInt64((int)addr);
+            if (current != expected) return 2;
+            return BlockOrTrap(timeoutNs);
+        }
+
+        public int Notify(MemoryInstance mem, long addr, int maxWaiters) => 0;
+
+        private static int BlockOrTrap(long timeoutNs)
+        {
+            if (timeoutNs < 0)
+                throw new TrapException(
+                    "atomic.wait would deadlock (ConcurrencyPolicy=NotSupported with infinite timeout)");
+            // Round up to at least 1 ms, clamp to int.MaxValue.
+            long ms = timeoutNs / 1_000_000;
+            if (ms <= 0) ms = 0;
+            else if (ms > int.MaxValue) ms = int.MaxValue;
+            if (ms > 0) Thread.Sleep((int)ms);
+            return 1; // timed-out
+        }
+    }
+}

--- a/Wacs.Core/Runtime/ExecContext.cs
+++ b/Wacs.Core/Runtime/ExecContext.cs
@@ -157,6 +157,8 @@ namespace Wacs.Core.Runtime
 
         public InstructionBaseFactory InstructionFactory => Attributes.InstructionFactory;
 
+        public Concurrency.IConcurrencyPolicy ConcurrencyPolicy => Attributes.ConcurrencyPolicy;
+
         public MemoryInstance DefaultMemory => Store[Frame.Module.MemAddrs[default]];
 
         public int LabelHeight => _linkLabelStack.Count;

--- a/Wacs.Core/Runtime/RuntimeAttributes.cs
+++ b/Wacs.Core/Runtime/RuntimeAttributes.cs
@@ -13,11 +13,47 @@
 // limitations under the License.
 
 using Wacs.Core.Instructions;
+using Wacs.Core.Runtime.Concurrency;
 
 namespace Wacs.Core.Runtime
 {
     public class RuntimeAttributes
     {
+        /// <summary>
+        /// Backend for <c>memory.atomic.wait*</c> / <c>memory.atomic.notify</c>
+        /// from the WebAssembly threads proposal. Defaults to
+        /// <see cref="NotSupportedPolicy"/> when the runtime detects a
+        /// Unity IL2CPP environment (main-thread blocking risks), and
+        /// <see cref="HostDefinedPolicy"/> elsewhere. Hosts may override
+        /// at any time before instantiation.
+        /// </summary>
+        public IConcurrencyPolicy ConcurrencyPolicy { get; set; } =
+            DetectIsUnity() ? (IConcurrencyPolicy)new NotSupportedPolicy()
+                            : new HostDefinedPolicy();
+
+        /// <summary>
+        /// When true, validation downgrades the "atomic op on non-shared
+        /// memory" error to a pass. Emscripten and LLVM sometimes emit
+        /// atomic ops on non-shared memories for single-threaded hosts; the
+        /// threads proposal itself requires shared. Default false (strict).
+        /// </summary>
+        public bool RelaxAtomicSharedCheck { get; set; } = false;
+
+        // Cache the Unity detection result to avoid reflecting on every
+        // new RuntimeAttributes().
+        private static readonly bool _isUnity = ProbeUnity();
+        private static bool DetectIsUnity() => _isUnity;
+        private static bool ProbeUnity()
+        {
+            // Type.GetType with throwOnError:false is AOT-safe under trimmer
+            // + IL2CPP. UnityEngine.Application is never stripped from a
+            // Unity build (it's bootstrap-critical).
+            var t = System.Type.GetType(
+                "UnityEngine.Application, UnityEngine.CoreModule",
+                throwOnError: false);
+            return t != null;
+        }
+
         public int GrowCallStack = 512;
 
         public int InitialCallStack = 512;

--- a/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -14,8 +14,10 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using FluentValidation;
 using Wacs.Core.Runtime.Exceptions;
 using Wacs.Core.Types;
@@ -26,6 +28,17 @@ namespace Wacs.Core.Runtime.Types
     public class MemoryInstance
     {
         public byte[] Data;
+
+        // Lazy-allocated only when the host has opted into concurrent wasm
+        // execution (see ConcurrencyPolicyMode.HostDefined) AND the memory
+        // type is shared. Without both, atomic ops operate on an
+        // uncontended Data array and Grow is only called from the one
+        // executing thread — no lock needed. Allocating this eagerly on
+        // every MemoryInstance would penalize the single-threaded common
+        // case, and ReaderWriterLockSlim has historical IL2CPP fragility
+        // pre-Unity-2022, so gating on HostDefined keeps Unity consumers
+        // off the lock entirely.
+        internal ReaderWriterLockSlim? _growLock;
 
         [SuppressMessage("ReSharper.DPA", "DPA0003: Excessive memory allocations in LOH", MessageId = "type: System.Byte[]; size: 134MB")]
         public MemoryInstance(MemoryType type)
@@ -77,14 +90,317 @@ namespace Wacs.Core.Runtime.Types
 
             int len = (int)(newNumPages * Constants.PageSize);
 
-            Array.Resize(ref Data, len);
-
-            Type = new MemoryType(newLimits);
+            var gl = _growLock;
+            if (gl != null)
+            {
+                gl.EnterWriteLock();
+                try
+                {
+                    Array.Resize(ref Data, len);
+                    Type = new MemoryType(newLimits);
+                }
+                finally
+                {
+                    gl.ExitWriteLock();
+                }
+            }
+            else
+            {
+                Array.Resize(ref Data, len);
+                Type = new MemoryType(newLimits);
+            }
 
             return true;
         }
 
-        public bool Contains(int offset, int width) => 
+        /// <summary>
+        /// Opt-in: allocate the concurrent-grow lock. Called by the
+        /// runtime when a shared memory is instantiated under
+        /// <see cref="Concurrency.ConcurrencyPolicyMode.HostDefined"/>.
+        /// Idempotent; safe to call more than once.
+        /// </summary>
+        internal void EnableConcurrentGrow()
+        {
+            if (_growLock == null)
+                Interlocked.CompareExchange(ref _growLock,
+                    new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion), null);
+        }
+
+        // Atomic helpers. These are the entry points every
+        // InstAtomic* class routes through for shared-memory access,
+        // so the lock-vs-Interlocked discipline lives in one place.
+        // When _growLock is null (single-thread / non-shared case) the
+        // read-lock/release pair is skipped — zero overhead beyond the
+        // Interlocked intrinsic itself.
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnterReadIfShared()
+        {
+            _growLock?.EnterReadLock();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ExitReadIfShared()
+        {
+            _growLock?.ExitReadLock();
+        }
+
+        /// <summary>Atomic 32-bit load at byte offset <paramref name="ea"/>.
+        /// Caller guarantees <paramref name="ea"/> is in-bounds and 4-byte
+        /// aligned.</summary>
+        public int AtomicLoadInt32(int ea)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                return Volatile.Read(ref cell);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        /// <summary>Atomic 64-bit load. Uses <see cref="Interlocked.Read(ref long)"/>
+        /// because 64-bit reads on 32-bit ARM are not naturally atomic.</summary>
+        public long AtomicLoadInt64(int ea)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                return Interlocked.Read(ref cell);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        /// <summary>Seq-cst store. Uses <see cref="Interlocked.Exchange(ref int, int)"/>
+        /// (ignoring the return) because <c>Volatile.Write</c> is release-only,
+        /// insufficient for the threads-proposal requirement.</summary>
+        public void AtomicStoreInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                Interlocked.Exchange(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public void AtomicStoreInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                Interlocked.Exchange(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        /// <summary>Returns the original value at <paramref name="ea"/>.</summary>
+        public int AtomicCompareExchangeInt32(int ea, int newValue, int expected)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                return Interlocked.CompareExchange(ref cell, newValue, expected);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicCompareExchangeInt64(int ea, long newValue, long expected)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                return Interlocked.CompareExchange(ref cell, newValue, expected);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        /// <summary>Fetch-and-add: returns the original value.</summary>
+        public int AtomicAddInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                // Interlocked.Add returns the new value; subtract to get original.
+                return Interlocked.Add(ref cell, value) - value;
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicAddInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                return Interlocked.Add(ref cell, value) - value;
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        /// <summary>Exchange: returns original.</summary>
+        public int AtomicExchangeInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                return Interlocked.Exchange(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicExchangeInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                return Interlocked.Exchange(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+#if NET8_0_OR_GREATER
+        // Native bitwise-atomic paths (.NET 5+). These return the original value.
+        public int AtomicAndInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                return Interlocked.And(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public int AtomicOrInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                return Interlocked.Or(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicAndInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                return Interlocked.And(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicOrInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                return Interlocked.Or(ref cell, value);
+            }
+            finally { ExitReadIfShared(); }
+        }
+#else
+        // netstandard2.1 fallbacks — CAS loops for And/Or. Xor is CAS on all targets.
+        public int AtomicAndInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                int old;
+                do { old = Volatile.Read(ref cell); }
+                while (Interlocked.CompareExchange(ref cell, old & value, old) != old);
+                return old;
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public int AtomicOrInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                int old;
+                do { old = Volatile.Read(ref cell); }
+                while (Interlocked.CompareExchange(ref cell, old | value, old) != old);
+                return old;
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicAndInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                long old;
+                do { old = Interlocked.Read(ref cell); }
+                while (Interlocked.CompareExchange(ref cell, old & value, old) != old);
+                return old;
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicOrInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                long old;
+                do { old = Interlocked.Read(ref cell); }
+                while (Interlocked.CompareExchange(ref cell, old & value, old) != old);
+                return old;
+            }
+            finally { ExitReadIfShared(); }
+        }
+#endif
+
+        // Xor is CAS-loop on all targets — Interlocked.Xor is .NET 7+.
+        public int AtomicXorInt32(int ea, int value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                int old;
+                do { old = Volatile.Read(ref cell); }
+                while (Interlocked.CompareExchange(ref cell, old ^ value, old) != old);
+                return old;
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public long AtomicXorInt64(int ea, long value)
+        {
+            EnterReadIfShared();
+            try
+            {
+                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                long old;
+                do { old = Interlocked.Read(ref cell); }
+                while (Interlocked.CompareExchange(ref cell, old ^ value, old) != old);
+                return old;
+            }
+            finally { ExitReadIfShared(); }
+        }
+
+        public bool Contains(int offset, int width) =>
             offset >= 0 && (offset + width) <= Data.Length;
 
         public string ReadString(uint ptr, uint len)

--- a/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -119,7 +119,7 @@ namespace Wacs.Core.Runtime.Types
         /// <see cref="Concurrency.ConcurrencyPolicyMode.HostDefined"/>.
         /// Idempotent; safe to call more than once.
         /// </summary>
-        internal void EnableConcurrentGrow()
+        public void EnableConcurrentGrow()
         {
             if (_growLock == null)
                 Interlocked.CompareExchange(ref _growLock,

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -293,7 +293,7 @@ namespace Wacs.Core.Runtime
             {
                 //1
                 if (!options.SkipModuleValidation)
-                    module.ValidateAndThrow();
+                    module.ValidateAndThrow(Context.Attributes);
             }
             catch (ValidationException exc)
             {

--- a/Wacs.Core/Text/TextModuleParser.Instructions.cs
+++ b/Wacs.Core/Text/TextModuleParser.Instructions.cs
@@ -834,6 +834,18 @@ namespace Wacs.Core.Text
             if (TryGetMemoryOpcode(kw, out var memCode, out var naturalAlign))
                 return BuildMemoryInstructionWithContext(memCode, naturalAlign, parent, ref i, fctx);
 
+            // Atomic memarg-carrying ops (threads proposal). Natural
+            // alignment is the exact access width; the rest of the memarg
+            // plumbing is identical to non-atomic memory ops.
+            if (TryGetAtomicMemoryOpcode(kw, out var atomCode, out var atomNaturalAlign))
+                return BuildMemoryInstructionWithContext(atomCode, atomNaturalAlign, parent, ref i, fctx);
+
+            // atomic.fence — no memarg, but the binary form carries a
+            // reserved 0x00 byte. Synthesize it so the factory's Parse
+            // succeeds.
+            if (kw == "atomic.fence")
+                return DecodeViaBinary((ByteCode)AtomCode.AtomicFence, w => w.Write((byte)0));
+
             // Zero-immediate ops — look up by mnemonic. The factory produces
             // a ready instance; we don't need to parse further immediates.
             if (Mnemonics.TryLookup(kw, out var bc) && IsZeroImmediate(bc))
@@ -992,6 +1004,102 @@ namespace Wacs.Core.Text
             ByteCode code, int naturalAlignLog2, SExpr parent, ref int i)
         {
             return BuildMemoryInstructionWithContext(code, naturalAlignLog2, parent, ref i, null);
+        }
+
+        /// <summary>
+        /// Memarg-carrying atomic ops (threads proposal). Excludes
+        /// <c>atomic.fence</c>, which takes no memarg. The
+        /// <paramref name="naturalAlignLog2"/> matches the access width
+        /// exactly — atomic ops require <c>align == width</c> at
+        /// validation, not the <c>align ≤ width</c> rule used by
+        /// non-atomic ops.
+        /// </summary>
+        private static bool TryGetAtomicMemoryOpcode(string kw, out ByteCode code, out int naturalAlignLog2)
+        {
+            switch (kw)
+            {
+                // Loads
+                case "i32.atomic.load":       code = (ByteCode)AtomCode.I32AtomicLoad;      naturalAlignLog2 = 2; return true;
+                case "i64.atomic.load":       code = (ByteCode)AtomCode.I64AtomicLoad;      naturalAlignLog2 = 3; return true;
+                case "i32.atomic.load8_u":    code = (ByteCode)AtomCode.I32AtomicLoad8U;    naturalAlignLog2 = 0; return true;
+                case "i32.atomic.load16_u":   code = (ByteCode)AtomCode.I32AtomicLoad16U;   naturalAlignLog2 = 1; return true;
+                case "i64.atomic.load8_u":    code = (ByteCode)AtomCode.I64AtomicLoad8U;    naturalAlignLog2 = 0; return true;
+                case "i64.atomic.load16_u":   code = (ByteCode)AtomCode.I64AtomicLoad16U;   naturalAlignLog2 = 1; return true;
+                case "i64.atomic.load32_u":   code = (ByteCode)AtomCode.I64AtomicLoad32U;   naturalAlignLog2 = 2; return true;
+                // Stores
+                case "i32.atomic.store":      code = (ByteCode)AtomCode.I32AtomicStore;     naturalAlignLog2 = 2; return true;
+                case "i64.atomic.store":      code = (ByteCode)AtomCode.I64AtomicStore;     naturalAlignLog2 = 3; return true;
+                case "i32.atomic.store8":     code = (ByteCode)AtomCode.I32AtomicStore8;    naturalAlignLog2 = 0; return true;
+                case "i32.atomic.store16":    code = (ByteCode)AtomCode.I32AtomicStore16;   naturalAlignLog2 = 1; return true;
+                case "i64.atomic.store8":     code = (ByteCode)AtomCode.I64AtomicStore8;    naturalAlignLog2 = 0; return true;
+                case "i64.atomic.store16":    code = (ByteCode)AtomCode.I64AtomicStore16;   naturalAlignLog2 = 1; return true;
+                case "i64.atomic.store32":    code = (ByteCode)AtomCode.I64AtomicStore32;   naturalAlignLog2 = 2; return true;
+                // Wait/notify
+                case "memory.atomic.notify":  code = (ByteCode)AtomCode.MemoryAtomicNotify; naturalAlignLog2 = 2; return true;
+                case "memory.atomic.wait32":  code = (ByteCode)AtomCode.MemoryAtomicWait32; naturalAlignLog2 = 2; return true;
+                case "memory.atomic.wait64":  code = (ByteCode)AtomCode.MemoryAtomicWait64; naturalAlignLog2 = 3; return true;
+                // RMW add
+                case "i32.atomic.rmw.add":    code = (ByteCode)AtomCode.I32AtomicRmwAdd;    naturalAlignLog2 = 2; return true;
+                case "i64.atomic.rmw.add":    code = (ByteCode)AtomCode.I64AtomicRmwAdd;    naturalAlignLog2 = 3; return true;
+                case "i32.atomic.rmw8.add_u": code = (ByteCode)AtomCode.I32AtomicRmw8AddU;  naturalAlignLog2 = 0; return true;
+                case "i32.atomic.rmw16.add_u":code = (ByteCode)AtomCode.I32AtomicRmw16AddU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw8.add_u": code = (ByteCode)AtomCode.I64AtomicRmw8AddU;  naturalAlignLog2 = 0; return true;
+                case "i64.atomic.rmw16.add_u":code = (ByteCode)AtomCode.I64AtomicRmw16AddU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw32.add_u":code = (ByteCode)AtomCode.I64AtomicRmw32AddU; naturalAlignLog2 = 2; return true;
+                // RMW sub
+                case "i32.atomic.rmw.sub":    code = (ByteCode)AtomCode.I32AtomicRmwSub;    naturalAlignLog2 = 2; return true;
+                case "i64.atomic.rmw.sub":    code = (ByteCode)AtomCode.I64AtomicRmwSub;    naturalAlignLog2 = 3; return true;
+                case "i32.atomic.rmw8.sub_u": code = (ByteCode)AtomCode.I32AtomicRmw8SubU;  naturalAlignLog2 = 0; return true;
+                case "i32.atomic.rmw16.sub_u":code = (ByteCode)AtomCode.I32AtomicRmw16SubU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw8.sub_u": code = (ByteCode)AtomCode.I64AtomicRmw8SubU;  naturalAlignLog2 = 0; return true;
+                case "i64.atomic.rmw16.sub_u":code = (ByteCode)AtomCode.I64AtomicRmw16SubU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw32.sub_u":code = (ByteCode)AtomCode.I64AtomicRmw32SubU; naturalAlignLog2 = 2; return true;
+                // RMW and
+                case "i32.atomic.rmw.and":    code = (ByteCode)AtomCode.I32AtomicRmwAnd;    naturalAlignLog2 = 2; return true;
+                case "i64.atomic.rmw.and":    code = (ByteCode)AtomCode.I64AtomicRmwAnd;    naturalAlignLog2 = 3; return true;
+                case "i32.atomic.rmw8.and_u": code = (ByteCode)AtomCode.I32AtomicRmw8AndU;  naturalAlignLog2 = 0; return true;
+                case "i32.atomic.rmw16.and_u":code = (ByteCode)AtomCode.I32AtomicRmw16AndU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw8.and_u": code = (ByteCode)AtomCode.I64AtomicRmw8AndU;  naturalAlignLog2 = 0; return true;
+                case "i64.atomic.rmw16.and_u":code = (ByteCode)AtomCode.I64AtomicRmw16AndU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw32.and_u":code = (ByteCode)AtomCode.I64AtomicRmw32AndU; naturalAlignLog2 = 2; return true;
+                // RMW or
+                case "i32.atomic.rmw.or":     code = (ByteCode)AtomCode.I32AtomicRmwOr;     naturalAlignLog2 = 2; return true;
+                case "i64.atomic.rmw.or":     code = (ByteCode)AtomCode.I64AtomicRmwOr;     naturalAlignLog2 = 3; return true;
+                case "i32.atomic.rmw8.or_u":  code = (ByteCode)AtomCode.I32AtomicRmw8OrU;   naturalAlignLog2 = 0; return true;
+                case "i32.atomic.rmw16.or_u": code = (ByteCode)AtomCode.I32AtomicRmw16OrU;  naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw8.or_u":  code = (ByteCode)AtomCode.I64AtomicRmw8OrU;   naturalAlignLog2 = 0; return true;
+                case "i64.atomic.rmw16.or_u": code = (ByteCode)AtomCode.I64AtomicRmw16OrU;  naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw32.or_u": code = (ByteCode)AtomCode.I64AtomicRmw32OrU;  naturalAlignLog2 = 2; return true;
+                // RMW xor
+                case "i32.atomic.rmw.xor":    code = (ByteCode)AtomCode.I32AtomicRmwXor;    naturalAlignLog2 = 2; return true;
+                case "i64.atomic.rmw.xor":    code = (ByteCode)AtomCode.I64AtomicRmwXor;    naturalAlignLog2 = 3; return true;
+                case "i32.atomic.rmw8.xor_u": code = (ByteCode)AtomCode.I32AtomicRmw8XorU;  naturalAlignLog2 = 0; return true;
+                case "i32.atomic.rmw16.xor_u":code = (ByteCode)AtomCode.I32AtomicRmw16XorU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw8.xor_u": code = (ByteCode)AtomCode.I64AtomicRmw8XorU;  naturalAlignLog2 = 0; return true;
+                case "i64.atomic.rmw16.xor_u":code = (ByteCode)AtomCode.I64AtomicRmw16XorU; naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw32.xor_u":code = (ByteCode)AtomCode.I64AtomicRmw32XorU; naturalAlignLog2 = 2; return true;
+                // RMW xchg
+                case "i32.atomic.rmw.xchg":   code = (ByteCode)AtomCode.I32AtomicRmwXchg;   naturalAlignLog2 = 2; return true;
+                case "i64.atomic.rmw.xchg":   code = (ByteCode)AtomCode.I64AtomicRmwXchg;   naturalAlignLog2 = 3; return true;
+                case "i32.atomic.rmw8.xchg_u":code = (ByteCode)AtomCode.I32AtomicRmw8XchgU; naturalAlignLog2 = 0; return true;
+                case "i32.atomic.rmw16.xchg_u":code = (ByteCode)AtomCode.I32AtomicRmw16XchgU;naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw8.xchg_u":code = (ByteCode)AtomCode.I64AtomicRmw8XchgU; naturalAlignLog2 = 0; return true;
+                case "i64.atomic.rmw16.xchg_u":code = (ByteCode)AtomCode.I64AtomicRmw16XchgU;naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw32.xchg_u":code = (ByteCode)AtomCode.I64AtomicRmw32XchgU;naturalAlignLog2 = 2; return true;
+                // Cmpxchg
+                case "i32.atomic.rmw.cmpxchg":code = (ByteCode)AtomCode.I32AtomicRmwCmpxchg;naturalAlignLog2 = 2; return true;
+                case "i64.atomic.rmw.cmpxchg":code = (ByteCode)AtomCode.I64AtomicRmwCmpxchg;naturalAlignLog2 = 3; return true;
+                case "i32.atomic.rmw8.cmpxchg_u":code = (ByteCode)AtomCode.I32AtomicRmw8CmpxchgU; naturalAlignLog2 = 0; return true;
+                case "i32.atomic.rmw16.cmpxchg_u":code = (ByteCode)AtomCode.I32AtomicRmw16CmpxchgU;naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw8.cmpxchg_u":code = (ByteCode)AtomCode.I64AtomicRmw8CmpxchgU; naturalAlignLog2 = 0; return true;
+                case "i64.atomic.rmw16.cmpxchg_u":code = (ByteCode)AtomCode.I64AtomicRmw16CmpxchgU;naturalAlignLog2 = 1; return true;
+                case "i64.atomic.rmw32.cmpxchg_u":code = (ByteCode)AtomCode.I64AtomicRmw32CmpxchgU;naturalAlignLog2 = 2; return true;
+
+                default:
+                    code = default;
+                    naturalAlignLog2 = 0;
+                    return false;
+            }
         }
 
         private static InstructionBase BuildMemoryInstructionWithContext(

--- a/Wacs.Core/Validation/Validation.cs
+++ b/Wacs.Core/Validation/Validation.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using FluentValidation;
+using Wacs.Core.Runtime;
 using Wacs.Core.Types;
 
 namespace Wacs.Core.Validation
@@ -22,13 +23,17 @@ namespace Wacs.Core.Validation
     /// </summary>
     public class ModuleValidator : AbstractValidator<Module>
     {
-        public ModuleValidator()
+        public ModuleValidator() : this(null) { }
+
+        public ModuleValidator(RuntimeAttributes? attributes)
         {
             //Set the validation context
             RuleFor(module => module)
                 .Custom((module, ctx) =>
                 {
-                    ctx.RootContextData[nameof(WasmValidationContext)] = new WasmValidationContext(module, ctx);
+                    var vctx = new WasmValidationContext(module, ctx);
+                    if (attributes != null) vctx.Attributes = attributes;
+                    ctx.RootContextData[nameof(WasmValidationContext)] = vctx;
                 });
 
             RuleForEach(module => module.Types).SetValidator(new RecursiveType.Validator());


### PR DESCRIPTION
## Summary

Phase 1 of the three-phase [WebAssembly threads proposal](https://github.com/webassembly/threads) implementation. Scope: polymorphic interpreter only; switch runtime and AOT transpiler are later phases and fall back to the polymorphic path for atomic-op functions.

Flips README feature table **Threads / threads ❌ → ✅**. Per the plan at `/Users/kelvinnishikawa/.claude/plans/agile-skipping-starfish.md`.

## What's in

### Concurrency-policy layer (`Wacs.Core/Runtime/Concurrency/`)
- `ConcurrencyPolicyMode` enum (NotSupported, HostDefined).
- `IConcurrencyPolicy` — Wait32/Wait64/Notify with spec return values (0=ok, 1=timed-out, 2=not-equal).
- `NotSupportedPolicy` — single-threaded host. Wait with mismatched value → 2; matching value + finite timeout → sleeps + returns 1; matching value + infinite timeout → `TrapException`. Notify → 0.
- `HostDefinedPolicy` — real wait/notify via `ConcurrentDictionary<(MemoryInstance, addr), WaitSlot>` + per-waiter `ManualResetEventSlim`.

### `MemoryInstance` concurrency (`Wacs.Core/Runtime/Types/MemoryInstance.cs`)
- Lazy `ReaderWriterLockSlim _growLock` — only allocated when memory is shared AND policy is HostDefined. Single-threaded modules pay nothing.
- Typed atomic helpers (`AtomicLoadInt32/64`, `AtomicStoreInt32/64`, `AtomicCompareExchangeInt32/64`, `AtomicAdd/Exchange/And/Or/Xor` for both widths). `Interlocked.*` on .NET 8+; CAS-loop fallback for And/Or/Xor on netstandard2.1.

### Runtime attributes
- `RuntimeAttributes.ConcurrencyPolicy` with IL2CPP-detecting default: `Type.GetType("UnityEngine.Application, UnityEngine.CoreModule", throwOnError: false)` chooses `NotSupportedPolicy` under Unity, `HostDefinedPolicy` elsewhere. AOT-safe (no `Reflection.Emit`).
- `RuntimeAttributes.RelaxAtomicSharedCheck` — strict-by-default, optional escape hatch for toolchains that emit atomics on non-shared memories. Flows through `Module.ValidateAndThrow(RuntimeAttributes)` into `WasmValidationContext.Attributes`.

### Instruction hierarchy (`Wacs.Core/Instructions/Atomic/`)
- `InstAtomicMemoryOp` base — shared parse/validate/link, caches `MemoryInstance`, enforces **exact** natural alignment (tighter than `≤` used by non-atomic ops) and the shared-memory requirement.
- 47 concrete classes across five files:
  - `AtomicLoadStore.cs` — 14 (7 loads + 7 stores).
  - `AtomicRmw.cs` — 35 (6 op families × i32/i64/subword widths). Full-width via `Interlocked.*`; subword via CAS loop on the enclosing 32-bit word (`SubwordCas` helper).
  - `AtomicCmpxchg.cs` — 7 (i32, i64, sub-word).
  - `AtomicWaitNotify.cs` — 3, routed through `IConcurrencyPolicy`.
  - `AtomicFence.cs` — 1, parses the reserved 0x00 byte and calls `Interlocked.MemoryBarrier()`.

### Factory + parser wiring
- `SpecFactoryFE.cs` populated with all 47 entries (previously an empty throw-stub).
- WAT text parser: new `TryGetAtomicMemoryOpcode` table + `atomic.fence` special-case. Both binary and text paths now dispatch atomic ops correctly.

### Bug fix
- `Alignment.LinearSize()` returns 0 when the log2 exponent is 0 (align=1), which the non-atomic `≤` check tolerated but atomic `==` did not. `InstAtomicMemoryOp.Validate` uses `LogSize()` directly.

### Pinned spec fixture (`Spec.Test/Data/threads/atomic.wast`)
- Upstream snapshot from WebAssembly/threads@f521d7b3 (2026-02-10). Lives in-tree rather than as a submodule because threads is still a Phase 4 proposal, not merged into wasm-3.0. Verification against `../WebAssembly.pdf` Release 3.0 (2026-04-09) §5.4 confirms the current spec binary format ends at 0xFD (SIMD) — 0xFE is threads-only.

### Tests — **331/331 passing** (21 new threads + 4 spec fixture + 306 pre-existing)
- `AtomicInstructionTests.cs` (21 tests): validation (wrong alignment, non-shared memory rejected/accepted); load/store round-trips across widths; RMW + subword CAS correctness; cmpxchg success + mismatch; fence; wait/notify policy semantics under both policies; default policy selection.
- `SpecWastThreadsTests.cs` (4 tests): full-file s-expr + script-parser smoke; instantiate the spec's first module and run a representative assert_return sample; assert_invalid alignment case rejected.

## Scope boundary

1. **No concurrent wasm execution in a single `WasmRuntime`.** The runtime still holds a single `ExecContext`, so two threads can't call `Invoke` on the same runtime simultaneously. The policy layer (`HostDefinedPolicy`) supports real cross-thread wait/notify on shared `MemoryInstance` directly — but a proper "wasm thread spawn" story requires per-thread `ExecContext`, which is a phase-2 follow-up.
2. **Switch runtime + AOT transpiler don't emit atomic ops yet.** Any function containing an atomic op falls back to the polymorphic interpreter via the existing mixed-mode path (same mechanism used for too-large functions in the transpiler).
3. **Shared tables / globals** are a separate "shared-everything threads" proposal; out of scope here.

## Build / AOT

- Build clean on `Wacs.Core` with `<IsAotCompatible>true</IsAotCompatible>` — **0 new IL trim / AOT warnings** introduced by threads code.
- Pre-existing IL warnings in `Delegates.cs` / `HostFunction.cs` / `ExecContext.cs` unchanged.
- Full-stack `dotnet publish -p:PublishAot=true` for Wacs.Console has a pre-existing netstandard2.1-multi-targeting issue unrelated to this PR.

## Test plan

- [x] Unit test suite: `dotnet test Wacs.Core.Test` — 331/331 pass.
- [x] End-to-end smoke via Wacs.Console on a `.wat` module exercising load/store/rmw/cmpxchg/subword/fence.
- [x] Library-level AOT analyzer clean (no new IL warnings).
- [ ] CI green on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)