### PR TITLE
Threads proposal phase 2: switch runtime

### DIFF
--- a/Wacs.Core.Test/AtomicInstructionTests.cs
+++ b/Wacs.Core.Test/AtomicInstructionTests.cs
@@ -23,12 +23,14 @@ namespace Wacs.Core.Test
     public class AtomicInstructionTests
     {
         private static (WasmRuntime runtime, ModuleInstance inst) Build(string src,
-            IConcurrencyPolicy? policy = null, bool relaxSharedCheck = false)
+            IConcurrencyPolicy? policy = null, bool relaxSharedCheck = false,
+            bool useSwitchRuntime = false)
         {
             var attrs = new RuntimeAttributes();
             if (policy != null) attrs.ConcurrencyPolicy = policy;
             attrs.RelaxAtomicSharedCheck = relaxSharedCheck;
             var runtime = new WasmRuntime(attrs);
+            runtime.UseSwitchRuntime = useSwitchRuntime;
             var module = TextModuleParser.ParseWat(src);
             var inst = runtime.InstantiateModule(module);
             runtime.RegisterModule("M", inst);
@@ -392,6 +394,131 @@ namespace Wacs.Core.Test
             // Running the test suite outside Unity → HostDefined default.
             var attrs = new RuntimeAttributes();
             Assert.Equal(ConcurrencyPolicyMode.HostDefined, attrs.ConcurrencyPolicy.Mode);
+        }
+
+        // ---- Switch-runtime parity (phase 2) ----------------------------
+        // Each polymorphic test has a switch-runtime twin. Identical input
+        // must produce identical output regardless of which back-end
+        // dispatches the atomic instruction.
+
+        [Fact]
+        public void Switch_i32_load_store_round_trip()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 0x12345678
+                    i32.atomic.store align=4
+                    i32.const 0
+                    i32.atomic.load align=4))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(0x12345678, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_i64_load_store_round_trip()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i64)
+                    i32.const 8
+                    i64.const 0x0123456789ABCDEF
+                    i64.atomic.store align=8
+                    i32.const 8
+                    i64.atomic.load align=8))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(0x0123456789ABCDEFL, InvokeI64(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_subword_load_store()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 7
+                    i32.const 0xA5
+                    i32.atomic.store8 align=1
+                    i32.const 7
+                    i32.atomic.load8_u align=1))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(0xA5, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_rmw_add_and_subword_cas()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""rmw32"") (result i32)
+                    i32.const 0 i32.const 10 i32.atomic.store align=4
+                    i32.const 0 i32.const 5 i32.atomic.rmw.add align=4)
+                  (func (export ""rmw8"") (result i32)
+                    i32.const 3 i32.const 100 i32.atomic.store8 align=1
+                    i32.const 3 i32.const 56 i32.atomic.rmw8.add_u align=1)
+                  (func (export ""load32"") (result i32)
+                    i32.const 0 i32.atomic.load align=4))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(10, InvokeI32(rt, "rmw32"));     // original
+            Assert.Equal(15, InvokeI32(rt, "load32"));    // cell updated via switch path
+            Assert.Equal(100, InvokeI32(rt, "rmw8"));     // subword CAS loop
+        }
+
+        [Fact]
+        public void Switch_cmpxchg_success_and_mismatch()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""match"") (result i32)
+                    i32.const 0 i32.const 50 i32.atomic.store align=4
+                    i32.const 0 i32.const 50 i32.const 99 i32.atomic.rmw.cmpxchg align=4)
+                  (func (export ""miss"") (result i32)
+                    i32.const 4 i32.const 50 i32.atomic.store align=4
+                    i32.const 4 i32.const 999 i32.const 99 i32.atomic.rmw.cmpxchg align=4)
+                  (func (export ""load"") (param i32) (result i32)
+                    local.get 0 i32.atomic.load align=4))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(50, InvokeI32(rt, "match"));
+            Assert.Equal(99, InvokeI32(rt, "load", 0));
+            Assert.Equal(50, InvokeI32(rt, "miss"));
+            Assert.Equal(50, InvokeI32(rt, "load", 4));   // unchanged on miss
+        }
+
+        [Fact]
+        public void Switch_fence_executes()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    atomic.fence
+                    i32.const 42))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(42, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_wait_and_notify_policy_semantics()
+        {
+            // NotSupported policy, mismatched expected → 2.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""wait_ne"") (result i32)
+                    i32.const 0 i32.const 99 i64.const 0
+                    memory.atomic.wait32 align=4)
+                  (func (export ""notify_empty"") (result i32)
+                    i32.const 0 i32.const 10
+                    memory.atomic.notify align=4))";
+            var (rt, _) = Build(src, policy: new NotSupportedPolicy(), useSwitchRuntime: true);
+            Assert.Equal(2, InvokeI32(rt, "wait_ne"));
+            Assert.Equal(0, InvokeI32(rt, "notify_empty"));
         }
     }
 }

--- a/Wacs.Core/Compilation/BytecodeCompiler.cs
+++ b/Wacs.Core/Compilation/BytecodeCompiler.cs
@@ -251,6 +251,10 @@ namespace Wacs.Core.Compilation
                 // pass-1 sizing and pass-2 emit stay in sync.
                 OpCode.FD => inst is Wacs.Core.Instructions.SIMD.InstMemoryLoadZero ? 12
                              : SizeOfSimd(inst.Op.xFD),
+                // FE-prefixed atomic ops (threads proposal) — every
+                // memarg-carrying op encodes [memIdx:u32][offset:u64]=12
+                // bytes; atomic.fence has no immediates.
+                OpCode.FE => SizeOfAtom(inst.Op.xFE),
                 // No-immediate ops (drop/select/return/unreachable/nop/numeric).
                 _ => 0,
             };
@@ -349,6 +353,19 @@ namespace Wacs.Core.Compilation
             ExtCode.TableSize  => 4,   // tableIdx:u32
             ExtCode.TableFill  => 4,   // tableIdx:u32
             _ => 0,
+        };
+
+        /// <summary>
+        /// 0xFE-prefixed atomic ops (threads proposal). All memarg-carrying
+        /// ops pack <c>[memIdx:u32][offset:u64]</c> for 12 bytes; only
+        /// <c>atomic.fence</c> has no immediate beyond its secondary byte.
+        /// </summary>
+        private static int SizeOfAtom(AtomCode code) => code switch
+        {
+            AtomCode.AtomicFence => 0,
+            // Every other op in the enum is memarg-carrying (loads,
+            // stores, rmw, cmpxchg, wait/notify) — all 12 bytes.
+            _ => 12,
         };
 
         private static int EmitExt(byte[] buf, int writePos, ExtCode code, InstructionBase inst)
@@ -676,6 +693,22 @@ namespace Wacs.Core.Compilation
             return writePos;
         }
 
+        /// <summary>
+        /// Emits 0xFE-prefixed atomic ops (threads proposal). Every
+        /// op except <c>atomic.fence</c> carries a memarg that maps
+        /// exactly like non-atomic memory ops: <c>memIdx:u32</c> +
+        /// <c>offset:u64</c>. The align hint is validation-only and
+        /// omitted from the annotated stream (like non-atomic loads).
+        /// </summary>
+        private static int EmitAtom(byte[] buf, int writePos, AtomCode code, InstructionBase inst)
+        {
+            if (code == AtomCode.AtomicFence) return writePos;
+            var m = (Wacs.Core.Instructions.Atomic.InstAtomicMemoryOp)inst;
+            writePos = WriteU32(buf, writePos, (uint)m.MemIndex);
+            writePos = WriteS64(buf, writePos, m.MemOffset);
+            return writePos;
+        }
+
         private static int Emit(
             byte[] buf, int writePos,
             InstructionBase inst,
@@ -855,6 +888,11 @@ namespace Wacs.Core.Compilation
                 // ---- FD-prefixed: SIMD ops --------
                 case OpCode.FD:
                     writePos = EmitSimd(buf, writePos, op.xFD, inst);
+                    break;
+
+                // ---- FE-prefixed: atomic ops (threads proposal) --------
+                case OpCode.FE:
+                    writePos = EmitAtom(buf, writePos, op.xFE, inst);
                     break;
 
                 // ---- branches ----

--- a/Wacs.Core/Instructions/Atomic/AtomicHandlers.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicHandlers.cs
@@ -1,0 +1,580 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Wacs.Core.Compilation;
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    /// <summary>
+    /// [OpHandler] entry points for the 0xFE-prefixed atomic ops
+    /// (threads proposal) on the switch runtime. Mirror the
+    /// polymorphic implementations in <c>AtomicBase.cs</c> + the
+    /// concrete <c>InstI32AtomicXxx</c> families, executing through
+    /// the same <see cref="MemoryInstance"/> atomic helpers so the
+    /// two back-ends share correctness properties.
+    ///
+    /// Stream encoding per memarg-carrying op:
+    /// <c>[memIdx:u32][offset:u64]</c> (12 bytes). Align is
+    /// validation-only and omitted. <c>atomic.fence</c> carries no
+    /// immediate.
+    /// </summary>
+    internal static class AtomicHandlers
+    {
+        // ---- Shared helper --------------------------------------------
+
+        /// <summary>
+        /// Resolve the memory, compute the effective address, and
+        /// verify bounds + exact natural alignment. Traps on any
+        /// failure. Returns the <see cref="MemoryInstance"/> so the
+        /// caller can route through its atomic helpers.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static MemoryInstance ResolveAtomic(
+            ExecContext ctx, uint memIdx, uint addr, ulong offset,
+            int widthBytes, string op, out int ea)
+        {
+            var mem = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)memIdx]];
+            long eaLong = (long)addr + (long)offset;
+            if (eaLong < 0 || eaLong + widthBytes > mem.Data.Length)
+                throw new TrapException(
+                    $"{op}: out of bounds atomic access (ea={eaLong}, width={widthBytes}, size={mem.Data.Length})");
+            if ((eaLong & (widthBytes - 1)) != 0)
+                throw new TrapException(
+                    $"{op}: unaligned atomic access at ea={eaLong} (width={widthBytes})");
+            ea = (int)eaLong;
+            return mem;
+        }
+
+        // ---- Loads ----------------------------------------------------
+        // Stack: (addr) → result. Handler signature: return type is
+        // pushed; trailing plain params are popped in reverse order.
+
+        [OpHandler(AtomCode.I32AtomicLoad)]
+        private static uint I32AtomicLoad(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.load", out int ea);
+            return (uint)mem.AtomicLoadInt32(ea);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad)]
+        private static ulong I64AtomicLoad(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.load", out int ea);
+            return (ulong)mem.AtomicLoadInt64(ea);
+        }
+
+        [OpHandler(AtomCode.I32AtomicLoad8U)]
+        private static uint I32AtomicLoad8U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.load8_u", out int ea);
+            return System.Threading.Volatile.Read(ref mem.Data[ea]);
+        }
+
+        [OpHandler(AtomCode.I32AtomicLoad16U)]
+        private static uint I32AtomicLoad16U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.load16_u", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            return System.Threading.Volatile.Read(ref cell);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad8U)]
+        private static ulong I64AtomicLoad8U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.load8_u", out int ea);
+            return System.Threading.Volatile.Read(ref mem.Data[ea]);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad16U)]
+        private static ulong I64AtomicLoad16U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.load16_u", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            return System.Threading.Volatile.Read(ref cell);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad32U)]
+        private static ulong I64AtomicLoad32U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.load32_u", out int ea);
+            return (uint)mem.AtomicLoadInt32(ea);
+        }
+
+        // ---- Stores ---------------------------------------------------
+        // Stack: (addr, value) → ∅. Handler pops in reverse param order,
+        // so put `addr` before `value` in the parameter list.
+
+        [OpHandler(AtomCode.I32AtomicStore)]
+        private static void I32AtomicStore(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.store", out int ea);
+            mem.AtomicStoreInt32(ea, (int)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore)]
+        private static void I64AtomicStore(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.store", out int ea);
+            mem.AtomicStoreInt64(ea, (long)value);
+        }
+
+        [OpHandler(AtomCode.I32AtomicStore8)]
+        private static void I32AtomicStore8(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.store8", out int ea);
+            System.Threading.Volatile.Write(ref mem.Data[ea], (byte)value);
+        }
+
+        [OpHandler(AtomCode.I32AtomicStore16)]
+        private static void I32AtomicStore16(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.store16", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            System.Threading.Volatile.Write(ref cell, (ushort)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore8)]
+        private static void I64AtomicStore8(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.store8", out int ea);
+            System.Threading.Volatile.Write(ref mem.Data[ea], (byte)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore16)]
+        private static void I64AtomicStore16(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.store16", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            System.Threading.Volatile.Write(ref cell, (ushort)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore32)]
+        private static void I64AtomicStore32(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.store32", out int ea);
+            mem.AtomicStoreInt32(ea, (int)value);
+        }
+
+        // ---- RMW: add ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwAdd)]
+        private static uint I32AtomicRmwAdd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.add", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwAdd)]
+        private static ulong I64AtomicRmwAdd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.add", out int ea);
+            return (ulong)mem.AtomicAddInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8AddU)]
+        private static uint I32AtomicRmw8AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.add_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old + (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16AddU)]
+        private static uint I32AtomicRmw16AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.add_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old + (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8AddU)]
+        private static ulong I64AtomicRmw8AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.add_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old + a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16AddU)]
+        private static ulong I64AtomicRmw16AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.add_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old + a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32AddU)]
+        private static ulong I64AtomicRmw32AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.add_u", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: sub ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwSub)]
+        private static uint I32AtomicRmwSub(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.sub", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, -(int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwSub)]
+        private static ulong I64AtomicRmwSub(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.sub", out int ea);
+            return (ulong)mem.AtomicAddInt64(ea, -(long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8SubU)]
+        private static uint I32AtomicRmw8SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.sub_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old - (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16SubU)]
+        private static uint I32AtomicRmw16SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.sub_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old - (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8SubU)]
+        private static ulong I64AtomicRmw8SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.sub_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old - a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16SubU)]
+        private static ulong I64AtomicRmw16SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.sub_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old - a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32SubU)]
+        private static ulong I64AtomicRmw32SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.sub_u", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, -(int)arg);
+        }
+
+        // ---- RMW: and ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwAnd)]
+        private static uint I32AtomicRmwAnd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.and", out int ea);
+            return (uint)mem.AtomicAndInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwAnd)]
+        private static ulong I64AtomicRmwAnd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.and", out int ea);
+            return (ulong)mem.AtomicAndInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8AndU)]
+        private static uint I32AtomicRmw8AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.and_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old & (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16AndU)]
+        private static uint I32AtomicRmw16AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.and_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old & (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8AndU)]
+        private static ulong I64AtomicRmw8AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.and_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old & a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16AndU)]
+        private static ulong I64AtomicRmw16AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.and_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old & a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32AndU)]
+        private static ulong I64AtomicRmw32AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.and_u", out int ea);
+            return (uint)mem.AtomicAndInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: or -------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwOr)]
+        private static uint I32AtomicRmwOr(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.or", out int ea);
+            return (uint)mem.AtomicOrInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwOr)]
+        private static ulong I64AtomicRmwOr(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.or", out int ea);
+            return (ulong)mem.AtomicOrInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8OrU)]
+        private static uint I32AtomicRmw8OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.or_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old | (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16OrU)]
+        private static uint I32AtomicRmw16OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.or_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old | (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8OrU)]
+        private static ulong I64AtomicRmw8OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.or_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old | a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16OrU)]
+        private static ulong I64AtomicRmw16OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.or_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old | a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32OrU)]
+        private static ulong I64AtomicRmw32OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.or_u", out int ea);
+            return (uint)mem.AtomicOrInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: xor ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwXor)]
+        private static uint I32AtomicRmwXor(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.xor", out int ea);
+            return (uint)mem.AtomicXorInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwXor)]
+        private static ulong I64AtomicRmwXor(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.xor", out int ea);
+            return (ulong)mem.AtomicXorInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8XorU)]
+        private static uint I32AtomicRmw8XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.xor_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old ^ (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16XorU)]
+        private static uint I32AtomicRmw16XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.xor_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old ^ (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8XorU)]
+        private static ulong I64AtomicRmw8XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.xor_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old ^ a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16XorU)]
+        private static ulong I64AtomicRmw16XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.xor_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old ^ a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32XorU)]
+        private static ulong I64AtomicRmw32XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.xor_u", out int ea);
+            return (uint)mem.AtomicXorInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: xchg -----------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwXchg)]
+        private static uint I32AtomicRmwXchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.xchg", out int ea);
+            return (uint)mem.AtomicExchangeInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwXchg)]
+        private static ulong I64AtomicRmwXchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.xchg", out int ea);
+            return (ulong)mem.AtomicExchangeInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8XchgU)]
+        private static uint I32AtomicRmw8XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, _ => a);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16XchgU)]
+        private static uint I32AtomicRmw16XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, _ => a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8XchgU)]
+        private static ulong I64AtomicRmw8XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, _ => a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16XchgU)]
+        private static ulong I64AtomicRmw16XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, _ => a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32XchgU)]
+        private static ulong I64AtomicRmw32XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.xchg_u", out int ea);
+            return (uint)mem.AtomicExchangeInt32(ea, (int)arg);
+        }
+
+        // ---- Cmpxchg -------------------------------------------------
+        // Stack: (addr, expected, replacement) → original.
+
+        [OpHandler(AtomCode.I32AtomicRmwCmpxchg)]
+        private static uint I32AtomicRmwCmpxchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, uint replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.cmpxchg", out int ea);
+            return (uint)mem.AtomicCompareExchangeInt32(ea, (int)replacement, (int)expected);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwCmpxchg)]
+        private static ulong I64AtomicRmwCmpxchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.cmpxchg", out int ea);
+            return (ulong)mem.AtomicCompareExchangeInt64(ea, (long)replacement, (long)expected);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8CmpxchgU)]
+        private static uint I32AtomicRmw8CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, uint replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 1, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16CmpxchgU)]
+        private static uint I32AtomicRmw16CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, uint replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 2, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8CmpxchgU)]
+        private static ulong I64AtomicRmw8CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 1, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16CmpxchgU)]
+        private static ulong I64AtomicRmw16CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 2, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32CmpxchgU)]
+        private static ulong I64AtomicRmw32CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.cmpxchg_u", out int ea);
+            return (uint)mem.AtomicCompareExchangeInt32(ea, (int)replacement, (int)expected);
+        }
+
+        // ---- Wait / notify -------------------------------------------
+
+        [OpHandler(AtomCode.MemoryAtomicNotify)]
+        private static uint MemoryAtomicNotify(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint count)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "memory.atomic.notify", out int ea);
+            return (uint)ctx.ConcurrencyPolicy.Notify(mem, ea, (int)count);
+        }
+
+        [OpHandler(AtomCode.MemoryAtomicWait32)]
+        private static uint MemoryAtomicWait32(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, long timeoutNs)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "memory.atomic.wait32", out int ea);
+            return (uint)ctx.ConcurrencyPolicy.Wait32(mem, ea, (int)expected, timeoutNs);
+        }
+
+        [OpHandler(AtomCode.MemoryAtomicWait64)]
+        private static uint MemoryAtomicWait64(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, long timeoutNs)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "memory.atomic.wait64", out int ea);
+            return (uint)ctx.ConcurrencyPolicy.Wait64(mem, ea, (long)expected, timeoutNs);
+        }
+
+        // ---- Fence ---------------------------------------------------
+
+        [OpHandler(AtomCode.AtomicFence)]
+        private static void AtomicFence(ExecContext ctx) => System.Threading.Interlocked.MemoryBarrier();
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [WebAssembly threads proposal](https://github.com/webassembly/threads) — extends the source-generated **switch runtime** (`GeneratedDispatcher`) to handle all 47 atomic ops, matching the phase-1 polymorphic semantics.

**Stacked on:** #79 (threads-phase1). Review that first; this PR's base should be retargeted to `main` once phase 1 merges.

**Before:** `DispatchFE` threw `NotSupportedException` for every AtomCode subop. Modules using atomics ran fine under the default polymorphic interpreter but crashed under `runtime.UseSwitchRuntime = true` or `Wacs.Console --switch`.

**After:** Full dispatch parity — identical input produces identical output across both back-ends.

## Wiring

### `BytecodeCompiler`
- `SizeOfAtom(AtomCode)`: 12 bytes for every memarg-carrying op (`[memIdx:u32][offset:u64]`, matching non-atomic memory ops — align is validation-only and not carried in the stream); 0 bytes for `atomic.fence`.
- `EmitAtom(buf, pos, code, inst)`: casts to `InstAtomicMemoryOp` and writes `MemIndex` + `MemOffset`. Fence writes nothing.
- `OpCode.FE` case added to the main `SizeOf` and `Emit` switches.

### `AtomicHandlers.cs` (new, ~470 LOC)
47 static methods tagged `[OpHandler(AtomCode.X)]`. The source generator (`DispatchGenerator`) auto-discovers them and inlines the bodies into `DispatchFE`. Verified: **67 AtomCode references** in the regenerated `GeneratedDispatcher.g.cs` vs. 0 before.

Shared `ResolveAtomic(ctx, memIdx, addr, offset, width, op, out ea)` helper performs bounds + exact-alignment checks (traps on either), mirroring `InstAtomicMemoryOp.CheckEa` from phase 1.

All handlers delegate into phase-1 infrastructure:
- `MemoryInstance.AtomicLoad/Store/Add/Exchange/And/Or/Xor/CompareExchange{Int32,Int64}` for full-width ops.
- `SubwordCas.Loop` / `SubwordCas.Cmpxchg` for 8/16-bit RMW and cmpxchg.
- `ExecContext.ConcurrencyPolicy.Wait32/Wait64/Notify` for wait/notify.
- `Interlocked.MemoryBarrier()` for fence.

**Zero duplication of atomic primitives between the two back-ends** — the switch path is pure dispatch glue.

### Signature convention (handler-parameter classification)
Mirrors `MemoryHandlers`:
```csharp
[OpHandler(AtomCode.I32AtomicLoad)]
private static uint I32AtomicLoad(ExecContext ctx,
    [Imm] uint memIdx, [Imm] ulong offset,    // pre-decoded from stream
    uint addr)                                 // popped from stack
{
    var mem = AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.load", out int ea);
    return (uint)mem.AtomicLoadInt32(ea);       // return value pushed
}
```

## Tests (338/338 passing)

- `AtomicInstructionTests` gains 7 switch-runtime parity tests: full-width load/store, subword load/store, RMW add (including subword CAS loop), cmpxchg match + mismatch, fence, wait/notify under `NotSupportedPolicy`. **28 atomic tests total** (21 polymorphic + 7 switch).
- `Wacs.Core.Test` full regression: 338/338 (up from 331 in phase 1).
- Smoke tested via `Wacs.Console --switch` across all five atomic families — identical results to the polymorphic path.
  - load_store → `0xDEADBEEF`
  - rmw_add(10,5) → 15
  - cmpxchg → 100 (original), cell updated to 200
  - subword_rmw → 128 (0x7F + 1)
  - fence → 42

## Scope boundaries (unchanged from phase 1)

- **Phase 3 (AOT transpiler) still out of scope.** Transpiled modules continue to fall back to the interpreter for atomic-containing functions via the existing mixed-mode path.
- **Concurrent wasm execution in a single `WasmRuntime` remains deferred** — still requires per-thread `ExecContext` restructuring. The policy layer works cross-thread (`HostDefinedPolicy` tests still pass); the runtime itself is the constraint.

## Build / AOT

- Build clean; no new IL trim / AOT warnings in `Wacs.Core` from phase-2 code.
- Pre-existing `Wacs.Compilation.Test.EndToEndTests.CallIndirect_dispatches_via_funcref_table` failures (2 cases) confirmed to reproduce on `HEAD` without phase-2 changes — not a regression from this PR. Tracking as a separate issue.

## Test plan

- [x] `dotnet test Wacs.Core.Test` — 338/338 pass.
- [x] `dotnet run --project Wacs.Console -c Release -- --switch …` on sample `.wat` with atomics.
- [x] Generated dispatcher inspected: 67 AtomCode references, all 47 op codes have inline cases.
- [ ] CI green on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)