### PR TITLE
Release: WACS 0.8.3 + WACS.Transpiler(.Lib) 0.2.1 (threads proposal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,74 @@
 # Changelog
 
+## [0.8.3] + WACS.Transpiler / Transpiler.Lib [0.2.1] — Threads proposal
+
+Implements the [WebAssembly threads proposal](https://github.com/webassembly/threads)
+across all three execution back-ends. Flips README feature table
+**Threads / threads ❌ → ✅**. All 47 atomic instructions — load/store
+(full-width + subword zero-extending), RMW (add/sub/and/or/xor/xchg in
+i32/i64/subword), cmpxchg, wait/notify, and fence — share the same
+phase-1 primitives so correctness is identical across back-ends.
+
+- **Polymorphic interpreter** (phase 1 / #79):
+  - New `Wacs.Core.Runtime.Concurrency` namespace:
+    `ConcurrencyPolicyMode` (NotSupported / HostDefined),
+    `IConcurrencyPolicy`, `NotSupportedPolicy` (single-thread semantics
+    — matching-value finite-timeout sleeps then returns 1, infinite
+    timeout traps, mismatch returns 2), `HostDefinedPolicy` (real
+    wait/notify via `ConcurrentDictionary<(MemoryInstance, addr),
+    WaitSlot>` + per-waiter `ManualResetEventSlim`).
+  - `MemoryInstance` atomic helpers:
+    `AtomicLoad/Store/Add/Exchange/And/Or/Xor/CompareExchange{Int32,
+    Int64}`. `Interlocked.*` on net8.0+; `CompareExchange` loop
+    fallback on netstandard2.1 for And/Or/Xor.
+    Lazy `ReaderWriterLockSlim _growLock` only allocated when shared
+    + HostDefined — single-threaded modules pay nothing.
+  - 47 instruction classes under `Wacs.Core.Instructions.Atomic/`:
+    `InstAtomicMemoryOp` base with exact-alignment + shared-memory
+    validation, subword CAS via `SubwordCas.Loop` / `SubwordCas.Cmpxchg`.
+  - Factory (`SpecFactoryFE.cs`) + WAT parser extended with
+    `TryGetAtomicMemoryOpcode` dispatch.
+  - `RuntimeAttributes.ConcurrencyPolicy` with IL2CPP-detecting default
+    (`Type.GetType("UnityEngine.Application,…")`, AOT-safe).
+    `RelaxAtomicSharedCheck` escape hatch for toolchains that emit
+    atomics on non-shared memories.
+- **Switch runtime** (phase 2 / #80):
+  - `BytecodeCompiler.SizeOfAtom` + `EmitAtom` — 12-byte memarg
+    (`[memIdx:u32][offset:u64]`) stream encoding, 0 bytes for
+    `atomic.fence`.
+  - `AtomicHandlers.cs` with 47 `[OpHandler(AtomCode.X)]` methods.
+    The source generator (`DispatchGenerator`) auto-discovers them and
+    inlines the bodies into `DispatchFE` — **67 AtomCode references**
+    in the regenerated `GeneratedDispatcher.g.cs` vs. 0 before.
+- **AOT transpiler** (phase 3 / #81):
+  - New `Wacs.Transpiler.Lib/AOT/Emitters/AtomicEmitter.cs` + public
+    `AtomicHelpers` class. Functions containing atomics transpile to
+    native CIL instead of falling back to the interpreter;
+    `FallbackCount` is 0 for mixed-family modules.
+  - Wait/notify routes through `ThinContext.ExecContext?.Concurrency-
+    Policy ?? _standaloneFallback` — standalone / saved-dll consumers
+    get `NotSupportedPolicy` semantics by default.
+- **Tests (new):**
+  - `Wacs.Core.Test.AtomicInstructionTests` — 28 tests (21 polymorphic
+    + 7 switch-runtime parity).
+  - `Wacs.Core.Test.SpecWastThreadsTests` — 4 tests over a pinned
+    snapshot of `WebAssembly/threads@f521d7b3` at
+    `Spec.Test/Data/threads/atomic.wast`.
+  - `Wacs.Transpiler.Test.AtomicEquivalenceTests` — 12 polymorphic ↔
+    transpiled equivalence tests.
+  - `Wacs.Core.Test` total: 338/338. `Wacs.Transpiler.Test` total:
+    561/561.
+- **AOT stays green.** No runtime `Reflection.Emit` introduced;
+  IL2CPP-safe by construction in `Wacs.Core`. Transpiler runtime
+  assembly unchanged w.r.t. AOT safety (still uses `Reflection.Emit`
+  as before — the produced DLL is AOT-loadable).
+
+Concurrent wasm execution in a single `WasmRuntime` and host
+thread-spawn imports remain out-of-scope for this release — the
+threads proposal itself doesn't standardize spawning, and WACS's
+single-`ExecContext` model is a separate refactor tracked for a
+future release.
+
 ## [0.8.2] First-class WAT / WAST text format
 
 - **Pure-C# WAT reader + writer.** New `Wacs.Core.Text` namespace

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Overview
 
 **Latest releases** (see the [CHANGELOG](CHANGELOG.md) for details):
-WACS `0.8.2` · WACS.WASIp1 `0.9.7` · WACS.Transpiler `0.2.0` · WACS.Transpiler.Lib `0.2.0`
+WACS `0.8.3` · WACS.WASIp1 `0.9.7` · WACS.Transpiler `0.2.1` · WACS.Transpiler.Lib `0.2.1`
 
 **WACS** is a pure C# WebAssembly Interpreter for running WASM modules in .NET environments, including Godot and AOT environments like Unity's IL2CPP.
 

--- a/Wacs.Core.Test/AtomicInstructionTests.cs
+++ b/Wacs.Core.Test/AtomicInstructionTests.cs
@@ -23,12 +23,14 @@ namespace Wacs.Core.Test
     public class AtomicInstructionTests
     {
         private static (WasmRuntime runtime, ModuleInstance inst) Build(string src,
-            IConcurrencyPolicy? policy = null, bool relaxSharedCheck = false)
+            IConcurrencyPolicy? policy = null, bool relaxSharedCheck = false,
+            bool useSwitchRuntime = false)
         {
             var attrs = new RuntimeAttributes();
             if (policy != null) attrs.ConcurrencyPolicy = policy;
             attrs.RelaxAtomicSharedCheck = relaxSharedCheck;
             var runtime = new WasmRuntime(attrs);
+            runtime.UseSwitchRuntime = useSwitchRuntime;
             var module = TextModuleParser.ParseWat(src);
             var inst = runtime.InstantiateModule(module);
             runtime.RegisterModule("M", inst);
@@ -392,6 +394,131 @@ namespace Wacs.Core.Test
             // Running the test suite outside Unity → HostDefined default.
             var attrs = new RuntimeAttributes();
             Assert.Equal(ConcurrencyPolicyMode.HostDefined, attrs.ConcurrencyPolicy.Mode);
+        }
+
+        // ---- Switch-runtime parity (phase 2) ----------------------------
+        // Each polymorphic test has a switch-runtime twin. Identical input
+        // must produce identical output regardless of which back-end
+        // dispatches the atomic instruction.
+
+        [Fact]
+        public void Switch_i32_load_store_round_trip()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 0x12345678
+                    i32.atomic.store align=4
+                    i32.const 0
+                    i32.atomic.load align=4))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(0x12345678, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_i64_load_store_round_trip()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i64)
+                    i32.const 8
+                    i64.const 0x0123456789ABCDEF
+                    i64.atomic.store align=8
+                    i32.const 8
+                    i64.atomic.load align=8))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(0x0123456789ABCDEFL, InvokeI64(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_subword_load_store()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 7
+                    i32.const 0xA5
+                    i32.atomic.store8 align=1
+                    i32.const 7
+                    i32.atomic.load8_u align=1))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(0xA5, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_rmw_add_and_subword_cas()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""rmw32"") (result i32)
+                    i32.const 0 i32.const 10 i32.atomic.store align=4
+                    i32.const 0 i32.const 5 i32.atomic.rmw.add align=4)
+                  (func (export ""rmw8"") (result i32)
+                    i32.const 3 i32.const 100 i32.atomic.store8 align=1
+                    i32.const 3 i32.const 56 i32.atomic.rmw8.add_u align=1)
+                  (func (export ""load32"") (result i32)
+                    i32.const 0 i32.atomic.load align=4))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(10, InvokeI32(rt, "rmw32"));     // original
+            Assert.Equal(15, InvokeI32(rt, "load32"));    // cell updated via switch path
+            Assert.Equal(100, InvokeI32(rt, "rmw8"));     // subword CAS loop
+        }
+
+        [Fact]
+        public void Switch_cmpxchg_success_and_mismatch()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""match"") (result i32)
+                    i32.const 0 i32.const 50 i32.atomic.store align=4
+                    i32.const 0 i32.const 50 i32.const 99 i32.atomic.rmw.cmpxchg align=4)
+                  (func (export ""miss"") (result i32)
+                    i32.const 4 i32.const 50 i32.atomic.store align=4
+                    i32.const 4 i32.const 999 i32.const 99 i32.atomic.rmw.cmpxchg align=4)
+                  (func (export ""load"") (param i32) (result i32)
+                    local.get 0 i32.atomic.load align=4))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(50, InvokeI32(rt, "match"));
+            Assert.Equal(99, InvokeI32(rt, "load", 0));
+            Assert.Equal(50, InvokeI32(rt, "miss"));
+            Assert.Equal(50, InvokeI32(rt, "load", 4));   // unchanged on miss
+        }
+
+        [Fact]
+        public void Switch_fence_executes()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    atomic.fence
+                    i32.const 42))";
+            var (rt, _) = Build(src, useSwitchRuntime: true);
+            Assert.Equal(42, InvokeI32(rt, "f"));
+        }
+
+        [Fact]
+        public void Switch_wait_and_notify_policy_semantics()
+        {
+            // NotSupported policy, mismatched expected → 2.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""wait_ne"") (result i32)
+                    i32.const 0 i32.const 99 i64.const 0
+                    memory.atomic.wait32 align=4)
+                  (func (export ""notify_empty"") (result i32)
+                    i32.const 0 i32.const 10
+                    memory.atomic.notify align=4))";
+            var (rt, _) = Build(src, policy: new NotSupportedPolicy(), useSwitchRuntime: true);
+            Assert.Equal(2, InvokeI32(rt, "wait_ne"));
+            Assert.Equal(0, InvokeI32(rt, "notify_empty"));
         }
     }
 }

--- a/Wacs.Core/Compilation/BytecodeCompiler.cs
+++ b/Wacs.Core/Compilation/BytecodeCompiler.cs
@@ -251,6 +251,10 @@ namespace Wacs.Core.Compilation
                 // pass-1 sizing and pass-2 emit stay in sync.
                 OpCode.FD => inst is Wacs.Core.Instructions.SIMD.InstMemoryLoadZero ? 12
                              : SizeOfSimd(inst.Op.xFD),
+                // FE-prefixed atomic ops (threads proposal) — every
+                // memarg-carrying op encodes [memIdx:u32][offset:u64]=12
+                // bytes; atomic.fence has no immediates.
+                OpCode.FE => SizeOfAtom(inst.Op.xFE),
                 // No-immediate ops (drop/select/return/unreachable/nop/numeric).
                 _ => 0,
             };
@@ -349,6 +353,19 @@ namespace Wacs.Core.Compilation
             ExtCode.TableSize  => 4,   // tableIdx:u32
             ExtCode.TableFill  => 4,   // tableIdx:u32
             _ => 0,
+        };
+
+        /// <summary>
+        /// 0xFE-prefixed atomic ops (threads proposal). All memarg-carrying
+        /// ops pack <c>[memIdx:u32][offset:u64]</c> for 12 bytes; only
+        /// <c>atomic.fence</c> has no immediate beyond its secondary byte.
+        /// </summary>
+        private static int SizeOfAtom(AtomCode code) => code switch
+        {
+            AtomCode.AtomicFence => 0,
+            // Every other op in the enum is memarg-carrying (loads,
+            // stores, rmw, cmpxchg, wait/notify) — all 12 bytes.
+            _ => 12,
         };
 
         private static int EmitExt(byte[] buf, int writePos, ExtCode code, InstructionBase inst)
@@ -676,6 +693,22 @@ namespace Wacs.Core.Compilation
             return writePos;
         }
 
+        /// <summary>
+        /// Emits 0xFE-prefixed atomic ops (threads proposal). Every
+        /// op except <c>atomic.fence</c> carries a memarg that maps
+        /// exactly like non-atomic memory ops: <c>memIdx:u32</c> +
+        /// <c>offset:u64</c>. The align hint is validation-only and
+        /// omitted from the annotated stream (like non-atomic loads).
+        /// </summary>
+        private static int EmitAtom(byte[] buf, int writePos, AtomCode code, InstructionBase inst)
+        {
+            if (code == AtomCode.AtomicFence) return writePos;
+            var m = (Wacs.Core.Instructions.Atomic.InstAtomicMemoryOp)inst;
+            writePos = WriteU32(buf, writePos, (uint)m.MemIndex);
+            writePos = WriteS64(buf, writePos, m.MemOffset);
+            return writePos;
+        }
+
         private static int Emit(
             byte[] buf, int writePos,
             InstructionBase inst,
@@ -855,6 +888,11 @@ namespace Wacs.Core.Compilation
                 // ---- FD-prefixed: SIMD ops --------
                 case OpCode.FD:
                     writePos = EmitSimd(buf, writePos, op.xFD, inst);
+                    break;
+
+                // ---- FE-prefixed: atomic ops (threads proposal) --------
+                case OpCode.FE:
+                    writePos = EmitAtom(buf, writePos, op.xFE, inst);
                     break;
 
                 // ---- branches ----

--- a/Wacs.Core/Instructions/Atomic/AtomicHandlers.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicHandlers.cs
@@ -1,0 +1,580 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Wacs.Core.Compilation;
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
+
+namespace Wacs.Core.Instructions.Atomic
+{
+    /// <summary>
+    /// [OpHandler] entry points for the 0xFE-prefixed atomic ops
+    /// (threads proposal) on the switch runtime. Mirror the
+    /// polymorphic implementations in <c>AtomicBase.cs</c> + the
+    /// concrete <c>InstI32AtomicXxx</c> families, executing through
+    /// the same <see cref="MemoryInstance"/> atomic helpers so the
+    /// two back-ends share correctness properties.
+    ///
+    /// Stream encoding per memarg-carrying op:
+    /// <c>[memIdx:u32][offset:u64]</c> (12 bytes). Align is
+    /// validation-only and omitted. <c>atomic.fence</c> carries no
+    /// immediate.
+    /// </summary>
+    internal static class AtomicHandlers
+    {
+        // ---- Shared helper --------------------------------------------
+
+        /// <summary>
+        /// Resolve the memory, compute the effective address, and
+        /// verify bounds + exact natural alignment. Traps on any
+        /// failure. Returns the <see cref="MemoryInstance"/> so the
+        /// caller can route through its atomic helpers.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static MemoryInstance ResolveAtomic(
+            ExecContext ctx, uint memIdx, uint addr, ulong offset,
+            int widthBytes, string op, out int ea)
+        {
+            var mem = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)memIdx]];
+            long eaLong = (long)addr + (long)offset;
+            if (eaLong < 0 || eaLong + widthBytes > mem.Data.Length)
+                throw new TrapException(
+                    $"{op}: out of bounds atomic access (ea={eaLong}, width={widthBytes}, size={mem.Data.Length})");
+            if ((eaLong & (widthBytes - 1)) != 0)
+                throw new TrapException(
+                    $"{op}: unaligned atomic access at ea={eaLong} (width={widthBytes})");
+            ea = (int)eaLong;
+            return mem;
+        }
+
+        // ---- Loads ----------------------------------------------------
+        // Stack: (addr) → result. Handler signature: return type is
+        // pushed; trailing plain params are popped in reverse order.
+
+        [OpHandler(AtomCode.I32AtomicLoad)]
+        private static uint I32AtomicLoad(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.load", out int ea);
+            return (uint)mem.AtomicLoadInt32(ea);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad)]
+        private static ulong I64AtomicLoad(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.load", out int ea);
+            return (ulong)mem.AtomicLoadInt64(ea);
+        }
+
+        [OpHandler(AtomCode.I32AtomicLoad8U)]
+        private static uint I32AtomicLoad8U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.load8_u", out int ea);
+            return System.Threading.Volatile.Read(ref mem.Data[ea]);
+        }
+
+        [OpHandler(AtomCode.I32AtomicLoad16U)]
+        private static uint I32AtomicLoad16U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.load16_u", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            return System.Threading.Volatile.Read(ref cell);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad8U)]
+        private static ulong I64AtomicLoad8U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.load8_u", out int ea);
+            return System.Threading.Volatile.Read(ref mem.Data[ea]);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad16U)]
+        private static ulong I64AtomicLoad16U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.load16_u", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            return System.Threading.Volatile.Read(ref cell);
+        }
+
+        [OpHandler(AtomCode.I64AtomicLoad32U)]
+        private static ulong I64AtomicLoad32U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.load32_u", out int ea);
+            return (uint)mem.AtomicLoadInt32(ea);
+        }
+
+        // ---- Stores ---------------------------------------------------
+        // Stack: (addr, value) → ∅. Handler pops in reverse param order,
+        // so put `addr` before `value` in the parameter list.
+
+        [OpHandler(AtomCode.I32AtomicStore)]
+        private static void I32AtomicStore(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.store", out int ea);
+            mem.AtomicStoreInt32(ea, (int)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore)]
+        private static void I64AtomicStore(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.store", out int ea);
+            mem.AtomicStoreInt64(ea, (long)value);
+        }
+
+        [OpHandler(AtomCode.I32AtomicStore8)]
+        private static void I32AtomicStore8(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.store8", out int ea);
+            System.Threading.Volatile.Write(ref mem.Data[ea], (byte)value);
+        }
+
+        [OpHandler(AtomCode.I32AtomicStore16)]
+        private static void I32AtomicStore16(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.store16", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            System.Threading.Volatile.Write(ref cell, (ushort)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore8)]
+        private static void I64AtomicStore8(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.store8", out int ea);
+            System.Threading.Volatile.Write(ref mem.Data[ea], (byte)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore16)]
+        private static void I64AtomicStore16(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.store16", out int ea);
+            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            System.Threading.Volatile.Write(ref cell, (ushort)value);
+        }
+
+        [OpHandler(AtomCode.I64AtomicStore32)]
+        private static void I64AtomicStore32(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.store32", out int ea);
+            mem.AtomicStoreInt32(ea, (int)value);
+        }
+
+        // ---- RMW: add ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwAdd)]
+        private static uint I32AtomicRmwAdd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.add", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwAdd)]
+        private static ulong I64AtomicRmwAdd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.add", out int ea);
+            return (ulong)mem.AtomicAddInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8AddU)]
+        private static uint I32AtomicRmw8AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.add_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old + (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16AddU)]
+        private static uint I32AtomicRmw16AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.add_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old + (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8AddU)]
+        private static ulong I64AtomicRmw8AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.add_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old + a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16AddU)]
+        private static ulong I64AtomicRmw16AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.add_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old + a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32AddU)]
+        private static ulong I64AtomicRmw32AddU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.add_u", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: sub ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwSub)]
+        private static uint I32AtomicRmwSub(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.sub", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, -(int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwSub)]
+        private static ulong I64AtomicRmwSub(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.sub", out int ea);
+            return (ulong)mem.AtomicAddInt64(ea, -(long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8SubU)]
+        private static uint I32AtomicRmw8SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.sub_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old - (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16SubU)]
+        private static uint I32AtomicRmw16SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.sub_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old - (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8SubU)]
+        private static ulong I64AtomicRmw8SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.sub_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old - a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16SubU)]
+        private static ulong I64AtomicRmw16SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.sub_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old - a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32SubU)]
+        private static ulong I64AtomicRmw32SubU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.sub_u", out int ea);
+            return (uint)mem.AtomicAddInt32(ea, -(int)arg);
+        }
+
+        // ---- RMW: and ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwAnd)]
+        private static uint I32AtomicRmwAnd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.and", out int ea);
+            return (uint)mem.AtomicAndInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwAnd)]
+        private static ulong I64AtomicRmwAnd(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.and", out int ea);
+            return (ulong)mem.AtomicAndInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8AndU)]
+        private static uint I32AtomicRmw8AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.and_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old & (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16AndU)]
+        private static uint I32AtomicRmw16AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.and_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old & (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8AndU)]
+        private static ulong I64AtomicRmw8AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.and_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old & a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16AndU)]
+        private static ulong I64AtomicRmw16AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.and_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old & a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32AndU)]
+        private static ulong I64AtomicRmw32AndU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.and_u", out int ea);
+            return (uint)mem.AtomicAndInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: or -------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwOr)]
+        private static uint I32AtomicRmwOr(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.or", out int ea);
+            return (uint)mem.AtomicOrInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwOr)]
+        private static ulong I64AtomicRmwOr(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.or", out int ea);
+            return (ulong)mem.AtomicOrInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8OrU)]
+        private static uint I32AtomicRmw8OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.or_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old | (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16OrU)]
+        private static uint I32AtomicRmw16OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.or_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old | (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8OrU)]
+        private static ulong I64AtomicRmw8OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.or_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old | a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16OrU)]
+        private static ulong I64AtomicRmw16OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.or_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old | a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32OrU)]
+        private static ulong I64AtomicRmw32OrU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.or_u", out int ea);
+            return (uint)mem.AtomicOrInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: xor ------------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwXor)]
+        private static uint I32AtomicRmwXor(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.xor", out int ea);
+            return (uint)mem.AtomicXorInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwXor)]
+        private static ulong I64AtomicRmwXor(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.xor", out int ea);
+            return (ulong)mem.AtomicXorInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8XorU)]
+        private static uint I32AtomicRmw8XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.xor_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old ^ (int)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16XorU)]
+        private static uint I32AtomicRmw16XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.xor_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old ^ (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8XorU)]
+        private static ulong I64AtomicRmw8XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.xor_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, old => old ^ a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16XorU)]
+        private static ulong I64AtomicRmw16XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.xor_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, old => old ^ a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32XorU)]
+        private static ulong I64AtomicRmw32XorU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.xor_u", out int ea);
+            return (uint)mem.AtomicXorInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: xchg -----------------------------------------------
+
+        [OpHandler(AtomCode.I32AtomicRmwXchg)]
+        private static uint I32AtomicRmwXchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.xchg", out int ea);
+            return (uint)mem.AtomicExchangeInt32(ea, (int)arg);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwXchg)]
+        private static ulong I64AtomicRmwXchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.xchg", out int ea);
+            return (ulong)mem.AtomicExchangeInt64(ea, (long)arg);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8XchgU)]
+        private static uint I32AtomicRmw8XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, _ => a);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16XchgU)]
+        private static uint I32AtomicRmw16XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, _ => a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8XchgU)]
+        private static ulong I64AtomicRmw8XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 1, _ => a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16XchgU)]
+        private static ulong I64AtomicRmw16XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.xchg_u", out int ea);
+            int a = (int)arg;
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Loop(mem, ea, 2, _ => a);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32XchgU)]
+        private static ulong I64AtomicRmw32XchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong arg)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.xchg_u", out int ea);
+            return (uint)mem.AtomicExchangeInt32(ea, (int)arg);
+        }
+
+        // ---- Cmpxchg -------------------------------------------------
+        // Stack: (addr, expected, replacement) → original.
+
+        [OpHandler(AtomCode.I32AtomicRmwCmpxchg)]
+        private static uint I32AtomicRmwCmpxchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, uint replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i32.atomic.rmw.cmpxchg", out int ea);
+            return (uint)mem.AtomicCompareExchangeInt32(ea, (int)replacement, (int)expected);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmwCmpxchg)]
+        private static ulong I64AtomicRmwCmpxchg(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "i64.atomic.rmw.cmpxchg", out int ea);
+            return (ulong)mem.AtomicCompareExchangeInt64(ea, (long)replacement, (long)expected);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw8CmpxchgU)]
+        private static uint I32AtomicRmw8CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, uint replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.rmw8.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 1, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I32AtomicRmw16CmpxchgU)]
+        private static uint I32AtomicRmw16CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, uint replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.rmw16.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 2, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw8CmpxchgU)]
+        private static ulong I64AtomicRmw8CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.rmw8.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 1, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw16CmpxchgU)]
+        private static ulong I64AtomicRmw16CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.rmw16.cmpxchg_u", out int ea);
+            return (uint)Wacs.Core.Instructions.Atomic.SubwordCas.Cmpxchg(mem, ea, 2, (int)expected, (int)replacement);
+        }
+
+        [OpHandler(AtomCode.I64AtomicRmw32CmpxchgU)]
+        private static ulong I64AtomicRmw32CmpxchgU(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, ulong replacement)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "i64.atomic.rmw32.cmpxchg_u", out int ea);
+            return (uint)mem.AtomicCompareExchangeInt32(ea, (int)replacement, (int)expected);
+        }
+
+        // ---- Wait / notify -------------------------------------------
+
+        [OpHandler(AtomCode.MemoryAtomicNotify)]
+        private static uint MemoryAtomicNotify(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint count)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "memory.atomic.notify", out int ea);
+            return (uint)ctx.ConcurrencyPolicy.Notify(mem, ea, (int)count);
+        }
+
+        [OpHandler(AtomCode.MemoryAtomicWait32)]
+        private static uint MemoryAtomicWait32(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, uint expected, long timeoutNs)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 4, "memory.atomic.wait32", out int ea);
+            return (uint)ctx.ConcurrencyPolicy.Wait32(mem, ea, (int)expected, timeoutNs);
+        }
+
+        [OpHandler(AtomCode.MemoryAtomicWait64)]
+        private static uint MemoryAtomicWait64(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset,
+            uint addr, ulong expected, long timeoutNs)
+        {
+            var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 8, "memory.atomic.wait64", out int ea);
+            return (uint)ctx.ConcurrencyPolicy.Wait64(mem, ea, (long)expected, timeoutNs);
+        }
+
+        // ---- Fence ---------------------------------------------------
+
+        [OpHandler(AtomCode.AtomicFence)]
+        private static void AtomicFence(ExecContext ctx) => System.Threading.Interlocked.MemoryBarrier();
+    }
+}

--- a/Wacs.Core/Instructions/Atomic/AtomicRmw.cs
+++ b/Wacs.Core/Instructions/Atomic/AtomicRmw.cs
@@ -27,7 +27,7 @@ namespace Wacs.Core.Instructions.Atomic
     // Naming: class names follow the AtomCode enum 1:1. File grouped
     // by op family (add/sub/and/or/xor/xchg).
 
-    internal static class SubwordCas
+    public static class SubwordCas
     {
         /// <summary>
         /// CAS loop on a sub-word within the enclosing 32-bit word.

--- a/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.8.2</AssemblyVersion>
-    <Version>0.8.2</Version>
+    <AssemblyVersion>0.8.3</AssemblyVersion>
+    <Version>0.8.3</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/Wacs.Transpiler.Lib/AOT/Emitters/AtomicEmitter.cs
+++ b/Wacs.Transpiler.Lib/AOT/Emitters/AtomicEmitter.cs
@@ -1,0 +1,699 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Wacs.Core.Instructions;
+using Wacs.Core.Instructions.Atomic;
+using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Concurrency;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.Types;
+using AtomOp = Wacs.Core.OpCodes.AtomCode;
+
+namespace Wacs.Transpiler.AOT.Emitters
+{
+    /// <summary>
+    /// Emits CIL for WebAssembly threads-proposal atomic ops (0xFE prefix).
+    ///
+    /// All emit sites defer to <see cref="AtomicHelpers"/> for correctness, so the
+    /// transpiled code shares semantics with the polymorphic interpreter and the
+    /// switch runtime: bounds + exact-alignment checks trap identically, and
+    /// RMW / cmpxchg / wait / notify go through the same
+    /// <see cref="MemoryInstance"/> atomic helpers + <see cref="IConcurrencyPolicy"/>
+    /// machinery phase 1 established.
+    ///
+    /// Stream shape per op (same as non-atomic loads/stores):
+    /// &lt;memIdx:i32 literal&gt; &lt;offset:i64 literal&gt; — the align hint is
+    /// validation-only.
+    /// </summary>
+    internal static class AtomicEmitter
+    {
+        private static readonly FieldInfo MemoriesField =
+            typeof(ThinContext).GetField(nameof(ThinContext.Memories))!;
+        private static readonly FieldInfo ExecContextField =
+            typeof(ThinContext).GetField(nameof(ThinContext.ExecContext))!;
+
+        /// <summary>
+        /// All 47 AtomCode sub-ops are emittable. Nothing opts-out, so a
+        /// function that used to fall back to the polymorphic interpreter
+        /// solely because of an atomic now transpiles to native IL.
+        /// </summary>
+        public static bool CanEmit(AtomOp op) => true;
+
+        public static void Emit(ILGenerator il, InstructionBase inst, AtomOp op)
+        {
+            switch (op)
+            {
+                // ---- Loads ----
+                case AtomOp.I32AtomicLoad:     EmitLoad(il, inst, nameof(AtomicHelpers.LoadI32));   break;
+                case AtomOp.I64AtomicLoad:     EmitLoad(il, inst, nameof(AtomicHelpers.LoadI64));   break;
+                case AtomOp.I32AtomicLoad8U:   EmitLoad(il, inst, nameof(AtomicHelpers.LoadI32_8U));break;
+                case AtomOp.I32AtomicLoad16U:  EmitLoad(il, inst, nameof(AtomicHelpers.LoadI32_16U));break;
+                case AtomOp.I64AtomicLoad8U:   EmitLoad(il, inst, nameof(AtomicHelpers.LoadI64_8U));break;
+                case AtomOp.I64AtomicLoad16U:  EmitLoad(il, inst, nameof(AtomicHelpers.LoadI64_16U));break;
+                case AtomOp.I64AtomicLoad32U:  EmitLoad(il, inst, nameof(AtomicHelpers.LoadI64_32U));break;
+
+                // ---- Stores ----
+                case AtomOp.I32AtomicStore:    EmitStore(il, inst, nameof(AtomicHelpers.StoreI32));  break;
+                case AtomOp.I64AtomicStore:    EmitStore(il, inst, nameof(AtomicHelpers.StoreI64));  break;
+                case AtomOp.I32AtomicStore8:   EmitStore(il, inst, nameof(AtomicHelpers.StoreI32_8));break;
+                case AtomOp.I32AtomicStore16:  EmitStore(il, inst, nameof(AtomicHelpers.StoreI32_16));break;
+                case AtomOp.I64AtomicStore8:   EmitStore(il, inst, nameof(AtomicHelpers.StoreI64_8));break;
+                case AtomOp.I64AtomicStore16:  EmitStore(il, inst, nameof(AtomicHelpers.StoreI64_16));break;
+                case AtomOp.I64AtomicStore32:  EmitStore(il, inst, nameof(AtomicHelpers.StoreI64_32));break;
+
+                // ---- RMW ----
+                case AtomOp.I32AtomicRmwAdd:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_Add));    break;
+                case AtomOp.I64AtomicRmwAdd:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_Add));    break;
+                case AtomOp.I32AtomicRmw8AddU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_8_AddU));  break;
+                case AtomOp.I32AtomicRmw16AddU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_16_AddU)); break;
+                case AtomOp.I64AtomicRmw8AddU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_8_AddU));  break;
+                case AtomOp.I64AtomicRmw16AddU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_16_AddU)); break;
+                case AtomOp.I64AtomicRmw32AddU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_32_AddU)); break;
+
+                case AtomOp.I32AtomicRmwSub:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_Sub));    break;
+                case AtomOp.I64AtomicRmwSub:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_Sub));    break;
+                case AtomOp.I32AtomicRmw8SubU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_8_SubU));  break;
+                case AtomOp.I32AtomicRmw16SubU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_16_SubU)); break;
+                case AtomOp.I64AtomicRmw8SubU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_8_SubU));  break;
+                case AtomOp.I64AtomicRmw16SubU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_16_SubU)); break;
+                case AtomOp.I64AtomicRmw32SubU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_32_SubU)); break;
+
+                case AtomOp.I32AtomicRmwAnd:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_And));    break;
+                case AtomOp.I64AtomicRmwAnd:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_And));    break;
+                case AtomOp.I32AtomicRmw8AndU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_8_AndU));  break;
+                case AtomOp.I32AtomicRmw16AndU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_16_AndU)); break;
+                case AtomOp.I64AtomicRmw8AndU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_8_AndU));  break;
+                case AtomOp.I64AtomicRmw16AndU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_16_AndU)); break;
+                case AtomOp.I64AtomicRmw32AndU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_32_AndU)); break;
+
+                case AtomOp.I32AtomicRmwOr:        EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_Or));     break;
+                case AtomOp.I64AtomicRmwOr:        EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_Or));     break;
+                case AtomOp.I32AtomicRmw8OrU:      EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_8_OrU));   break;
+                case AtomOp.I32AtomicRmw16OrU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_16_OrU));  break;
+                case AtomOp.I64AtomicRmw8OrU:      EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_8_OrU));   break;
+                case AtomOp.I64AtomicRmw16OrU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_16_OrU));  break;
+                case AtomOp.I64AtomicRmw32OrU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_32_OrU));  break;
+
+                case AtomOp.I32AtomicRmwXor:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_Xor));    break;
+                case AtomOp.I64AtomicRmwXor:       EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_Xor));    break;
+                case AtomOp.I32AtomicRmw8XorU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_8_XorU));  break;
+                case AtomOp.I32AtomicRmw16XorU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_16_XorU)); break;
+                case AtomOp.I64AtomicRmw8XorU:     EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_8_XorU));  break;
+                case AtomOp.I64AtomicRmw16XorU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_16_XorU)); break;
+                case AtomOp.I64AtomicRmw32XorU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_32_XorU)); break;
+
+                case AtomOp.I32AtomicRmwXchg:      EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_Xchg));   break;
+                case AtomOp.I64AtomicRmwXchg:      EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_Xchg));   break;
+                case AtomOp.I32AtomicRmw8XchgU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_8_XchgU)); break;
+                case AtomOp.I32AtomicRmw16XchgU:   EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I32_16_XchgU));break;
+                case AtomOp.I64AtomicRmw8XchgU:    EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_8_XchgU)); break;
+                case AtomOp.I64AtomicRmw16XchgU:   EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_16_XchgU));break;
+                case AtomOp.I64AtomicRmw32XchgU:   EmitRmw(il, inst, nameof(AtomicHelpers.Rmw_I64_32_XchgU));break;
+
+                // ---- Cmpxchg ----
+                case AtomOp.I32AtomicRmwCmpxchg:      EmitCmpxchg(il, inst, nameof(AtomicHelpers.Cmpxchg_I32));     break;
+                case AtomOp.I64AtomicRmwCmpxchg:      EmitCmpxchg(il, inst, nameof(AtomicHelpers.Cmpxchg_I64));     break;
+                case AtomOp.I32AtomicRmw8CmpxchgU:    EmitCmpxchg(il, inst, nameof(AtomicHelpers.Cmpxchg_I32_8U));   break;
+                case AtomOp.I32AtomicRmw16CmpxchgU:   EmitCmpxchg(il, inst, nameof(AtomicHelpers.Cmpxchg_I32_16U));  break;
+                case AtomOp.I64AtomicRmw8CmpxchgU:    EmitCmpxchg(il, inst, nameof(AtomicHelpers.Cmpxchg_I64_8U));   break;
+                case AtomOp.I64AtomicRmw16CmpxchgU:   EmitCmpxchg(il, inst, nameof(AtomicHelpers.Cmpxchg_I64_16U));  break;
+                case AtomOp.I64AtomicRmw32CmpxchgU:   EmitCmpxchg(il, inst, nameof(AtomicHelpers.Cmpxchg_I64_32U));  break;
+
+                // ---- Wait / notify ----
+                case AtomOp.MemoryAtomicNotify:  EmitNotify(il, inst);           break;
+                case AtomOp.MemoryAtomicWait32:  EmitWait(il, inst, is64: false); break;
+                case AtomOp.MemoryAtomicWait64:  EmitWait(il, inst, is64: true);  break;
+
+                // ---- Fence ----
+                case AtomOp.AtomicFence:
+                    il.Emit(OpCodes.Call, typeof(AtomicHelpers).GetMethod(
+                        nameof(AtomicHelpers.Fence), BindingFlags.Public | BindingFlags.Static)!);
+                    break;
+
+                default:
+                    throw new System.NotSupportedException(
+                        $"AtomicEmitter: no case for {op.GetMnemonic()}");
+            }
+        }
+
+        // Emit: stack is [addr], becomes [value]. Loads MemoryInstance from
+        // ctx.Memories[memIdx], then calls AtomicHelpers.LoadXxx(mem, addr, offset).
+        private static void EmitLoad(ILGenerator il, InstructionBase inst, string helperName)
+        {
+            var op = (InstAtomicMemoryOp)inst;
+            var addrLocal = il.DeclareLocal(typeof(int));
+            il.Emit(OpCodes.Stloc, addrLocal);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, MemoriesField);
+            il.Emit(OpCodes.Ldc_I4, op.MemIndex);
+            il.Emit(OpCodes.Ldelem_Ref);             // MemoryInstance
+            il.Emit(OpCodes.Ldloc, addrLocal);       // addr
+            il.Emit(OpCodes.Ldc_I8, op.MemOffset);   // offset
+
+            il.Emit(OpCodes.Call, typeof(AtomicHelpers).GetMethod(helperName,
+                BindingFlags.Public | BindingFlags.Static)!);
+        }
+
+        // Emit: stack is [addr, value], becomes [].
+        private static void EmitStore(ILGenerator il, InstructionBase inst, string helperName)
+        {
+            var op = (InstAtomicMemoryOp)inst;
+            var method = typeof(AtomicHelpers).GetMethod(helperName,
+                BindingFlags.Public | BindingFlags.Static)!;
+            var valueType = method.GetParameters()[3].ParameterType;
+
+            var valueLocal = il.DeclareLocal(valueType);
+            il.Emit(OpCodes.Stloc, valueLocal);      // save value
+            var addrLocal = il.DeclareLocal(typeof(int));
+            il.Emit(OpCodes.Stloc, addrLocal);       // save addr
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, MemoriesField);
+            il.Emit(OpCodes.Ldc_I4, op.MemIndex);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Ldloc, addrLocal);
+            il.Emit(OpCodes.Ldc_I8, op.MemOffset);
+            il.Emit(OpCodes.Ldloc, valueLocal);
+
+            il.Emit(OpCodes.Call, method);
+        }
+
+        // Emit: stack is [addr, arg], becomes [original].
+        private static void EmitRmw(ILGenerator il, InstructionBase inst, string helperName)
+        {
+            var op = (InstAtomicMemoryOp)inst;
+            var method = typeof(AtomicHelpers).GetMethod(helperName,
+                BindingFlags.Public | BindingFlags.Static)!;
+            var argType = method.GetParameters()[3].ParameterType;
+
+            var argLocal = il.DeclareLocal(argType);
+            il.Emit(OpCodes.Stloc, argLocal);
+            var addrLocal = il.DeclareLocal(typeof(int));
+            il.Emit(OpCodes.Stloc, addrLocal);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, MemoriesField);
+            il.Emit(OpCodes.Ldc_I4, op.MemIndex);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Ldloc, addrLocal);
+            il.Emit(OpCodes.Ldc_I8, op.MemOffset);
+            il.Emit(OpCodes.Ldloc, argLocal);
+
+            il.Emit(OpCodes.Call, method);
+        }
+
+        // Emit: stack is [addr, expected, replacement], becomes [original].
+        private static void EmitCmpxchg(ILGenerator il, InstructionBase inst, string helperName)
+        {
+            var op = (InstAtomicMemoryOp)inst;
+            var method = typeof(AtomicHelpers).GetMethod(helperName,
+                BindingFlags.Public | BindingFlags.Static)!;
+            var paramTypes = method.GetParameters();
+            var expectedType = paramTypes[3].ParameterType;
+            var replacementType = paramTypes[4].ParameterType;
+
+            var replLocal = il.DeclareLocal(replacementType);
+            il.Emit(OpCodes.Stloc, replLocal);
+            var expLocal = il.DeclareLocal(expectedType);
+            il.Emit(OpCodes.Stloc, expLocal);
+            var addrLocal = il.DeclareLocal(typeof(int));
+            il.Emit(OpCodes.Stloc, addrLocal);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, MemoriesField);
+            il.Emit(OpCodes.Ldc_I4, op.MemIndex);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Ldloc, addrLocal);
+            il.Emit(OpCodes.Ldc_I8, op.MemOffset);
+            il.Emit(OpCodes.Ldloc, expLocal);
+            il.Emit(OpCodes.Ldloc, replLocal);
+
+            il.Emit(OpCodes.Call, method);
+        }
+
+        // notify: stack is [addr, count], becomes [woken].
+        // Routes through ThinContext.ExecContext for policy access.
+        private static void EmitNotify(ILGenerator il, InstructionBase inst)
+        {
+            var op = (InstAtomicMemoryOp)inst;
+            var countLocal = il.DeclareLocal(typeof(int));
+            il.Emit(OpCodes.Stloc, countLocal);
+            var addrLocal = il.DeclareLocal(typeof(int));
+            il.Emit(OpCodes.Stloc, addrLocal);
+
+            il.Emit(OpCodes.Ldarg_0);                    // ThinContext
+            il.Emit(OpCodes.Ldc_I4, op.MemIndex);        // memIdx
+            il.Emit(OpCodes.Ldloc, addrLocal);           // addr
+            il.Emit(OpCodes.Ldc_I8, op.MemOffset);       // offset
+            il.Emit(OpCodes.Ldloc, countLocal);          // count
+
+            il.Emit(OpCodes.Call, typeof(AtomicHelpers).GetMethod(
+                nameof(AtomicHelpers.Notify), BindingFlags.Public | BindingFlags.Static)!);
+        }
+
+        // wait: stack is [addr, expected, timeoutNs], becomes [result].
+        private static void EmitWait(ILGenerator il, InstructionBase inst, bool is64)
+        {
+            var op = (InstAtomicMemoryOp)inst;
+            var timeoutLocal = il.DeclareLocal(typeof(long));
+            il.Emit(OpCodes.Stloc, timeoutLocal);
+            var expectedType = is64 ? typeof(long) : typeof(int);
+            var expectedLocal = il.DeclareLocal(expectedType);
+            il.Emit(OpCodes.Stloc, expectedLocal);
+            var addrLocal = il.DeclareLocal(typeof(int));
+            il.Emit(OpCodes.Stloc, addrLocal);
+
+            il.Emit(OpCodes.Ldarg_0);                    // ThinContext
+            il.Emit(OpCodes.Ldc_I4, op.MemIndex);
+            il.Emit(OpCodes.Ldloc, addrLocal);
+            il.Emit(OpCodes.Ldc_I8, op.MemOffset);
+            il.Emit(OpCodes.Ldloc, expectedLocal);
+            il.Emit(OpCodes.Ldloc, timeoutLocal);
+
+            var name = is64 ? nameof(AtomicHelpers.Wait64) : nameof(AtomicHelpers.Wait32);
+            il.Emit(OpCodes.Call, typeof(AtomicHelpers).GetMethod(
+                name, BindingFlags.Public | BindingFlags.Static)!);
+        }
+    }
+
+    /// <summary>
+    /// Runtime support for transpiled atomic ops. Each entry point does bounds +
+    /// exact-alignment checks (trap on failure) and then delegates to the phase-1
+    /// <see cref="MemoryInstance"/> atomic helpers, so correctness properties
+    /// (e.g. concurrent-grow safety) are shared with the polymorphic interpreter
+    /// and the switch runtime.
+    /// </summary>
+    public static class AtomicHelpers
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int CheckEa(MemoryInstance mem, int addr, long offset, int widthBytes, string op)
+        {
+            long ea = (uint)addr + offset;
+            if (ea < 0 || ea + widthBytes > mem.Data.Length)
+                throw new TrapException(
+                    $"{op}: out of bounds atomic access (ea={ea}, width={widthBytes}, size={mem.Data.Length})");
+            if ((ea & (widthBytes - 1)) != 0)
+                throw new TrapException(
+                    $"{op}: unaligned atomic access at ea={ea} (width={widthBytes})");
+            return (int)ea;
+        }
+
+        // ---- Loads ----
+        public static int LoadI32(MemoryInstance mem, int addr, long offset)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.load");
+            return mem.AtomicLoadInt32(ea);
+        }
+        public static long LoadI64(MemoryInstance mem, int addr, long offset)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.load");
+            return mem.AtomicLoadInt64(ea);
+        }
+        public static int LoadI32_8U(MemoryInstance mem, int addr, long offset)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.load8_u");
+            return Volatile.Read(ref mem.Data[ea]);
+        }
+        public static int LoadI32_16U(MemoryInstance mem, int addr, long offset)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.load16_u");
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            return Volatile.Read(ref cell);
+        }
+        public static long LoadI64_8U(MemoryInstance mem, int addr, long offset)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.load8_u");
+            return Volatile.Read(ref mem.Data[ea]);
+        }
+        public static long LoadI64_16U(MemoryInstance mem, int addr, long offset)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.load16_u");
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            return Volatile.Read(ref cell);
+        }
+        public static long LoadI64_32U(MemoryInstance mem, int addr, long offset)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.load32_u");
+            return (uint)mem.AtomicLoadInt32(ea);  // zero-extend
+        }
+
+        // ---- Stores ----
+        public static void StoreI32(MemoryInstance mem, int addr, long offset, int value)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.store");
+            mem.AtomicStoreInt32(ea, (int)value);
+        }
+        public static void StoreI64(MemoryInstance mem, int addr, long offset, long value)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.store");
+            mem.AtomicStoreInt64(ea, (long)value);
+        }
+        public static void StoreI32_8(MemoryInstance mem, int addr, long offset, int value)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.store8");
+            Volatile.Write(ref mem.Data[ea], (byte)value);
+        }
+        public static void StoreI32_16(MemoryInstance mem, int addr, long offset, int value)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.store16");
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            Volatile.Write(ref cell, (ushort)value);
+        }
+        public static void StoreI64_8(MemoryInstance mem, int addr, long offset, long value)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.store8");
+            Volatile.Write(ref mem.Data[ea], (byte)value);
+        }
+        public static void StoreI64_16(MemoryInstance mem, int addr, long offset, long value)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.store16");
+            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            Volatile.Write(ref cell, (ushort)value);
+        }
+        public static void StoreI64_32(MemoryInstance mem, int addr, long offset, long value)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.store32");
+            mem.AtomicStoreInt32(ea, (int)value);
+        }
+
+        // ---- RMW: add ----
+        public static int Rmw_I32_Add(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.rmw.add");
+            return mem.AtomicAddInt32(ea, arg);
+        }
+        public static long Rmw_I64_Add(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.rmw.add");
+            return mem.AtomicAddInt64(ea, arg);
+        }
+        public static int Rmw_I32_8_AddU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.rmw8.add_u");
+            return SubwordCas.Loop(mem, ea, 1, old => old + arg);
+        }
+        public static int Rmw_I32_16_AddU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.rmw16.add_u");
+            return SubwordCas.Loop(mem, ea, 2, old => old + arg);
+        }
+        public static long Rmw_I64_8_AddU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.rmw8.add_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 1, old => old + a);
+        }
+        public static long Rmw_I64_16_AddU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.rmw16.add_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 2, old => old + a);
+        }
+        public static long Rmw_I64_32_AddU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.rmw32.add_u");
+            return (uint)mem.AtomicAddInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: sub ----
+        public static int Rmw_I32_Sub(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.rmw.sub");
+            return mem.AtomicAddInt32(ea, -arg);
+        }
+        public static long Rmw_I64_Sub(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.rmw.sub");
+            return mem.AtomicAddInt64(ea, -arg);
+        }
+        public static int Rmw_I32_8_SubU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.rmw8.sub_u");
+            return SubwordCas.Loop(mem, ea, 1, old => old - arg);
+        }
+        public static int Rmw_I32_16_SubU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.rmw16.sub_u");
+            return SubwordCas.Loop(mem, ea, 2, old => old - arg);
+        }
+        public static long Rmw_I64_8_SubU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.rmw8.sub_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 1, old => old - a);
+        }
+        public static long Rmw_I64_16_SubU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.rmw16.sub_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 2, old => old - a);
+        }
+        public static long Rmw_I64_32_SubU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.rmw32.sub_u");
+            return (uint)mem.AtomicAddInt32(ea, -(int)arg);
+        }
+
+        // ---- RMW: and ----
+        public static int Rmw_I32_And(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.rmw.and");
+            return mem.AtomicAndInt32(ea, arg);
+        }
+        public static long Rmw_I64_And(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.rmw.and");
+            return mem.AtomicAndInt64(ea, arg);
+        }
+        public static int Rmw_I32_8_AndU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.rmw8.and_u");
+            return SubwordCas.Loop(mem, ea, 1, old => old & arg);
+        }
+        public static int Rmw_I32_16_AndU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.rmw16.and_u");
+            return SubwordCas.Loop(mem, ea, 2, old => old & arg);
+        }
+        public static long Rmw_I64_8_AndU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.rmw8.and_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 1, old => old & a);
+        }
+        public static long Rmw_I64_16_AndU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.rmw16.and_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 2, old => old & a);
+        }
+        public static long Rmw_I64_32_AndU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.rmw32.and_u");
+            return (uint)mem.AtomicAndInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: or ----
+        public static int Rmw_I32_Or(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.rmw.or");
+            return mem.AtomicOrInt32(ea, arg);
+        }
+        public static long Rmw_I64_Or(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.rmw.or");
+            return mem.AtomicOrInt64(ea, arg);
+        }
+        public static int Rmw_I32_8_OrU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.rmw8.or_u");
+            return SubwordCas.Loop(mem, ea, 1, old => old | arg);
+        }
+        public static int Rmw_I32_16_OrU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.rmw16.or_u");
+            return SubwordCas.Loop(mem, ea, 2, old => old | arg);
+        }
+        public static long Rmw_I64_8_OrU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.rmw8.or_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 1, old => old | a);
+        }
+        public static long Rmw_I64_16_OrU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.rmw16.or_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 2, old => old | a);
+        }
+        public static long Rmw_I64_32_OrU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.rmw32.or_u");
+            return (uint)mem.AtomicOrInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: xor ----
+        public static int Rmw_I32_Xor(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.rmw.xor");
+            return mem.AtomicXorInt32(ea, arg);
+        }
+        public static long Rmw_I64_Xor(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.rmw.xor");
+            return mem.AtomicXorInt64(ea, arg);
+        }
+        public static int Rmw_I32_8_XorU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.rmw8.xor_u");
+            return SubwordCas.Loop(mem, ea, 1, old => old ^ arg);
+        }
+        public static int Rmw_I32_16_XorU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.rmw16.xor_u");
+            return SubwordCas.Loop(mem, ea, 2, old => old ^ arg);
+        }
+        public static long Rmw_I64_8_XorU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.rmw8.xor_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 1, old => old ^ a);
+        }
+        public static long Rmw_I64_16_XorU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.rmw16.xor_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 2, old => old ^ a);
+        }
+        public static long Rmw_I64_32_XorU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.rmw32.xor_u");
+            return (uint)mem.AtomicXorInt32(ea, (int)arg);
+        }
+
+        // ---- RMW: xchg ----
+        public static int Rmw_I32_Xchg(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.rmw.xchg");
+            return mem.AtomicExchangeInt32(ea, arg);
+        }
+        public static long Rmw_I64_Xchg(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.rmw.xchg");
+            return mem.AtomicExchangeInt64(ea, arg);
+        }
+        public static int Rmw_I32_8_XchgU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.rmw8.xchg_u");
+            return SubwordCas.Loop(mem, ea, 1, _ => arg);
+        }
+        public static int Rmw_I32_16_XchgU(MemoryInstance mem, int addr, long offset, int arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.rmw16.xchg_u");
+            return SubwordCas.Loop(mem, ea, 2, _ => arg);
+        }
+        public static long Rmw_I64_8_XchgU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.rmw8.xchg_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 1, _ => a);
+        }
+        public static long Rmw_I64_16_XchgU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.rmw16.xchg_u");
+            int a = (int)arg;
+            return (uint)SubwordCas.Loop(mem, ea, 2, _ => a);
+        }
+        public static long Rmw_I64_32_XchgU(MemoryInstance mem, int addr, long offset, long arg)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.rmw32.xchg_u");
+            return (uint)mem.AtomicExchangeInt32(ea, (int)arg);
+        }
+
+        // ---- Cmpxchg ----
+        public static int Cmpxchg_I32(MemoryInstance mem, int addr, long offset, int expected, int replacement)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i32.atomic.rmw.cmpxchg");
+            return mem.AtomicCompareExchangeInt32(ea, replacement, expected);
+        }
+        public static long Cmpxchg_I64(MemoryInstance mem, int addr, long offset, long expected, long replacement)
+        {
+            int ea = CheckEa(mem, addr, offset, 8, "i64.atomic.rmw.cmpxchg");
+            return mem.AtomicCompareExchangeInt64(ea, replacement, expected);
+        }
+        public static int Cmpxchg_I32_8U(MemoryInstance mem, int addr, long offset, int expected, int replacement)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i32.atomic.rmw8.cmpxchg_u");
+            return SubwordCas.Cmpxchg(mem, ea, 1, expected, replacement);
+        }
+        public static int Cmpxchg_I32_16U(MemoryInstance mem, int addr, long offset, int expected, int replacement)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i32.atomic.rmw16.cmpxchg_u");
+            return SubwordCas.Cmpxchg(mem, ea, 2, expected, replacement);
+        }
+        public static long Cmpxchg_I64_8U(MemoryInstance mem, int addr, long offset, long expected, long replacement)
+        {
+            int ea = CheckEa(mem, addr, offset, 1, "i64.atomic.rmw8.cmpxchg_u");
+            return SubwordCas.Cmpxchg(mem, ea, 1, (int)expected, (int)replacement);
+        }
+        public static long Cmpxchg_I64_16U(MemoryInstance mem, int addr, long offset, long expected, long replacement)
+        {
+            int ea = CheckEa(mem, addr, offset, 2, "i64.atomic.rmw16.cmpxchg_u");
+            return SubwordCas.Cmpxchg(mem, ea, 2, (int)expected, (int)replacement);
+        }
+        public static long Cmpxchg_I64_32U(MemoryInstance mem, int addr, long offset, long expected, long replacement)
+        {
+            int ea = CheckEa(mem, addr, offset, 4, "i64.atomic.rmw32.cmpxchg_u");
+            // Zero-extend int result to long (upper 32 bits = 0) per wasm rmw32 spec.
+            return (uint)mem.AtomicCompareExchangeInt32(ea, (int)replacement, (int)expected);
+        }
+
+        // ---- Wait / Notify ----
+        // Wait/notify need access to the ConcurrencyPolicy. In-framework,
+        // ThinContext.ExecContext gives us the runtime's policy. Standalone
+        // mode (ExecContext == null) falls back to NotSupportedPolicy so the
+        // ops still behave correctly: wait returns timed-out/not-equal,
+        // notify returns 0, neither deadlocks.
+
+        private static readonly IConcurrencyPolicy _standaloneFallback = new NotSupportedPolicy();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static IConcurrencyPolicy GetPolicy(ThinContext ctx)
+            => ctx.ExecContext?.ConcurrencyPolicy ?? _standaloneFallback;
+
+        public static int Notify(ThinContext ctx, int memIdx, int addr, long offset, int count)
+        {
+            var mem = ctx.Memories[memIdx];
+            int ea = CheckEa(mem, addr, offset, 4, "memory.atomic.notify");
+            return GetPolicy(ctx).Notify(mem, ea, count);
+        }
+
+        public static int Wait32(ThinContext ctx, int memIdx, int addr, long offset, int expected, long timeoutNs)
+        {
+            var mem = ctx.Memories[memIdx];
+            int ea = CheckEa(mem, addr, offset, 4, "memory.atomic.wait32");
+            return GetPolicy(ctx).Wait32(mem, ea, expected, timeoutNs);
+        }
+
+        public static int Wait64(ThinContext ctx, int memIdx, int addr, long offset, long expected, long timeoutNs)
+        {
+            var mem = ctx.Memories[memIdx];
+            int ea = CheckEa(mem, addr, offset, 8, "memory.atomic.wait64");
+            return GetPolicy(ctx).Wait64(mem, ea, expected, timeoutNs);
+        }
+
+        // ---- Fence ----
+        public static void Fence() => Interlocked.MemoryBarrier();
+    }
+}

--- a/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
+++ b/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
@@ -469,11 +469,13 @@ namespace Wacs.Transpiler.AOT
                 return;
             }
 
-            // Other multi-byte prefix opcodes (not yet supported)
+            // 0xFE prefix (threads proposal atomics)
             if (op == WasmOpCode.FE)
             {
-                throw new TranspilerException(
-                    $"FunctionCodegen: prefix opcode {inst.Op.GetMnemonic()} should have been caught by CanEmit");
+                TrackAtomicStackEffect(inst, before: true);
+                AtomicEmitter.Emit(il, inst, inst.Op.xFE);
+                TrackAtomicStackEffect(inst, before: false);
+                return;
             }
 
             // Numeric instructions (constants, arithmetic, comparisons, conversions)
@@ -1128,6 +1130,222 @@ namespace Wacs.Transpiler.AOT
         /// Constants push a typed value; unary ops pop+push; binary ops pop 2 push 1.
         /// </summary>
         /// <summary>Track memory instruction stack effects.</summary>
+        /// <summary>
+        /// Track stack effects for 0xFE-prefixed atomic ops. Mirrors the
+        /// before/after shape used by <c>TrackExtStackEffect</c>: pops inputs
+        /// before the emit, pushes the result after. The CIL emitter's
+        /// helper invocation ensures the generated IL already matches these
+        /// pops/pushes — this method just keeps the validator's type stack
+        /// in sync so downstream ops see the right representation.
+        /// </summary>
+        private void TrackAtomicStackEffect(InstructionBase inst, bool before)
+        {
+            var op = inst.Op.xFE;
+            if (before)
+            {
+                switch (op)
+                {
+                    // Loads: [addr] → …
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicLoad:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicLoad8U:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicLoad16U:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad8U:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad16U:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad32U:
+                        _cilValidator.Pop(context: "atomic.load addr");
+                        break;
+
+                    // i32 stores: [addr, i32] → []
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicStore:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicStore8:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicStore16:
+                        _cilValidator.Pop(typeof(int), "i32.atomic.store val");
+                        _cilValidator.Pop(context: "atomic.store addr");
+                        break;
+                    // i64 stores: [addr, i64] → []
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicStore:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicStore8:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicStore16:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicStore32:
+                        _cilValidator.Pop(typeof(long), "i64.atomic.store val");
+                        _cilValidator.Pop(context: "atomic.store addr");
+                        break;
+
+                    // i32 RMW: [addr, i32] → [i32]
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwAdd:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwSub:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwAnd:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwOr:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwXor:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwXchg:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16XchgU:
+                        _cilValidator.Pop(typeof(int), "i32.atomic.rmw arg");
+                        _cilValidator.Pop(context: "atomic.rmw addr");
+                        break;
+
+                    // i64 RMW: [addr, i64] → [i64]
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwAdd:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwSub:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwAnd:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwOr:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwXor:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwXchg:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32XchgU:
+                        _cilValidator.Pop(typeof(long), "i64.atomic.rmw arg");
+                        _cilValidator.Pop(context: "atomic.rmw addr");
+                        break;
+
+                    // i32 Cmpxchg: [addr, i32 expected, i32 replacement] → [i32]
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwCmpxchg:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8CmpxchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16CmpxchgU:
+                        _cilValidator.Pop(typeof(int), "cmpxchg replacement");
+                        _cilValidator.Pop(typeof(int), "cmpxchg expected");
+                        _cilValidator.Pop(context: "cmpxchg addr");
+                        break;
+
+                    // i64 Cmpxchg: [addr, i64 expected, i64 replacement] → [i64]
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwCmpxchg:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8CmpxchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16CmpxchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32CmpxchgU:
+                        _cilValidator.Pop(typeof(long), "cmpxchg replacement");
+                        _cilValidator.Pop(typeof(long), "cmpxchg expected");
+                        _cilValidator.Pop(context: "cmpxchg addr");
+                        break;
+
+                    // Notify: [addr, i32 count] → [i32 woken]
+                    case Wacs.Core.OpCodes.AtomCode.MemoryAtomicNotify:
+                        _cilValidator.Pop(typeof(int), "notify count");
+                        _cilValidator.Pop(context: "notify addr");
+                        break;
+
+                    // Wait32: [addr, i32 expected, i64 timeoutNs] → [i32]
+                    case Wacs.Core.OpCodes.AtomCode.MemoryAtomicWait32:
+                        _cilValidator.Pop(typeof(long), "wait32 timeoutNs");
+                        _cilValidator.Pop(typeof(int),  "wait32 expected");
+                        _cilValidator.Pop(context: "wait32 addr");
+                        break;
+
+                    // Wait64: [addr, i64 expected, i64 timeoutNs] → [i32]
+                    case Wacs.Core.OpCodes.AtomCode.MemoryAtomicWait64:
+                        _cilValidator.Pop(typeof(long), "wait64 timeoutNs");
+                        _cilValidator.Pop(typeof(long), "wait64 expected");
+                        _cilValidator.Pop(context: "wait64 addr");
+                        break;
+
+                    // Fence: [] → []
+                    case Wacs.Core.OpCodes.AtomCode.AtomicFence:
+                        break;
+                }
+            }
+            else
+            {
+                switch (op)
+                {
+                    // i32 result
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicLoad:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicLoad8U:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicLoad16U:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwAdd:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwSub:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwAnd:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwOr:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwXor:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwXchg:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmwCmpxchg:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw8CmpxchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I32AtomicRmw16CmpxchgU:
+                    case Wacs.Core.OpCodes.AtomCode.MemoryAtomicNotify:
+                    case Wacs.Core.OpCodes.AtomCode.MemoryAtomicWait32:
+                    case Wacs.Core.OpCodes.AtomCode.MemoryAtomicWait64:
+                        _cilValidator.Push(typeof(int));
+                        break;
+
+                    // i64 result
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad8U:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad16U:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicLoad32U:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwAdd:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwSub:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwAnd:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwOr:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwXor:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwXchg:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32AddU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32SubU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32AndU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32OrU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32XorU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32XchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmwCmpxchg:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw8CmpxchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw16CmpxchgU:
+                    case Wacs.Core.OpCodes.AtomCode.I64AtomicRmw32CmpxchgU:
+                        _cilValidator.Push(typeof(long));
+                        break;
+
+                    // Stores + fence: no result
+                    default:
+                        break;
+                }
+            }
+        }
+
         private void TrackMemoryStackEffect(WasmOpCode op)
         {
             // Address type: i32 for memory32, i64 for memory64.
@@ -1674,9 +1892,9 @@ namespace Wacs.Transpiler.AOT
             if (op == WasmOpCode.FD)
                 return SimdEmitter.CanEmit(inst.Op.xFD);
 
-            // Other multi-byte opcodes — not yet supported
+            // 0xFE prefix (threads proposal atomics)
             if (op == WasmOpCode.FE)
-                return false;
+                return AtomicEmitter.CanEmit(inst.Op.xFE);
 
             // Numeric instructions (0x41-0xC4)
             if (NumericEmitter.CanEmit(op))

--- a/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -11,8 +11,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.2.0</Version>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
+        <Version>0.2.1</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2025 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies.</Description>

--- a/Wacs.Transpiler.Test/AtomicEquivalenceTests.cs
+++ b/Wacs.Transpiler.Test/AtomicEquivalenceTests.cs
@@ -1,0 +1,261 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Concurrency;
+using Wacs.Core.Text;
+using Wacs.Transpiler.AOT;
+using Xunit;
+
+namespace Wacs.Transpiler.Test
+{
+    /// <summary>
+    /// Phase-3 equivalence tests for atomic ops. Each test parses a small
+    /// WAT source, instantiates the module on the polymorphic runtime, and
+    /// transpiles it through <see cref="ModuleTranspiler"/>. Both back-ends
+    /// must produce the same result for the same invocation — the whole
+    /// point of phase 3 is correctness parity with phases 1 and 2.
+    /// </summary>
+    public class AtomicEquivalenceTests
+    {
+        private static (object Poly, object Aot) RunBoth(string src, string export, params Value[] args)
+        {
+            // Polymorphic path
+            var polyRt = new WasmRuntime(new RuntimeAttributes
+            {
+                ConcurrencyPolicy = new NotSupportedPolicy(),
+            });
+            var module = TextModuleParser.ParseWat(src);
+            var polyInst = polyRt.InstantiateModule(module);
+            polyRt.RegisterModule("M", polyInst);
+            var polyFunc = polyRt.GetExportedFunction(("M", export));
+            var polyResult = polyRt.CreateStackInvoker(polyFunc)(args);
+            object polyVal = polyResult.Length == 0 ? null! : (object)polyResult[0];
+
+            // Transpiled path
+            var aotRt = new WasmRuntime(new RuntimeAttributes
+            {
+                ConcurrencyPolicy = new NotSupportedPolicy(),
+            });
+            var module2 = TextModuleParser.ParseWat(src);
+            var aotInst = aotRt.InstantiateModule(module2);
+            aotRt.RegisterModule("M", aotInst);
+
+            var transpiler = new ModuleTranspiler();
+            var result = transpiler.Transpile(aotInst, aotRt);
+            Assert.NotNull(result.ModuleClass);
+            Assert.Equal(0, result.FallbackCount);
+
+            var wrapper = new TranspiledModuleWrapper(result);
+            wrapper.Instantiate();
+            var aotResult = wrapper.InvokeExport(export, args);
+            object aotVal = aotResult.Length == 0 ? null! : (object)aotResult[0];
+
+            return (polyVal, aotVal);
+        }
+
+        private static int I32(Value v) => v.Data.Int32;
+        private static long I64(Value v) => v.Data.Int64;
+
+        [Fact]
+        public void I32_load_store_round_trip_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 0x12345678
+                    i32.atomic.store align=4
+                    i32.const 0
+                    i32.atomic.load align=4))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(0x12345678, I32((Value)aot));
+        }
+
+        [Fact]
+        public void I64_load_store_round_trip_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i64)
+                    i32.const 8
+                    i64.const 0x0123456789ABCDEF
+                    i64.atomic.store align=8
+                    i32.const 8
+                    i64.atomic.load align=8))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I64((Value)poly), I64((Value)aot));
+            Assert.Equal(0x0123456789ABCDEFL, I64((Value)aot));
+        }
+
+        [Fact]
+        public void Subword_load_store_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 7
+                    i32.const 0xA5
+                    i32.atomic.store8 align=1
+                    i32.const 7
+                    i32.atomic.load8_u align=1))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(0xA5, I32((Value)aot));
+        }
+
+        [Fact]
+        public void Rmw_add_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0 i32.const 10 i32.atomic.store align=4
+                    i32.const 0 i32.const 5 i32.atomic.rmw.add align=4))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(10, I32((Value)aot));  // returns original
+        }
+
+        [Fact]
+        public void Rmw_xchg_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0 i32.const 7 i32.atomic.store align=4
+                    i32.const 0 i32.const 42 i32.atomic.rmw.xchg align=4))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(7, I32((Value)aot));
+        }
+
+        [Fact]
+        public void Subword_rmw_add_CAS_loop_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 3 i32.const 100 i32.atomic.store8 align=1
+                    i32.const 3 i32.const 56 i32.atomic.rmw8.add_u align=1))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(100, I32((Value)aot));  // original
+        }
+
+        [Fact]
+        public void Cmpxchg_match_and_mismatch()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""match"") (result i32)
+                    i32.const 0 i32.const 50 i32.atomic.store align=4
+                    i32.const 0 i32.const 50 i32.const 99 i32.atomic.rmw.cmpxchg align=4)
+                  (func (export ""miss"") (result i32)
+                    i32.const 4 i32.const 50 i32.atomic.store align=4
+                    i32.const 4 i32.const 999 i32.const 99 i32.atomic.rmw.cmpxchg align=4))";
+            var (polyM, aotM) = RunBoth(src, "match");
+            Assert.Equal(I32((Value)polyM), I32((Value)aotM));
+            Assert.Equal(50, I32((Value)aotM));
+
+            var (polyF, aotF) = RunBoth(src, "miss");
+            Assert.Equal(I32((Value)polyF), I32((Value)aotF));
+            Assert.Equal(50, I32((Value)aotF));
+        }
+
+        [Fact]
+        public void Fence_executes_and_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    atomic.fence
+                    i32.const 42))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(42, I32((Value)aot));
+        }
+
+        [Fact]
+        public void Wait_mismatch_returns_2()
+        {
+            // NotSupported policy: wait with mismatched expected → 2.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0
+                    i32.const 99
+                    i64.const 0
+                    memory.atomic.wait32 align=4))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(2, I32((Value)aot));
+        }
+
+        [Fact]
+        public void Notify_with_no_waiters_returns_0()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0 i32.const 10
+                    memory.atomic.notify align=4))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I32((Value)poly), I32((Value)aot));
+            Assert.Equal(0, I32((Value)aot));
+        }
+
+        [Fact]
+        public void I64_rmw_add_matches()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i64)
+                    i32.const 0 i64.const 100 i64.atomic.store align=8
+                    i32.const 0 i64.const 23 i64.atomic.rmw.add align=8))";
+            var (poly, aot) = RunBoth(src, "f");
+            Assert.Equal(I64((Value)poly), I64((Value)aot));
+            Assert.Equal(100L, I64((Value)aot));
+        }
+
+        [Fact]
+        public void Function_with_atomics_does_not_fall_back()
+        {
+            // Ensure phase-3 gives us full transpilation coverage for
+            // every atomic family — a FallbackCount of 0 means no
+            // function bailed to the interpreter.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""f"") (result i32)
+                    i32.const 0 i32.const 1 i32.atomic.store align=4
+                    i32.const 0 i32.const 2 i32.atomic.rmw.add align=4
+                    i32.const 0 i32.const 3 i32.const 4 i32.atomic.rmw.cmpxchg align=4
+                    i32.const 0 i32.const 5 i32.atomic.rmw8.add_u align=1
+                    atomic.fence
+                    drop drop drop
+                    i32.const 0 i32.atomic.load align=4))";
+            var rt = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = rt.InstantiateModule(module);
+            rt.RegisterModule("M", inst);
+            var result = new ModuleTranspiler().Transpile(inst, rt);
+            Assert.Equal(0, result.FallbackCount);
+        }
+    }
+}

--- a/Wacs.Transpiler/Wacs.Transpiler.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.csproj
@@ -13,8 +13,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler</PackageId>
         <Title>WACS Transpiler</Title>
-        <Version>0.2.0</Version>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
+        <Version>0.2.1</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2025 Kelvin Nishikawa</Copyright>
         <Description>Ahead-of-time WebAssembly-to-.NET IL transpiler for WACS. Installs the `wasm-transpile` CLI tool. For programmatic use, reference WACS.Transpiler.Lib.</Description>

--- a/Wacs.WASIp1/FsPath.cs
+++ b/Wacs.WASIp1/FsPath.cs
@@ -167,6 +167,23 @@ namespace Wacs.WASIp1
             // return ErrNo.Success;
         }
 
+        // This function signiature may SEGFAULT dotnet runtimes, but is required for some where reflection isn't 100% available.
+        // * provided for situations like Unity
+        public ErrNo NakedPathOpen(ExecContext ctx,
+            fd dirFd,
+            LookupFlags dirFlags,
+            ptr pathPtr,
+            size pathLen,
+            OFlags oFlags,
+            Rights fsRightsBase,
+            Rights fsRightsInheriting,
+            FdFlags fsFlags,
+            ptr fdPtr)
+        {
+            PathOpen(ctx, dirFd, dirFlags, pathPtr, pathLen, oFlags, fsRightsBase, fsRightsInheriting, fsFlags, fdPtr, out ErrNo result);
+            return result;
+        }
+
         /// <summary>
         /// Open a file or directory (similar to POSIX openat).
         /// </summary>


### PR DESCRIPTION
## Summary

Release-cut PR for the threads-proposal work (phases 1/2/3 combined). Brings phases 2 (#80) and 3 (#81) onto `main` — both were merged into their stack bases rather than into `main`, so `origin/main` currently only contains phase 1 (#79).

This PR:
- Merges phase-2 and phase-3 content onto `main`.
- Bumps versions: **WACS 0.8.2 → 0.8.3**, **WACS.Transpiler 0.2.0 → 0.2.1**, **WACS.Transpiler.Lib 0.2.0 → 0.2.1**.
- Updates the README "Latest releases" line.
- Adds a consolidated CHANGELOG entry for the threads work across all three back-ends.

## After merge

Tag on the resulting merge commit:
- `WACS-v0.8.3` → triggers `nuget.yml` publish of WACS 0.8.3.
- `WACS-Transpiler-v0.2.1` → triggers publish of both WACS.Transpiler 0.2.1 and WACS.Transpiler.Lib 0.2.1 (same prefix matches both matrix rows).

WACS.WASIp1 unchanged at 0.9.7 — no new tag needed.

## Scope

Includes everything from #80 (switch runtime) and #81 (AOT transpiler) plus the version bumps. See the phase PRs for detailed per-back-end notes; the consolidated CHANGELOG entry in this PR covers the whole threads story in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)