### PR TITLE
Concurrent wasm execution: per-thread ExecContext, wasi-threads, shared-everything foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,96 @@
 # Changelog
 
+## [Unreleased] — Concurrent wasm execution
+
+Makes the WACS runtime reentrant under concurrent host threads,
+hardens shared-mutable state, adds a wasi-threads host adapter, and
+lands the type-system foundation for shared-everything-threads.
+Five stacked layers, 24 commits. No backwards-incompatible changes
+to baseline wasm — all new behavior is opt-in or gated behind a
+host-visible primitive.
+
+**Layer 1 — Per-thread execution substrate.** The `WasmRuntime.Context`
+singleton `ExecContext` became a `ConcurrentDictionary<ThreadId,
+ExecContext>` keyed by `ManagedThreadId`. Each host thread entering the
+runtime lazily gets its own operand stack, frame pool, locals pool,
+and call stack while sharing a new `SharedRuntimeState` (Store,
+Attributes, linked instruction arrays) by reference. `WasmThread` +
+`IWasmThreadHost` primitives in `Wacs.Core/Runtime/Concurrency/` —
+thread-spawn with task-based completion, cancellation-token
+observation at call boundaries, `InterruptedException : TrapException`
+propagating through existing trap handlers to `WasmThread.Completion`.
+`IConcurrencyPolicy` grows async default-methods
+(`Wait32Async`/`Wait64Async`/`NotifyAsync`) that wrap the sync versions
+— shape only, enables a truly-yielding wait implementation as a later
+additive change.
+
+**Layer 2 — Shared-mutable state hardening.** `GlobalInstance.Value`
+(24-byte struct) now serializes concurrent read/write through a
+lazy per-instance lock when `IsShared` — non-shared globals stay on
+the zero-overhead direct path. `TableInstance.Grow` pre-allocates
+`List<T>.Capacity` in a single atomic field-swap before appending,
+so concurrent `call_indirect` readers never see a mid-resize state;
+readers stay lock-free even for shared tables. `TranspiledFunction`
+swaps its reused `_paramBuffer` for `ArrayPool<object?>.Shared.Rent/
+Return` per call. Dead `_asideVals` static stacks removed.
+`Store.ReplaceFunction` documented as init-only.
+
+**Layer 3 — wasi-threads adapter.** New sibling project
+`Wacs.WASI.Threads` with `WasiThreads : IBindable`, 30 lines of actual
+logic wiring the `wasi:thread-spawn` host import onto
+`IWasmThreadHost.Spawn`. Monotonic positive-i32 tid allocation;
+`wasi_thread_start` resolution via `ctx.Frame.Module.Exports` — no
+explicit module registration. AOT-compatible (net8.0 + netstandard2.1,
+`IsAotCompatible`). Hosts that don't want threads don't pay for them.
+
+**Layer 4 — Soak + integration testing.** 13 new tests:
+atomic-op-variety stress matrix (every RMW family × i32/i64 +
+subword rmw8/rmw16 under 16-thread × 1k-iter contention), end-to-end
+wait/notify producer-consumer through `HostDefinedPolicy` (with
+timeout and not-equal precheck paths), and a 60-runtime soak that
+would have caught the original Layer 1c `ThreadLocal<ExecContext>`
+slot-exhaustion crash.
+
+**Layer 5 — Shared-everything-threads foundation.** Feature-flag
+`RuntimeAttributes.EnableSharedEverythingThreads` (default false) gates
+the Phase-1-proposal subset that's stable enough to ship:
+- `shared` annotations on globals (binary bit 1 of the mutability byte;
+  text `(global (shared) ...)`) and tables (leveraging existing Limits
+  Shared infrastructure).
+- `thread_local` annotations on globals (binary bit 2; text
+  `(global (thread_local) ...)`). Each host thread sees its own slot,
+  initialized from the declared initializer on first access; storage
+  lives on the per-thread `ExecContext` from Layer 1c.
+- Declaration-driven `IsShared` wiring through to
+  `GlobalInstance.EnableConcurrentAccess` / `TableInstance.EnableConcurrentAccess`.
+  Layer 2b's "any shared memory → all globals/tables shared"
+  approximation stays as a fallback for threads-1.0 modules that
+  predate per-declaration annotations.
+- Import-type matching: shared/thread_local must match exactly; a
+  non-shared host global can't satisfy a shared import.
+
+Deferred in Layer 5 because the proposal hasn't assigned canonical
+opcode bytes: `global.atomic.{get,set,rmw.*}` instructions and
+`pause`. Shared globals still work correctly through regular
+`global.get`/`global.set` via the locking foundation — atomic ops are
+a performance refinement on top.
+
+Deferred as separate programs of work:
+- **Emscripten pthreads ABI** (complex Web-flavored runtime surface;
+  converging wasi-threads is the forward direction for most workflows).
+- **Component Model canonical builtins** (`thread.spawn_ref`,
+  `thread.spawn_indirect`) — will wire onto the same
+  `IWasmThreadHost.Spawn` primitive when Component Model support lands.
+- **Shared struct/array types**, **shared function references** —
+  type-system discipline still evolving in the proposal.
+
+**Verification:**
+- Wacs.Core.Test: **366/366** (+28 new concurrent-execution tests)
+- Wacs.Transpiler.Test: 561/561
+- Spec.Test (full wasm-3.0 suite): 723/723
+- `dotnet publish -p:PublishAot=true` produces a clean 15MB native
+  binary.
+
 ## [0.8.3] + WACS.Transpiler / Transpiler.Lib [0.2.1] — Threads proposal
 
 Implements the [WebAssembly threads proposal](https://github.com/webassembly/threads)

--- a/WACS.sln
+++ b/WACS.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wacs.Transpiler.Lib", "Wacs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wacs.Core.Test", "Wacs.Core.Test\Wacs.Core.Test.csproj", "{6DB10230-B3B1-49CF-97E4-939A5DF4FF4B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wacs.WASI.Threads", "Wacs.WASI.Threads\Wacs.WASI.Threads.csproj", "{29E1FED0-1867-43DF-A473-EB7871C32EBB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,5 +81,9 @@ Global
 		{6DB10230-B3B1-49CF-97E4-939A5DF4FF4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DB10230-B3B1-49CF-97E4-939A5DF4FF4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6DB10230-B3B1-49CF-97E4-939A5DF4FF4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29E1FED0-1867-43DF-A473-EB7871C32EBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29E1FED0-1867-43DF-A473-EB7871C32EBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29E1FED0-1867-43DF-A473-EB7871C32EBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29E1FED0-1867-43DF-A473-EB7871C32EBB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Wacs.Core.Test/ConcurrentAtomicMatrixTests.cs
+++ b/Wacs.Core.Test/ConcurrentAtomicMatrixTests.cs
@@ -1,0 +1,366 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// Concurrent atomic-op variety stress (Layer 4a). Exercises every
+    /// RMW family (add, sub, and, or, xor, xchg, cmpxchg) across i32 and
+    /// i64 widths plus i32.rmw8 / i32.rmw16 subword paths under 16-thread
+    /// contention. Each test has an op-commutative expected value so a
+    /// single incorrect final observation fails the test deterministically.
+    ///
+    /// <para>Bigger iteration counts than the Layer 1 smoke tests — the
+    /// goal is to exercise the CAS-loop fallback on subword ops and the
+    /// native <c>Interlocked</c> paths on full-width ops through many
+    /// cycles to surface any stale-register / ordering bugs.</para>
+    /// </summary>
+    public class ConcurrentAtomicMatrixTests
+    {
+        private const int ThreadCount = 16;
+        private const int Iterations = 1000;
+
+        private static (WasmRuntime runtime, FuncAddr addr, FuncAddr readAddr)
+            Build(string src, string writeExport, string readExport)
+        {
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            return (
+                runtime,
+                runtime.GetExportedFunction(("M", writeExport)),
+                runtime.GetExportedFunction(("M", readExport))
+            );
+        }
+
+        private static long ReadI64(WasmRuntime runtime, FuncAddr addr)
+            => (long)runtime.CreateStackInvoker(addr)(Array.Empty<Value>())[0];
+
+        private static int ReadI32(WasmRuntime runtime, FuncAddr addr)
+            => (int)runtime.CreateStackInvoker(addr)(Array.Empty<Value>())[0];
+
+        // ---- i32.atomic.rmw.add -----------------------------------------
+
+        [Fact]
+        public void I32_rmw_add_is_commutative_under_contention()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""inc"")
+                    i32.const 0
+                    i32.const 1
+                    i32.atomic.rmw.add
+                    drop)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load))";
+            var (runtime, inc, read) = Build(src, "inc", "read");
+
+            RunWriters(runtime, inc);
+            Assert.Equal(ThreadCount * Iterations, ReadI32(runtime, read));
+        }
+
+        // ---- i32.atomic.rmw.sub (add-with-negation) ---------------------
+
+        [Fact]
+        public void I32_rmw_sub_from_large_initial_reaches_zero()
+        {
+            // Pre-populate cell via a one-off host write (simpler than a data
+            // segment literal). Then each thread subs 1 until zero. Final == 0
+            // only if every RMW was commutative-correct.
+            int initial = ThreadCount * Iterations;
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""seed"") (param $v i32)
+                    i32.const 0
+                    local.get $v
+                    i32.atomic.store)
+                  (func (export ""dec"")
+                    i32.const 0
+                    i32.const 1
+                    i32.atomic.rmw.sub
+                    drop)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load))";
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var seedAddr = runtime.GetExportedFunction(("M", "seed"));
+            var dec = runtime.GetExportedFunction(("M", "dec"));
+            var read = runtime.GetExportedFunction(("M", "read"));
+
+            runtime.CreateStackInvoker(seedAddr)(new Value[] { (Value)initial });
+            RunWriters(runtime, dec);
+            Assert.Equal(0, ReadI32(runtime, read));
+        }
+
+        // ---- i32.atomic.rmw.or (commutative idempotent bitwise) ---------
+
+        [Fact]
+        public void I32_rmw_or_applies_all_bits()
+        {
+            // Each thread ORs in its own unique bit position. Final value
+            // must be the OR of all ThreadCount bits = (1 << ThreadCount) - 1.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""or_bit"") (param $bit i32)
+                    i32.const 0
+                    local.get $bit
+                    i32.atomic.rmw.or
+                    drop)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load))";
+            var (runtime, orBit, read) = Build(src, "or_bit", "read");
+
+            var barrier = new Barrier(ThreadCount);
+            var threads = new Thread[ThreadCount];
+            for (int t = 0; t < ThreadCount; t++)
+            {
+                int bit = 1 << t;
+                threads[t] = new Thread(() =>
+                {
+                    var inv = runtime.CreateStackInvoker(orBit);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < Iterations; i++)
+                        inv(new Value[] { (Value)bit });
+                });
+            }
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+
+            int expected = (1 << ThreadCount) - 1;
+            Assert.Equal(expected, ReadI32(runtime, read));
+        }
+
+        // ---- i32.atomic.rmw.xor (each bit toggled even-count times) -----
+
+        [Fact]
+        public void I32_rmw_xor_even_iterations_is_identity()
+        {
+            // Each thread XORs its unique bit Iterations times. If Iterations
+            // is even, every bit ends up toggled back to its initial state
+            // (0) regardless of interleaving.
+            Assert.True(Iterations % 2 == 0, "test assumes even iteration count");
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""xor_bit"") (param $bit i32)
+                    i32.const 0
+                    local.get $bit
+                    i32.atomic.rmw.xor
+                    drop)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load))";
+            var (runtime, xorBit, read) = Build(src, "xor_bit", "read");
+
+            var barrier = new Barrier(ThreadCount);
+            var threads = new Thread[ThreadCount];
+            for (int t = 0; t < ThreadCount; t++)
+            {
+                int bit = 1 << t;
+                threads[t] = new Thread(() =>
+                {
+                    var inv = runtime.CreateStackInvoker(xorBit);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < Iterations; i++)
+                        inv(new Value[] { (Value)bit });
+                });
+            }
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+
+            Assert.Equal(0, ReadI32(runtime, read));
+        }
+
+        // ---- i32.atomic.rmw.xchg (result is one of the written values) ---
+
+        [Fact]
+        public void I32_rmw_xchg_final_is_one_of_written_values()
+        {
+            // Each thread writes its thread-id (1..N) repeatedly. Final
+            // value is whichever thread wrote last — always in [1, N].
+            // Pre-2c a torn struct write could produce a value outside the
+            // legal set; post-2c the lock serializes and tests should see
+            // only the written values.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""set"") (param $v i32)
+                    i32.const 0
+                    local.get $v
+                    i32.atomic.rmw.xchg
+                    drop)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load))";
+            var (runtime, set, read) = Build(src, "set", "read");
+
+            var barrier = new Barrier(ThreadCount);
+            var threads = new Thread[ThreadCount];
+            for (int t = 0; t < ThreadCount; t++)
+            {
+                int id = t + 1;
+                threads[t] = new Thread(() =>
+                {
+                    var inv = runtime.CreateStackInvoker(set);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < Iterations; i++)
+                        inv(new Value[] { (Value)id });
+                });
+            }
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+
+            int final = ReadI32(runtime, read);
+            Assert.InRange(final, 1, ThreadCount);
+        }
+
+        // ---- i32.atomic.rmw.cmpxchg (CAS-loop counter) ------------------
+
+        [Fact]
+        public void I32_rmw_cmpxchg_loop_sums_correctly()
+        {
+            // Each thread uses cmpxchg in a loop to atomically increment.
+            // Proves the cmpxchg round-trip (read expected → cas → retry)
+            // composes under ThreadCount-way contention.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""inc_cas"")
+                    (local $cur i32)
+                    (loop $retry
+                      ;; cur = atomic.load[0]
+                      i32.const 0
+                      i32.atomic.load
+                      local.set $cur
+
+                      ;; prev = cmpxchg(addr=0, expected=cur, replacement=cur+1)
+                      i32.const 0
+                      local.get $cur
+                      local.get $cur
+                      i32.const 1
+                      i32.add
+                      i32.atomic.rmw.cmpxchg
+
+                      ;; retry if prev != cur
+                      local.get $cur
+                      i32.ne
+                      br_if $retry))
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load))";
+            var (runtime, inc, read) = Build(src, "inc_cas", "read");
+
+            RunWriters(runtime, inc);
+            Assert.Equal(ThreadCount * Iterations, ReadI32(runtime, read));
+        }
+
+        // ---- i64.atomic.rmw.add -----------------------------------------
+
+        [Fact]
+        public void I64_rmw_add_is_commutative_under_contention()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""inc"")
+                    i32.const 0
+                    i64.const 1
+                    i64.atomic.rmw.add
+                    drop)
+                  (func (export ""read"") (result i64)
+                    i32.const 0
+                    i64.atomic.load))";
+            var (runtime, inc, read) = Build(src, "inc", "read");
+
+            RunWriters(runtime, inc);
+            Assert.Equal((long)ThreadCount * Iterations, ReadI64(runtime, read));
+        }
+
+        // ---- Subword: i32.atomic.rmw8.add_u (CAS-loop path) -------------
+
+        [Fact]
+        public void I32_rmw8_add_u_commutes_under_contention()
+        {
+            // Subword RMW goes through SubwordCas.Loop — a CAS loop on the
+            // enclosing 32-bit word. Modular arithmetic is the expectation:
+            // final = (threads × iters × delta) mod 256.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""inc"")
+                    i32.const 0
+                    i32.const 1
+                    i32.atomic.rmw8.add_u
+                    drop)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load8_u))";
+            var (runtime, inc, read) = Build(src, "inc", "read");
+
+            RunWriters(runtime, inc);
+            int expected = (ThreadCount * Iterations) & 0xFF;
+            Assert.Equal(expected, ReadI32(runtime, read));
+        }
+
+        // ---- Subword: i32.atomic.rmw16.add_u ----------------------------
+
+        [Fact]
+        public void I32_rmw16_add_u_commutes_under_contention()
+        {
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""inc"")
+                    i32.const 0
+                    i32.const 1
+                    i32.atomic.rmw16.add_u
+                    drop)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load16_u))";
+            var (runtime, inc, read) = Build(src, "inc", "read");
+
+            RunWriters(runtime, inc);
+            int expected = (ThreadCount * Iterations) & 0xFFFF;
+            Assert.Equal(expected, ReadI32(runtime, read));
+        }
+
+        // ---- shared helper ----------------------------------------------
+
+        private static void RunWriters(WasmRuntime runtime, FuncAddr addr)
+        {
+            var barrier = new Barrier(ThreadCount);
+            var threads = new Thread[ThreadCount];
+            for (int t = 0; t < ThreadCount; t++)
+            {
+                threads[t] = new Thread(() =>
+                {
+                    var inv = runtime.CreateStackInvoker(addr);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < Iterations; i++)
+                        inv(Array.Empty<Value>());
+                });
+            }
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+        }
+    }
+}

--- a/Wacs.Core.Test/ConcurrentInvokeTests.cs
+++ b/Wacs.Core.Test/ConcurrentInvokeTests.cs
@@ -117,6 +117,55 @@ namespace Wacs.Core.Test
         }
 
         [Fact]
+        public void Concurrent_atomic_rmw_on_shared_memory_sums_correctly()
+        {
+            // Each thread performs N atomic.add ops against the same cell.
+            // Final sum must equal threadCount * iterations * delta.
+            // Proves per-thread ExecContext (Layer 1c) + atomic RMW semantics
+            // (phase-1 atomics) compose correctly under real concurrency.
+            var src = @"
+                (module
+                  (memory (export ""m"") 1 1 shared)
+                  (func (export ""inc"") (param $delta i32) (result i32)
+                    i32.const 0
+                    local.get $delta
+                    i32.atomic.rmw.add)
+                  (func (export ""read"") (result i32)
+                    i32.const 0
+                    i32.atomic.load))";
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var incAddr = runtime.GetExportedFunction(("M", "inc"));
+            var readAddr = runtime.GetExportedFunction(("M", "read"));
+
+            const int threadCount = 8;
+            const int iterations = 1000;
+            const int delta = 3;
+            var barrier = new Barrier(threadCount);
+
+            var threads = new Thread[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                threads[t] = new Thread(() =>
+                {
+                    var invoker = runtime.CreateStackInvoker(incAddr);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < iterations; i++)
+                        invoker(new Value[] { (Value)delta });
+                });
+            }
+
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+
+            var reader = runtime.CreateStackInvoker(readAddr);
+            var finalSum = (int)reader(Array.Empty<Value>())[0];
+            Assert.Equal(threadCount * iterations * delta, finalSum);
+        }
+
+        [Fact]
         public async Task WasmThread_runs_entry_and_completes_task()
         {
             var runtime = new WasmRuntime();

--- a/Wacs.Core.Test/ConcurrentInvokeTests.cs
+++ b/Wacs.Core.Test/ConcurrentInvokeTests.cs
@@ -166,6 +166,168 @@ namespace Wacs.Core.Test
         }
 
         [Fact]
+        public void Concurrent_global_read_write_never_tears()
+        {
+            // i64 global backed by a shared-memory module → IsShared fires at
+            // instantiation (Layer 2b). Two distinctive 64-bit bit patterns are
+            // written in alternation. Readers assert every read equals one of
+            // those exact patterns — never a mix of bytes from each (which a
+            // pre-Layer-2c torn write could produce on platforms where the
+            // struct write is non-atomic).
+            var src = @"
+                (module
+                  (memory (export ""m"") 1 1 shared)
+                  (global $g (export ""g"") (mut i64) (i64.const 0))
+                  (func (export ""set_g"") (param $v i64)
+                    local.get $v
+                    global.set $g)
+                  (func (export ""get_g"") (result i64)
+                    global.get $g))";
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var setAddr = runtime.GetExportedFunction(("M", "set_g"));
+            var getAddr = runtime.GetExportedFunction(("M", "get_g"));
+
+            const long patternA = unchecked((long)0x0123456789ABCDEF);
+            const long patternB = unchecked((long)0xFEDCBA9876543210);
+            const int writerCount = 4;
+            const int readerCount = 4;
+            const int iterations = 5000;
+
+            var torn = 0;
+            var stop = false;
+            var barrier = new Barrier(writerCount + readerCount);
+
+            var threads = new Thread[writerCount + readerCount];
+            for (int w = 0; w < writerCount; w++)
+            {
+                int which = w;
+                threads[w] = new Thread(() =>
+                {
+                    var invoker = runtime.CreateStackInvoker(setAddr);
+                    long val = (which % 2 == 0) ? patternA : patternB;
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        invoker(new Value[] { (Value)val });
+                        val = val == patternA ? patternB : patternA;
+                    }
+                });
+            }
+            for (int r = 0; r < readerCount; r++)
+            {
+                threads[writerCount + r] = new Thread(() =>
+                {
+                    var invoker = runtime.CreateStackInvoker(getAddr);
+                    barrier.SignalAndWait();
+                    while (!Volatile.Read(ref stop))
+                    {
+                        var v = (long)invoker(Array.Empty<Value>())[0];
+                        if (v != patternA && v != patternB && v != 0)
+                            Interlocked.Increment(ref torn);
+                    }
+                });
+            }
+
+            foreach (var th in threads) th.Start();
+            // Let writers finish; then stop readers.
+            for (int w = 0; w < writerCount; w++) threads[w].Join();
+            Volatile.Write(ref stop, true);
+            for (int r = 0; r < readerCount; r++) threads[writerCount + r].Join();
+
+            Assert.Equal(0, torn);
+        }
+
+        [Fact]
+        public void Concurrent_table_grow_never_crashes()
+        {
+            // Multiple threads calling table.grow on the same shared table
+            // + other threads calling call_indirect into the stable prefix.
+            // Pre-Layer-2d, a reader hitting List<T>.Elements[i] during another
+            // thread's List<T>.Add-triggered internal resize could OOB or see
+            // stale backing. Post-2d, Grow pre-allocates capacity atomically
+            // and readers stay lock-free on valid indices.
+            var src = @"
+                (module
+                  (memory (export ""m"") 1 1 shared)
+                  (table (export ""t"") 4 funcref)
+                  (elem (i32.const 0) $fa $fb $fc $fd)
+                  (func $fa (result i32) i32.const 10)
+                  (func $fb (result i32) i32.const 20)
+                  (func $fc (result i32) i32.const 30)
+                  (func $fd (result i32) i32.const 40)
+                  (type $ret_i32 (func (result i32)))
+                  (func (export ""call_n"") (param $i i32) (result i32)
+                    local.get $i
+                    call_indirect (type $ret_i32))
+                  (func (export ""grow_one"") (result i32)
+                    ref.func $fa
+                    i32.const 1
+                    table.grow 0))";
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var callAddr = runtime.GetExportedFunction(("M", "call_n"));
+            var growAddr = runtime.GetExportedFunction(("M", "grow_one"));
+
+            const int growerCount = 4;
+            const int readerCount = 4;
+            const int iterations = 500;
+
+            var exceptions = 0;
+            var wrongResults = 0;
+            var stop = false;
+            var barrier = new Barrier(growerCount + readerCount);
+
+            var threads = new Thread[growerCount + readerCount];
+            for (int g = 0; g < growerCount; g++)
+            {
+                threads[g] = new Thread(() =>
+                {
+                    var invoker = runtime.CreateStackInvoker(growAddr);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        try { invoker(Array.Empty<Value>()); }
+                        catch { Interlocked.Increment(ref exceptions); }
+                    }
+                });
+            }
+            for (int r = 0; r < readerCount; r++)
+            {
+                int rid = r;
+                threads[growerCount + r] = new Thread(() =>
+                {
+                    var invoker = runtime.CreateStackInvoker(callAddr);
+                    barrier.SignalAndWait();
+                    int idx = rid & 3; // stable prefix: always one of fa/fb/fc/fd
+                    int[] expected = { 10, 20, 30, 40 };
+                    while (!Volatile.Read(ref stop))
+                    {
+                        try
+                        {
+                            var result = (int)invoker(new Value[] { (Value)idx })[0];
+                            if (result != expected[idx])
+                                Interlocked.Increment(ref wrongResults);
+                        }
+                        catch { Interlocked.Increment(ref exceptions); }
+                    }
+                });
+            }
+
+            foreach (var th in threads) th.Start();
+            for (int g = 0; g < growerCount; g++) threads[g].Join();
+            Volatile.Write(ref stop, true);
+            for (int r = 0; r < readerCount; r++) threads[growerCount + r].Join();
+
+            Assert.Equal(0, exceptions);
+            Assert.Equal(0, wrongResults);
+        }
+
+        [Fact]
         public async Task WasmThread_runs_entry_and_completes_task()
         {
             var runtime = new WasmRuntime();

--- a/Wacs.Core.Test/ConcurrentInvokeTests.cs
+++ b/Wacs.Core.Test/ConcurrentInvokeTests.cs
@@ -134,6 +134,63 @@ namespace Wacs.Core.Test
         }
 
         [Fact]
+        public async Task WasmThread_cancels_via_CancellationToken()
+        {
+            // Tight infinite loop calling a nop function. Cancellation is
+            // observed at function-call boundaries (Layer 1f), so the next
+            // `call $nop` after the CT fires produces an InterruptedException.
+            var src = @"
+                (module
+                  (func $nop)
+                  (func (export ""spin"")
+                    (loop $L
+                      call $nop
+                      br $L)))";
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", "spin"));
+
+            using var cts = new CancellationTokenSource();
+            var wt = runtime.ThreadHost.Spawn(addr, ReadOnlySpan<Value>.Empty, cts.Token);
+
+            // Let the thread enter its loop, then cancel.
+            await Task.Delay(50);
+            cts.Cancel();
+
+            var trap = await wt.Completion;
+            Assert.NotNull(trap);
+            Assert.Contains("interrupted", trap!.Message);
+        }
+
+        [Fact]
+        public async Task WasmThread_cancels_via_RequestTrap()
+        {
+            // Same loop, cancel via wasmThread.RequestTrap instead of CT.
+            var src = @"
+                (module
+                  (func $nop)
+                  (func (export ""spin"")
+                    (loop $L
+                      call $nop
+                      br $L)))";
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", "spin"));
+
+            var wt = runtime.ThreadHost.Spawn(addr, ReadOnlySpan<Value>.Empty);
+            await Task.Delay(50);
+            wt.RequestTrap("host-stop");
+
+            var trap = await wt.Completion;
+            Assert.NotNull(trap);
+            Assert.Contains("interrupted", trap!.Message);
+        }
+
+        [Fact]
         public async Task WasmThread_surfaces_trap_in_completion()
         {
             // Function that unconditionally traps via unreachable.

--- a/Wacs.Core.Test/ConcurrentInvokeTests.cs
+++ b/Wacs.Core.Test/ConcurrentInvokeTests.cs
@@ -1,0 +1,118 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// Regression gate for per-thread <see cref="ExecContext"/> (Layer 1c). Proves
+    /// that concurrent host threads invoking the same exported function against
+    /// the same <see cref="WasmRuntime"/> don't corrupt each other's operand
+    /// stack, frame pool, or call stack.
+    ///
+    /// <para>Pre-1c this test would race and either trap
+    /// (OpStack underflow / frame-pool exhaustion) or return wrong values. Post-1c
+    /// each host thread lazily gets its own ExecContext while sharing the
+    /// <see cref="SharedRuntimeState"/> (Store, linked instructions, attributes)
+    /// by reference.</para>
+    /// </summary>
+    public class ConcurrentInvokeTests
+    {
+        private const string PureAddWat = @"
+            (module
+              (func (export ""add"") (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                i32.add))";
+
+        [Fact]
+        public void Concurrent_invoke_of_pure_function_returns_correct_results()
+        {
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(PureAddWat);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", "add"));
+
+            const int threadCount = 8;
+            const int iterations = 1000;
+            var failures = 0;
+            var barrier = new Barrier(threadCount);
+
+            var threads = new Thread[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int threadId = t;
+                threads[t] = new Thread(() =>
+                {
+                    var invoker = runtime.CreateStackInvoker(addr);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        // Use thread-id-dependent inputs so interleaved corruption
+                        // produces wrong results, not just crashes.
+                        int a = threadId * 10000 + i;
+                        int b = threadId * 10000 + i + 1;
+                        var result = invoker(new Value[] { a, b });
+                        if ((int)result[0] != a + b)
+                            Interlocked.Increment(ref failures);
+                    }
+                });
+            }
+
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+
+            Assert.Equal(0, failures);
+        }
+
+        [Fact]
+        public void Concurrent_invoke_under_switch_runtime_returns_correct_results()
+        {
+            var runtime = new WasmRuntime();
+            runtime.UseSwitchRuntime = true;
+            var module = TextModuleParser.ParseWat(PureAddWat);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", "add"));
+
+            const int threadCount = 8;
+            const int iterations = 1000;
+            var failures = 0;
+            var barrier = new Barrier(threadCount);
+
+            var threads = new Thread[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int threadId = t;
+                threads[t] = new Thread(() =>
+                {
+                    var invoker = runtime.CreateStackInvoker(addr);
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        int a = threadId * 10000 + i;
+                        int b = threadId * 10000 + i + 1;
+                        var result = invoker(new Value[] { a, b });
+                        if ((int)result[0] != a + b)
+                            Interlocked.Increment(ref failures);
+                    }
+                });
+            }
+
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+
+            Assert.Equal(0, failures);
+        }
+    }
+}

--- a/Wacs.Core.Test/ConcurrentInvokeTests.cs
+++ b/Wacs.Core.Test/ConcurrentInvokeTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Concurrency;
 using Wacs.Core.Runtime.Types;
 using Wacs.Core.Text;
 using Xunit;
@@ -113,6 +114,43 @@ namespace Wacs.Core.Test
             foreach (var th in threads) th.Join();
 
             Assert.Equal(0, failures);
+        }
+
+        [Fact]
+        public async Task WasmThread_runs_entry_and_completes_task()
+        {
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(PureAddWat);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", "add"));
+
+            Value[] args = { (Value)7, (Value)35 };
+            var wt = runtime.ThreadHost.Spawn(addr, args);
+
+            var trap = await wt.Completion;
+            Assert.Null(trap);
+            Assert.True(wt.HostId > 0);
+        }
+
+        [Fact]
+        public async Task WasmThread_surfaces_trap_in_completion()
+        {
+            // Function that unconditionally traps via unreachable.
+            var src = @"
+                (module
+                  (func (export ""boom"")
+                    unreachable))";
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", "boom"));
+
+            var wt = runtime.ThreadHost.Spawn(addr, ReadOnlySpan<Value>.Empty);
+            var trap = await wt.Completion;
+
+            Assert.NotNull(trap);
         }
     }
 }

--- a/Wacs.Core.Test/ConcurrentWaitNotifyTests.cs
+++ b/Wacs.Core.Test/ConcurrentWaitNotifyTests.cs
@@ -1,0 +1,177 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// End-to-end wait/notify synchronization through the
+    /// <see cref="Wacs.Core.Runtime.Concurrency.HostDefinedPolicy"/>
+    /// (Layer 4b). Proves the default concurrency policy actually parks
+    /// a real host thread on <c>memory.atomic.wait32</c> and wakes it
+    /// on <c>memory.atomic.notify</c> — not just the mechanical atomic
+    /// RMW path.
+    /// </summary>
+    public class ConcurrentWaitNotifyTests
+    {
+        /// <summary>
+        /// Consumer wasm thread parks on wait32(signal, 0); producer on
+        /// main thread stores data + sets signal=1 + notify. Consumer
+        /// resumes, copies data into a result cell, exits. Main thread
+        /// awaits completion and reads the result.
+        ///
+        /// <para>Race-free by wait's atomic-check semantics: if notify
+        /// fires before consumer reaches wait, the in-wait check sees
+        /// signal != 0 and returns "not-equal" (2) immediately. Either
+        /// ordering converges on consumer reading the correct data.</para>
+        /// </summary>
+        [Fact]
+        public async Task Producer_notifies_consumer_waiting_on_shared_cell()
+        {
+            // Layout:
+            //   cell 0: signal (0=pending, 1=data-ready)
+            //   cell 4: data (producer's payload)
+            //   cell 8: consumer's observed result
+            var src = @"
+                (module
+                  (memory (export ""memory"") 1 1 shared)
+                  (func (export ""produce"") (param $payload i32)
+                    i32.const 4
+                    local.get $payload
+                    i32.atomic.store
+                    i32.const 0
+                    i32.const 1
+                    i32.atomic.store
+                    i32.const 0
+                    i32.const -1
+                    memory.atomic.notify
+                    drop)
+                  (func (export ""consume"")
+                    i32.const 0
+                    i32.const 0
+                    i64.const -1
+                    memory.atomic.wait32
+                    drop
+                    i32.const 8
+                    i32.const 4
+                    i32.atomic.load
+                    i32.atomic.store)
+                  (func (export ""read_result"") (result i32)
+                    i32.const 8
+                    i32.atomic.load))";
+
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var produceAddr = runtime.GetExportedFunction(("M", "produce"));
+            var consumeAddr = runtime.GetExportedFunction(("M", "consume"));
+            var readAddr = runtime.GetExportedFunction(("M", "read_result"));
+
+            // Spawn consumer — parks on wait32 against signal==0.
+            var consumer = runtime.ThreadHost.Spawn(consumeAddr, ReadOnlySpan<Value>.Empty);
+
+            // Give the consumer time to reach the wait state. Not required
+            // for correctness (wait's atomic check handles both orderings)
+            // but makes the "waiting thread actually got woken" code path
+            // the one under test most often.
+            await Task.Delay(50);
+
+            // Main thread fires the notify.
+            runtime.CreateStackInvoker(produceAddr)(new Value[] { (Value)42 });
+
+            // Consumer must complete within a reasonable deadline — failure
+            // here means notify never woke the waiter.
+            var trap = await consumer.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Null(trap);
+
+            Assert.Equal(42, (int)runtime.CreateStackInvoker(readAddr)(Array.Empty<Value>())[0]);
+        }
+
+        /// <summary>
+        /// Timeout path: no notifier. Consumer waits with a short timeout
+        /// and must return 1 (timed out). Proves
+        /// <c>HostDefinedPolicy.Wait32</c> respects the timeout, doesn't
+        /// park forever.
+        /// </summary>
+        [Fact]
+        public void Wait32_returns_timed_out_when_no_notifier()
+        {
+            // 10ms timeout (10,000,000 ns) on a cell whose current value
+            // matches the expected argument — wait blocks, then returns 1.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""wait_briefly"") (result i32)
+                    i32.const 0
+                    i32.const 0
+                    i64.const 10000000
+                    memory.atomic.wait32))";
+
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", "wait_briefly"));
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var result = (int)runtime.CreateStackInvoker(addr)(Array.Empty<Value>())[0];
+            sw.Stop();
+
+            Assert.Equal(1, result); // spec: 1 = timed-out
+            // Sanity on the timing — waited at least 8ms (10ms nominal, allow slack).
+            Assert.True(sw.ElapsedMilliseconds >= 8,
+                $"wait returned too fast ({sw.ElapsedMilliseconds}ms); expected ~10ms");
+        }
+
+        /// <summary>
+        /// Mismatched-expected path: wait32 returns 2 (not-equal) immediately
+        /// without parking when the cell's current value doesn't match the
+        /// expected argument. Proves the atomic check-before-park semantics.
+        /// </summary>
+        [Fact]
+        public void Wait32_returns_not_equal_when_cell_already_differs()
+        {
+            // Seed cell with 1; wait expects 0 → immediate return 2.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""seed"")
+                    i32.const 0
+                    i32.const 1
+                    i32.atomic.store)
+                  (func (export ""wait_expect_zero"") (result i32)
+                    i32.const 0
+                    i32.const 0
+                    i64.const -1
+                    memory.atomic.wait32))";
+
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var seed = runtime.GetExportedFunction(("M", "seed"));
+            var wait = runtime.GetExportedFunction(("M", "wait_expect_zero"));
+
+            runtime.CreateStackInvoker(seed)(Array.Empty<Value>());
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var result = (int)runtime.CreateStackInvoker(wait)(Array.Empty<Value>())[0];
+            sw.Stop();
+
+            Assert.Equal(2, result); // spec: 2 = not-equal
+            // Should return immediately — well under a second.
+            Assert.True(sw.ElapsedMilliseconds < 1000,
+                $"wait blocked despite not-equal precheck ({sw.ElapsedMilliseconds}ms)");
+        }
+    }
+}

--- a/Wacs.Core.Test/MultiRuntimeSoakTests.cs
+++ b/Wacs.Core.Test/MultiRuntimeSoakTests.cs
@@ -1,0 +1,114 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Wacs.WASI.Threads;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// Multi-runtime soak (Layer 4c). Creates many
+    /// <see cref="WasmRuntime"/> instances sequentially, each running a
+    /// small wasi-threads workload, then lets them fall out of scope.
+    /// Regression gate for the class of resource-accumulation bug that
+    /// crashed the .NET test host in Layer 1c's original
+    /// <c>ThreadLocal&lt;ExecContext&gt;</c> implementation after ~20-30
+    /// spec-test runtimes. Post-fix (swap to
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
+    /// keyed by ManagedThreadId), many hundreds of runtimes survive with
+    /// zero residue.
+    /// </summary>
+    public class MultiRuntimeSoakTests
+    {
+        private const int RuntimeCount = 60;
+        private const int WorkersPerRuntime = 4;
+
+        private const string SoakModule = @"
+            (module
+              (import ""wasi"" ""thread-spawn"" (func $spawn (param i32) (result i32)))
+              (memory (export ""memory"") 1 1 shared)
+              (func (export ""wasi_thread_start"") (param $tid i32) (param $start_arg i32)
+                i32.const 0
+                i32.const 1
+                i32.atomic.rmw.add
+                drop)
+              (func (export ""spawn_n"") (param $n i32) (result i32)
+                (local $i i32) (local $fail i32)
+                (loop $L
+                  (if (i32.lt_s (local.get $i) (local.get $n))
+                    (then
+                      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                      (if (i32.lt_s (call $spawn (i32.const 0)) (i32.const 1))
+                        (then (local.set $fail (i32.add (local.get $fail) (i32.const 1)))))
+                      (br $L))))
+                (local.get $fail))
+              (func (export ""read"") (result i32)
+                i32.const 0
+                i32.atomic.load))";
+
+        [Fact]
+        public void Many_runtimes_in_sequence_do_not_accumulate_resources()
+        {
+            var sw = Stopwatch.StartNew();
+
+            for (int iter = 0; iter < RuntimeCount; iter++)
+            {
+                RunOne(iter);
+
+                // Force collection every 10 iterations so any leak
+                // accumulation surfaces within the loop rather than at the
+                // end. Not required for correctness — just tightens the
+                // regression window.
+                if ((iter + 1) % 10 == 0)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                }
+            }
+
+            sw.Stop();
+            // Loose wall-clock sanity: 60 × (spawn 4 workers + 4 atomic adds
+            // + read) should fit comfortably under 30s. A runaway here
+            // usually means the prior runtime's ExecContexts are still
+            // being held and the GC is under pressure.
+            Assert.True(sw.ElapsedMilliseconds < 30_000,
+                $"soak took {sw.ElapsedMilliseconds}ms — suspect resource accumulation");
+        }
+
+        private static void RunOne(int iter)
+        {
+            var runtime = new WasmRuntime();
+            new WasiThreads().BindToRuntime(runtime);
+
+            var module = TextModuleParser.ParseWat(SoakModule);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+
+            var spawnAddr = runtime.GetExportedFunction(("M", "spawn_n"));
+            var readAddr = runtime.GetExportedFunction(("M", "read"));
+
+            var failures = (int)runtime.CreateStackInvoker(spawnAddr)(new Value[] { (Value)WorkersPerRuntime })[0];
+            Assert.True(failures == 0, $"iter {iter}: {failures} spawn failures");
+
+            // Poll for every worker's increment to land.
+            var deadline = Stopwatch.StartNew();
+            int final = 0;
+            while (deadline.ElapsedMilliseconds < 2000)
+            {
+                final = (int)runtime.CreateStackInvoker(readAddr)(Array.Empty<Value>())[0];
+                if (final == WorkersPerRuntime) break;
+                Thread.Sleep(5);
+            }
+            Assert.True(final == WorkersPerRuntime,
+                $"iter {iter}: expected {WorkersPerRuntime}, got {final}");
+        }
+    }
+}

--- a/Wacs.Core.Test/SharedEverythingTests.cs
+++ b/Wacs.Core.Test/SharedEverythingTests.cs
@@ -1,0 +1,191 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// Regression gate for the shared-everything-threads foundation
+    /// subset (Layer 5). Covers feature-flag gating, shared-global
+    /// concurrent semantics, and thread-local global per-thread scoping.
+    /// Instructions (<c>global.atomic.*</c>, <c>pause</c>) are deferred
+    /// until the proposal assigns canonical opcode bytes, so those
+    /// subphases are not tested here.
+    /// </summary>
+    public class SharedEverythingTests
+    {
+        // ---- 5f: feature-flag enforcement -------------------------------
+
+        [Fact]
+        public void Shared_global_rejected_without_feature_flag()
+        {
+            var src = @"
+                (module
+                  (global (shared) (mut i64) (i64.const 0)))";
+
+            var runtime = new WasmRuntime(new RuntimeAttributes
+            {
+                EnableSharedEverythingThreads = false,
+            });
+            var module = TextModuleParser.ParseWat(src);
+
+            Assert.Throws<NotSupportedException>(() => runtime.InstantiateModule(module));
+        }
+
+        [Fact]
+        public void Thread_local_global_rejected_without_feature_flag()
+        {
+            var src = @"
+                (module
+                  (global (thread_local) (mut i32) (i32.const 0)))";
+
+            var runtime = new WasmRuntime(new RuntimeAttributes
+            {
+                EnableSharedEverythingThreads = false,
+            });
+            var module = TextModuleParser.ParseWat(src);
+
+            Assert.Throws<NotSupportedException>(() => runtime.InstantiateModule(module));
+        }
+
+        // ---- 5a: shared globals under contention ------------------------
+
+        [Fact]
+        public void Shared_global_serializes_concurrent_reads_and_writes()
+        {
+            // Two distinctive 64-bit patterns alternated by writers; readers
+            // must never observe a torn mix. Post-Layer-2c the per-instance
+            // lock serializes struct assignments; Layer 5a now drives
+            // IsShared from the per-declaration flag rather than the
+            // module-has-shared-memory approximation.
+            var src = @"
+                (module
+                  (global $g (export ""g"") (shared) (mut i64) (i64.const 0))
+                  (func (export ""set"") (param $v i64)
+                    local.get $v
+                    global.set $g)
+                  (func (export ""get"") (result i64)
+                    global.get $g))";
+
+            var runtime = new WasmRuntime(new RuntimeAttributes
+            {
+                EnableSharedEverythingThreads = true,
+            });
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var setAddr = runtime.GetExportedFunction(("M", "set"));
+            var getAddr = runtime.GetExportedFunction(("M", "get"));
+
+            // Verify the global actually landed as IsShared.
+            var gAddr = ((ExternalValue.Global)inst.Exports[0].Value).Address;
+            Assert.True(runtime.RuntimeStore[gAddr].IsShared);
+
+            const long patternA = unchecked((long)0x0123456789ABCDEF);
+            const long patternB = unchecked((long)0xFEDCBA9876543210);
+            const int iters = 3000;
+            var torn = 0;
+            var stop = false;
+            var barrier = new Barrier(3); // 2 writers + 1 reader
+
+            var writerA = new Thread(() =>
+            {
+                var inv = runtime.CreateStackInvoker(setAddr);
+                barrier.SignalAndWait();
+                for (int i = 0; i < iters; i++) inv(new Value[] { (Value)patternA });
+            });
+            var writerB = new Thread(() =>
+            {
+                var inv = runtime.CreateStackInvoker(setAddr);
+                barrier.SignalAndWait();
+                for (int i = 0; i < iters; i++) inv(new Value[] { (Value)patternB });
+            });
+            var reader = new Thread(() =>
+            {
+                var inv = runtime.CreateStackInvoker(getAddr);
+                barrier.SignalAndWait();
+                while (!Volatile.Read(ref stop))
+                {
+                    var v = (long)inv(Array.Empty<Value>())[0];
+                    if (v != 0 && v != patternA && v != patternB)
+                        Interlocked.Increment(ref torn);
+                }
+            });
+
+            writerA.Start(); writerB.Start(); reader.Start();
+            writerA.Join(); writerB.Join();
+            Volatile.Write(ref stop, true);
+            reader.Join();
+
+            Assert.Equal(0, torn);
+        }
+
+        // ---- 5c: thread-local globals -----------------------------------
+
+        [Fact]
+        public void Thread_local_global_stores_are_per_thread()
+        {
+            // Each thread writes its own thread-id into the TL global, reads
+            // it back, and checks it matches. Main thread writes 0 (the
+            // initial value from the declarator), then asserts its own read
+            // returns 0 after worker threads finish — writes in other
+            // threads' slots must not leak.
+            var src = @"
+                (module
+                  (global $t (export ""t"") (thread_local) (mut i32) (i32.const 0))
+                  (func (export ""set_t"") (param $v i32)
+                    local.get $v
+                    global.set $t)
+                  (func (export ""get_t"") (result i32)
+                    global.get $t))";
+
+            var runtime = new WasmRuntime(new RuntimeAttributes
+            {
+                EnableSharedEverythingThreads = true,
+            });
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            var setAddr = runtime.GetExportedFunction(("M", "set_t"));
+            var getAddr = runtime.GetExportedFunction(("M", "get_t"));
+
+            // Main thread's TL slot defaults to the declared initializer (0).
+            var mainGet = runtime.CreateStackInvoker(getAddr);
+            Assert.Equal(0, (int)mainGet(Array.Empty<Value>())[0]);
+
+            const int threadCount = 8;
+            var mismatches = 0;
+            var threads = new Thread[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int value = 100 + t;
+                threads[t] = new Thread(() =>
+                {
+                    var set = runtime.CreateStackInvoker(setAddr);
+                    var get = runtime.CreateStackInvoker(getAddr);
+                    // Write, read back — expect exactly my value, not 0 and
+                    // not any other thread's value.
+                    set(new Value[] { (Value)value });
+                    var read = (int)get(Array.Empty<Value>())[0];
+                    if (read != value) Interlocked.Increment(ref mismatches);
+                });
+            }
+            foreach (var th in threads) th.Start();
+            foreach (var th in threads) th.Join();
+
+            Assert.Equal(0, mismatches);
+
+            // Main thread's TL slot must still be 0 — worker writes don't
+            // leak across thread slots.
+            Assert.Equal(0, (int)mainGet(Array.Empty<Value>())[0]);
+        }
+    }
+}

--- a/Wacs.Core.Test/Wacs.Core.Test.csproj
+++ b/Wacs.Core.Test/Wacs.Core.Test.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Wacs.Core\Wacs.Core.csproj" />
+      <ProjectReference Include="..\Wacs.WASI.Threads\Wacs.WASI.Threads.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Wacs.Core.Test/WasiThreadsTests.cs
+++ b/Wacs.Core.Test/WasiThreadsTests.cs
@@ -1,0 +1,121 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Wacs.WASI.Threads;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// End-to-end regression for the wasi-threads adapter (Layer 3). A wasm
+    /// module imports <c>wasi:thread-spawn</c> and spawns N worker threads that
+    /// each perform an atomic RMW on shared memory. The test waits for every
+    /// worker's contribution to land in the counter and asserts the final
+    /// value matches the expected sum — which passes only if all layers of
+    /// the stack compose correctly:
+    /// <list type="bullet">
+    /// <item>Layer 1c/1d: per-thread ExecContext + ThreadBasedHost spawn real Threads</item>
+    /// <item>Layer 2b-2d: IsShared flips for globals/tables in modules with shared memory</item>
+    /// <item>Layer 3: WasiThreads host import wires spawn to IWasmThreadHost</item>
+    /// <item>Phase-1 threads atomics: i32.atomic.rmw.add is actually atomic across those threads</item>
+    /// </list>
+    /// </summary>
+    public class WasiThreadsTests
+    {
+        private const string SpawnModule = @"
+            (module
+              (import ""wasi"" ""thread-spawn"" (func $spawn (param i32) (result i32)))
+              (memory (export ""memory"") 1 1 shared)
+              (func $wasi_thread_start (export ""wasi_thread_start"")
+                (param $tid i32) (param $start_arg i32)
+                i32.const 0
+                i32.const 1
+                i32.atomic.rmw.add
+                drop)
+              (func (export ""spawn_workers"") (param $n i32) (result i32)
+                (local $i i32) (local $fail i32)
+                (local.set $i (i32.const 0))
+                (local.set $fail (i32.const 0))
+                (loop $L
+                  (if (i32.lt_s (local.get $i) (local.get $n))
+                    (then
+                      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                      (if (i32.lt_s (call $spawn (i32.const 0)) (i32.const 1))
+                        (then (local.set $fail (i32.add (local.get $fail) (i32.const 1)))))
+                      (br $L))))
+                (local.get $fail))
+              (func (export ""read"") (result i32)
+                i32.const 0
+                i32.atomic.load))";
+
+        [Fact]
+        public void Spawn_workers_each_increment_shared_counter()
+        {
+            const int workerCount = 16;
+
+            var runtime = new WasmRuntime();
+            new WasiThreads().BindToRuntime(runtime);
+
+            var module = TextModuleParser.ParseWat(SpawnModule);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+
+            var spawnAddr = runtime.GetExportedFunction(("M", "spawn_workers"));
+            var readAddr = runtime.GetExportedFunction(("M", "read"));
+
+            var spawnInvoker = runtime.CreateStackInvoker(spawnAddr);
+            var readInvoker = runtime.CreateStackInvoker(readAddr);
+
+            var failures = (int)spawnInvoker(new Value[] { (Value)workerCount })[0];
+            Assert.Equal(0, failures);
+
+            // Spin until every worker has contributed its increment. The
+            // atomic RMW on shared memory is the synchronization point;
+            // nothing else in the test observes thread completion.
+            var deadline = Stopwatch.StartNew();
+            int final = 0;
+            while (deadline.ElapsedMilliseconds < 5000)
+            {
+                final = (int)readInvoker(Array.Empty<Value>())[0];
+                if (final == workerCount) break;
+                Thread.Sleep(10);
+            }
+            Assert.Equal(workerCount, final);
+        }
+
+        [Fact]
+        public void Spawn_with_no_thread_start_export_returns_error()
+        {
+            // Module imports thread-spawn but omits the wasi_thread_start
+            // export the spec requires. The adapter must surface a negative
+            // return value rather than crashing.
+            var src = @"
+                (module
+                  (import ""wasi"" ""thread-spawn"" (func $spawn (param i32) (result i32)))
+                  (memory 1 1 shared)
+                  (func (export ""try_spawn"") (result i32)
+                    i32.const 0
+                    call $spawn))";
+
+            var runtime = new WasmRuntime();
+            new WasiThreads().BindToRuntime(runtime);
+
+            var module = TextModuleParser.ParseWat(src);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+
+            var addr = runtime.GetExportedFunction(("M", "try_spawn"));
+            var result = (int)runtime.CreateStackInvoker(addr)(Array.Empty<Value>())[0];
+
+            Assert.True(result < 0, $"expected negative tid, got {result}");
+        }
+    }
+}

--- a/Wacs.Core/Instructions/Control.cs
+++ b/Wacs.Core/Instructions/Control.cs
@@ -466,8 +466,6 @@ namespace Wacs.Core.Instructions
     {
         public InstBranch() : base(ByteCode.Br) { }
 
-        private static Stack<Value> _asideVals = new();
-
         private LabelIdx L;
         // Populated by Link() with the resolved block this branch targets. Consumed by
         // Wacs.Core.Compilation.BytecodeCompiler when emitting the annotated-stream form.
@@ -527,8 +525,6 @@ namespace Wacs.Core.Instructions
             
             context.Assert( context.OpStack.Count >= label.Arity,
                 $"Instruction br failed. Not enough values on the stack.");
-            context.Assert(_asideVals.Count == 0,
-                "Shared temporary stack had values left in it.");
             
             int targetStackHeight = label.StackHeight + label.Arity;
             if (label != context.Frame.ReturnLabel)

--- a/Wacs.Core/Instructions/GlobalVariable.cs
+++ b/Wacs.Core/Instructions/GlobalVariable.cs
@@ -121,7 +121,14 @@ namespace Wacs.Core.Instructions
             //5.
             var glob = context.Store[a];
             //6.
-            var val = glob.Value;
+            // Layer 5c: thread-local globals route through the per-thread
+            // ExecContext slot; initial value comes from the module's
+            // declared initializer (stored in glob.Value, unchanged across
+            // threads). Shared / unshared globals use the instance's
+            // Value field directly.
+            var val = glob.IsThreadLocal
+                ? context.GetThreadLocalGlobalValue(a, glob.Value)
+                : glob.Value;
             //7.
             return val;
         }
@@ -211,9 +218,19 @@ namespace Wacs.Core.Instructions
                 $"Runtime Store did not contain Global at address {a} in global.set");
             //5.
             var glob = context.Store[a];
-            
+
             //8.
-            glob.Value = value;
+            // Layer 5c: thread-local writes stay in the per-thread slot;
+            // the instance's Value field keeps the initializer for other
+            // threads' future first-access.
+            if (glob.IsThreadLocal)
+            {
+                context.SetThreadLocalGlobalValue(a, value);
+            }
+            else
+            {
+                glob.Value = value;
+            }
         }
     }
     

--- a/Wacs.Core/Instructions/VariableHandlers.cs
+++ b/Wacs.Core/Instructions/VariableHandlers.cs
@@ -45,7 +45,12 @@ namespace Wacs.Core.Instructions
         private static void GlobalGet(ExecContext ctx, [Imm] uint idx)
         {
             var addr = ctx.Frame.Module.GlobalAddrs[(GlobalIdx)idx];
-            ctx.OpStack.PushValue(ctx.Store[addr].Value);
+            var glob = ctx.Store[addr];
+            // Layer 5c: thread-local globals route through the per-thread slot.
+            var val = glob.IsThreadLocal
+                ? ctx.GetThreadLocalGlobalValue(addr, glob.Value)
+                : glob.Value;
+            ctx.OpStack.PushValue(val);
         }
 
         // 0x24 global.set — stream: [u32 global index]; pops one value.
@@ -53,7 +58,15 @@ namespace Wacs.Core.Instructions
         private static void GlobalSet(ExecContext ctx, [Imm] uint idx, Value v)
         {
             var addr = ctx.Frame.Module.GlobalAddrs[(GlobalIdx)idx];
-            ctx.Store[addr].Value = v;
+            var glob = ctx.Store[addr];
+            if (glob.IsThreadLocal)
+            {
+                ctx.SetThreadLocalGlobalValue(addr, v);
+            }
+            else
+            {
+                glob.Value = v;
+            }
         }
     }
 }

--- a/Wacs.Core/Runtime/Concurrency/IConcurrencyPolicy.cs
+++ b/Wacs.Core/Runtime/Concurrency/IConcurrencyPolicy.cs
@@ -6,6 +6,8 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Threading;
+using System.Threading.Tasks;
 using Wacs.Core.Runtime.Types;
 
 namespace Wacs.Core.Runtime.Concurrency
@@ -53,5 +55,44 @@ namespace Wacs.Core.Runtime.Concurrency
         /// woken.
         /// </summary>
         int Notify(MemoryInstance mem, long addr, int maxWaiters);
+
+        // ----- Async surface (Layer 1e) -----
+        //
+        // Default-implemented async variants wrap the synchronous ones on the
+        // calling thread. They exist so a future policy implementation can
+        // override them with a truly-yielding async wait — letting a wasm thread
+        // blocked on atomic.wait release its host thread back to the pool and
+        // resume on a different thread when notified. ExecContext is movable
+        // across host threads (nothing stack-allocated), so this is a real option.
+        //
+        // Layer 1 ships only the surface; no async implementation is wired yet.
+        // Introducing the interface now keeps later additions purely additive —
+        // existing implementations (NotSupportedPolicy, HostDefinedPolicy) get
+        // the default wrapper for free.
+
+        /// <summary>
+        /// Async counterpart to <see cref="Wait32"/>. Default implementation
+        /// calls the synchronous version on the calling thread. Override for a
+        /// truly-yielding implementation.
+        /// </summary>
+        ValueTask<int> Wait32Async(MemoryInstance mem, long addr, int expected,
+            long timeoutNs, CancellationToken ct = default)
+            => new ValueTask<int>(Wait32(mem, addr, expected, timeoutNs));
+
+        /// <summary>
+        /// Async counterpart to <see cref="Wait64"/>. Default implementation
+        /// calls the synchronous version on the calling thread.
+        /// </summary>
+        ValueTask<int> Wait64Async(MemoryInstance mem, long addr, long expected,
+            long timeoutNs, CancellationToken ct = default)
+            => new ValueTask<int>(Wait64(mem, addr, expected, timeoutNs));
+
+        /// <summary>
+        /// Async counterpart to <see cref="Notify"/>. Default implementation
+        /// calls the synchronous version on the calling thread.
+        /// </summary>
+        ValueTask<int> NotifyAsync(MemoryInstance mem, long addr, int maxWaiters,
+            CancellationToken ct = default)
+            => new ValueTask<int>(Notify(mem, addr, maxWaiters));
     }
 }

--- a/Wacs.Core/Runtime/Concurrency/IWasmThreadHost.cs
+++ b/Wacs.Core/Runtime/Concurrency/IWasmThreadHost.cs
@@ -1,0 +1,40 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Runtime.Concurrency
+{
+    /// <summary>
+    /// Core primitive for spawning wasm-level threads. Both wasi-threads (a thin host
+    /// import adapter) and shared-everything's future <c>thread.spawn</c> instruction
+    /// dispatch to one of these — the host-import layer and the instruction layer
+    /// remain two clients of the same core, which is what makes the transition from
+    /// wasi-threads to shared-everything purely additive.
+    ///
+    /// <para>Layer 1d introduces the interface; the default <see cref="ThreadBasedHost"/>
+    /// creates a real <see cref="System.Threading.Thread"/> per spawn. Shared state
+    /// (linear memory, tables, globals) is shared by reference through the runtime's
+    /// <see cref="SharedRuntimeState"/>; each spawned thread gets its own ExecContext
+    /// via the runtime's ThreadLocal (Layer 1c).</para>
+    /// </summary>
+    public interface IWasmThreadHost
+    {
+        /// <summary>
+        /// Spawn a wasm function on a new host thread. The caller passes
+        /// <paramref name="args"/> as a ReadOnlySpan; the implementation must copy
+        /// the values into its own storage before the call returns — the underlying
+        /// span must not outlive this method.
+        ///
+        /// <para>The <paramref name="ct"/> token lets the host cancel the spawned
+        /// thread cooperatively; the running thread observes the token at call
+        /// boundaries and traps with <c>TrapException("cancelled")</c> on
+        /// cancellation (Layer 1f wires this into the invoke loop).</para>
+        /// </summary>
+        WasmThread Spawn(FuncAddr entry, ReadOnlySpan<Value> args, CancellationToken ct = default);
+    }
+}

--- a/Wacs.Core/Runtime/Concurrency/ThreadBasedHost.cs
+++ b/Wacs.Core/Runtime/Concurrency/ThreadBasedHost.cs
@@ -49,18 +49,19 @@ namespace Wacs.Core.Runtime.Concurrency
             // the span may live on the stack and won't survive this method's return.
             var argArray = args.ToArray();
 
-            var thread = new WasmThread(Interlocked.Increment(ref _nextHostId));
-
-            // Hook CancellationToken to the cooperative-trap mechanism. The invoke
-            // loop in Layer 1f observes TrapReason at call boundaries.
-            CancellationTokenRegistration reg = default;
-            if (ct.CanBeCanceled)
-                reg = ct.Register(() => thread.RequestTrap("cancelled"));
+            var thread = new WasmThread(Interlocked.Increment(ref _nextHostId), ct);
 
             var t = new Thread(() =>
             {
                 try
                 {
+                    // Bind the CT to the per-thread ExecContext (Layer 1c) before
+                    // invoking. The invoke loop observes ctx.Ct at call boundaries
+                    // and traps with InterruptedException on cancellation.
+                    var ctx = _runtime.ExecContext;
+                    ctx.Ct = thread.CancellationToken;
+                    ctx.InterruptReason = thread.TrapReason;
+
                     var invoker = _runtime.CreateStackInvoker(entry);
                     _ = invoker(argArray);
                     thread.Complete(null);
@@ -72,10 +73,6 @@ namespace Wacs.Core.Runtime.Concurrency
                 catch (Exception exc)
                 {
                     thread.Fault(exc);
-                }
-                finally
-                {
-                    reg.Dispose();
                 }
             })
             {

--- a/Wacs.Core/Runtime/Concurrency/ThreadBasedHost.cs
+++ b/Wacs.Core/Runtime/Concurrency/ThreadBasedHost.cs
@@ -1,0 +1,89 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Runtime.Concurrency
+{
+    /// <summary>
+    /// Default <see cref="IWasmThreadHost"/> — spawns a dedicated
+    /// <see cref="System.Threading.Thread"/> per call. Uses <see cref="Thread"/>
+    /// rather than <see cref="System.Threading.Tasks.Task.Run(Action)"/> for two
+    /// reasons:
+    /// <list type="bullet">
+    /// <item><description>
+    /// wasm threads may block on <c>atomic.wait</c> for long durations; running them
+    /// on the thread pool would exhaust it under even moderate wasm-thread counts.
+    /// </description></item>
+    /// <item><description>
+    /// <c>Task.Run</c> can capture a <see cref="SynchronizationContext"/> (e.g. ASP.NET
+    /// request context, Unity main-thread context). Wasm threads must not marshal
+    /// continuations back to the main thread — Unity especially.
+    /// </description></item>
+    /// </list>
+    ///
+    /// <para>Each spawned <see cref="WasmThread"/> is associated with a fresh
+    /// <see cref="ExecContext"/> via the runtime's ThreadLocal (Layer 1c) —
+    /// the host creates the thread, the first <c>CreateInvoker</c> / <c>invoke</c>
+    /// call on that thread lazily provisions its ExecContext, and all shared state
+    /// (Store, linked ops, memory/table/globals) is shared by reference through
+    /// <see cref="SharedRuntimeState"/>.</para>
+    /// </summary>
+    public sealed class ThreadBasedHost : IWasmThreadHost
+    {
+        private readonly WasmRuntime _runtime;
+        private int _nextHostId;
+
+        public ThreadBasedHost(WasmRuntime runtime)
+        {
+            _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        }
+
+        public WasmThread Spawn(FuncAddr entry, ReadOnlySpan<Value> args, CancellationToken ct = default)
+        {
+            // Copy args off the caller's span before yielding to the new thread —
+            // the span may live on the stack and won't survive this method's return.
+            var argArray = args.ToArray();
+
+            var thread = new WasmThread(Interlocked.Increment(ref _nextHostId));
+
+            // Hook CancellationToken to the cooperative-trap mechanism. The invoke
+            // loop in Layer 1f observes TrapReason at call boundaries.
+            CancellationTokenRegistration reg = default;
+            if (ct.CanBeCanceled)
+                reg = ct.Register(() => thread.RequestTrap("cancelled"));
+
+            var t = new Thread(() =>
+            {
+                try
+                {
+                    var invoker = _runtime.CreateStackInvoker(entry);
+                    _ = invoker(argArray);
+                    thread.Complete(null);
+                }
+                catch (TrapException trap)
+                {
+                    thread.Complete(trap);
+                }
+                catch (Exception exc)
+                {
+                    thread.Fault(exc);
+                }
+                finally
+                {
+                    reg.Dispose();
+                }
+            })
+            {
+                IsBackground = true,
+                Name = $"WasmThread#{thread.HostId}",
+            };
+            t.Start();
+            return thread;
+        }
+    }
+}

--- a/Wacs.Core/Runtime/Concurrency/WasmThread.cs
+++ b/Wacs.Core/Runtime/Concurrency/WasmThread.cs
@@ -31,6 +31,7 @@ namespace Wacs.Core.Runtime.Concurrency
     {
         private readonly TaskCompletionSource<TrapException?> _tcs =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly CancellationTokenSource _cts;
         private volatile string? _trapReason;
 
         public int HostId { get; }
@@ -38,30 +39,57 @@ namespace Wacs.Core.Runtime.Concurrency
         /// <summary>
         /// Completes when the thread exits. The result is <c>null</c> for a clean
         /// return, a <see cref="TrapException"/> for a wasm-level trap (including
-        /// traps requested via <see cref="RequestTrap"/> or CancellationToken).
-        /// A non-trap host exception surfaces as a faulted task.
+        /// traps requested via <see cref="RequestTrap"/> or external
+        /// CancellationToken). A non-trap host exception surfaces as a faulted task.
         /// </summary>
         public Task<TrapException?> Completion => _tcs.Task;
 
-        internal WasmThread(int hostId)
+        /// <summary>
+        /// Combined cancellation signal for the thread — fires on either
+        /// <see cref="RequestTrap"/> or the external CancellationToken passed to
+        /// <see cref="IWasmThreadHost.Spawn"/>. The invoke loop (Layer 1f)
+        /// observes this at call boundaries and traps.
+        /// </summary>
+        internal CancellationToken CancellationToken => _cts.Token;
+
+        /// <summary>Reason string for <see cref="InterruptedException"/>. Set by
+        /// either <see cref="RequestTrap"/> or the external CT firing.</summary>
+        internal string TrapReason => _trapReason ?? "cancelled";
+
+        internal WasmThread(int hostId, CancellationToken externalCt)
         {
             HostId = hostId;
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
+            if (externalCt.CanBeCanceled)
+            {
+                // If the external CT fires, stamp a reason so traps surface as
+                // "cancelled" rather than the empty default. The linked CTS
+                // already forwards the cancellation signal itself.
+                externalCt.Register(() => _trapReason ??= "cancelled");
+            }
         }
 
         /// <summary>
-        /// Request cooperative termination. The running thread will trap at the next
-        /// instruction boundary check (Layer 1f wires the invoke loop to observe
-        /// this). Safe to call from any thread.
+        /// Request cooperative termination. The running thread traps at the next
+        /// instruction-boundary check (Layer 1f wires the invoke loop to observe
+        /// the linked CancellationToken). Safe to call from any thread.
         /// </summary>
         public void RequestTrap(string reason)
         {
             _trapReason = reason ?? "WasmThread.RequestTrap";
+            try { _cts.Cancel(); } catch (ObjectDisposedException) { /* already completed */ }
         }
 
-        /// <summary>Non-null when <see cref="RequestTrap"/> or a CancellationToken has fired.</summary>
-        internal string? TrapReason => _trapReason;
+        internal void Complete(TrapException? trap)
+        {
+            _tcs.TrySetResult(trap);
+            _cts.Dispose();
+        }
 
-        internal void Complete(TrapException? trap) => _tcs.TrySetResult(trap);
-        internal void Fault(Exception exc) => _tcs.TrySetException(exc);
+        internal void Fault(Exception exc)
+        {
+            _tcs.TrySetException(exc);
+            _cts.Dispose();
+        }
     }
 }

--- a/Wacs.Core/Runtime/Concurrency/WasmThread.cs
+++ b/Wacs.Core/Runtime/Concurrency/WasmThread.cs
@@ -1,0 +1,67 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Runtime.Concurrency
+{
+    /// <summary>
+    /// Handle to a wasm-level thread spawned via <see cref="IWasmThreadHost.Spawn"/>.
+    /// Task-based completion lets callers <c>await</c> the thread, compose with
+    /// other asynchronous work, and observe traps/cancellation uniformly.
+    ///
+    /// <para>The underlying execution runs to completion on a dedicated host
+    /// <see cref="System.Threading.Thread"/> (no <see cref="SynchronizationContext"/>
+    /// capture, no thread-pool contention with other async work). Layer 1 only wires
+    /// the sync path; future layers can add async <c>atomic.wait</c> yielding on top
+    /// without changing this surface — the ExecContext is movable across host
+    /// threads (all state on the managed heap, nothing stack-allocated).</para>
+    ///
+    /// <para>Forward-compatible with both wasi-threads (thin adapter owns positive-i32
+    /// tid allocation and <c>wasi_thread_start</c> wiring) and shared-everything's
+    /// future <c>thread.spawn</c> instruction (handlers dispatch to the same
+    /// <see cref="IWasmThreadHost"/>).</para>
+    /// </summary>
+    public sealed class WasmThread
+    {
+        private readonly TaskCompletionSource<TrapException?> _tcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private volatile string? _trapReason;
+
+        public int HostId { get; }
+
+        /// <summary>
+        /// Completes when the thread exits. The result is <c>null</c> for a clean
+        /// return, a <see cref="TrapException"/> for a wasm-level trap (including
+        /// traps requested via <see cref="RequestTrap"/> or CancellationToken).
+        /// A non-trap host exception surfaces as a faulted task.
+        /// </summary>
+        public Task<TrapException?> Completion => _tcs.Task;
+
+        internal WasmThread(int hostId)
+        {
+            HostId = hostId;
+        }
+
+        /// <summary>
+        /// Request cooperative termination. The running thread will trap at the next
+        /// instruction boundary check (Layer 1f wires the invoke loop to observe
+        /// this). Safe to call from any thread.
+        /// </summary>
+        public void RequestTrap(string reason)
+        {
+            _trapReason = reason ?? "WasmThread.RequestTrap";
+        }
+
+        /// <summary>Non-null when <see cref="RequestTrap"/> or a CancellationToken has fired.</summary>
+        internal string? TrapReason => _trapReason;
+
+        internal void Complete(TrapException? trap) => _tcs.TrySetResult(trap);
+        internal void Fault(Exception exc) => _tcs.TrySetException(exc);
+    }
+}

--- a/Wacs.Core/Runtime/Exceptions/InterruptedException.cs
+++ b/Wacs.Core/Runtime/Exceptions/InterruptedException.cs
@@ -1,0 +1,22 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.Core.Runtime.Exceptions
+{
+    /// <summary>
+    /// Trap kind produced when a wasm thread is interrupted via a CancellationToken
+    /// or <see cref="Wacs.Core.Runtime.Concurrency.WasmThread.RequestTrap"/>. Subclass of
+    /// <see cref="TrapException"/> so existing trap-handling paths propagate it
+    /// naturally through to <c>WasmThread.Completion</c>.
+    /// </summary>
+    public class InterruptedException : TrapException
+    {
+        public InterruptedException(string reason) : base($"interrupted: {reason}")
+        {
+        }
+    }
+}

--- a/Wacs.Core/Runtime/ExecContext.cs
+++ b/Wacs.Core/Runtime/ExecContext.cs
@@ -18,10 +18,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.ObjectPool;
 using Wacs.Core.Instructions;
 using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime.Concurrency;
 using Wacs.Core.Runtime.Exceptions;
 using Wacs.Core.Runtime.Types;
 using Wacs.Core.Types;
@@ -84,6 +87,25 @@ namespace Wacs.Core.Runtime
 
         public Frame Frame = NullFrame;
         public int InstructionPointer;
+
+        /// <summary>
+        /// Optional cancellation signal observed at function-call boundaries
+        /// (Layer 1f). When set and cancelled, the invoke path throws
+        /// <see cref="InterruptedException"/> with <see cref="InterruptReason"/>
+        /// so the trap propagates through to <c>WasmThread.Completion</c>.
+        ///
+        /// <para>Set by <see cref="ThreadBasedHost"/> on the per-thread ExecContext
+        /// before dispatching the entry point. Default <see cref="CancellationToken.None"/>
+        /// — single-threaded callers pay no observation cost.</para>
+        /// </summary>
+        public CancellationToken Ct;
+
+        /// <summary>
+        /// Reason string stamped by the cancellation source (e.g. from
+        /// <see cref="WasmThread.RequestTrap"/>). Reported through the thrown
+        /// <see cref="InterruptedException"/>.
+        /// </summary>
+        public string InterruptReason = "cancelled";
         public int LinkOpStackHeight;
         public int MaxLinkOpStackHeight;
         public bool LinkUnreachable;
@@ -381,9 +403,25 @@ namespace Wacs.Core.Runtime
         public BlockTarget PeekLabel() => _linkLabelStack.Peek();
 
 
+        /// <summary>
+        /// Observes the cancellation signal set by
+        /// <see cref="ThreadBasedHost"/> / <see cref="WasmThread.RequestTrap"/>.
+        /// Called at function-call boundaries (Layer 1f); <see cref="Ct"/> defaults
+        /// to <see cref="CancellationToken.None"/> for callers that don't opt in,
+        /// so the observation is a single cheap field read + branch.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CheckInterrupt()
+        {
+            if (Ct.IsCancellationRequested)
+                throw new InterruptedException(InterruptReason);
+        }
+
         // @Spec 4.4.10.1 Function Invocation
         public async Task InvokeAsync(FuncAddr addr)
         {
+            CheckInterrupt();
+
             //1.
             Assert( Store.Contains(addr),
                 $"Failure in Function Invocation. Address does not exist {addr}");
@@ -410,6 +448,8 @@ namespace Wacs.Core.Runtime
 
         public void Invoke(FuncAddr addr)
         {
+            CheckInterrupt();
+
             //1.
             Assert( Store.Contains(addr),
                 $"Failure in Function Invocation. Address does not exist {addr}");

--- a/Wacs.Core/Runtime/ExecContext.cs
+++ b/Wacs.Core/Runtime/ExecContext.cs
@@ -116,6 +116,40 @@ namespace Wacs.Core.Runtime
         public long steps;
 
         /// <summary>
+        /// Per-thread storage for thread-local globals (Layer 5c). Each
+        /// <see cref="ExecContext"/> is per-host-thread (Layer 1c), so
+        /// keying thread-local global slots off the context gives us
+        /// natural per-thread scoping without a cross-thread dictionary.
+        /// Null until a thread-local global is first accessed on this
+        /// thread; thereafter, lazy-initialized from the module's declared
+        /// initializer (<see cref="Types.GlobalInstance.Value"/>) on first
+        /// touch per-global per-thread.
+        /// </summary>
+        private Dictionary<GlobalAddr, Value>? _threadLocalGlobals;
+
+        /// <summary>Read a thread-local global's current value for this
+        /// host thread. On first access, initializes from the supplied
+        /// initializer (the module's declared initial value).</summary>
+        public Value GetThreadLocalGlobalValue(GlobalAddr addr, Value initialValue)
+        {
+            _threadLocalGlobals ??= new Dictionary<GlobalAddr, Value>();
+            if (!_threadLocalGlobals.TryGetValue(addr, out var v))
+            {
+                v = initialValue;
+                _threadLocalGlobals[addr] = v;
+            }
+            return v;
+        }
+
+        /// <summary>Write a thread-local global's value for this host
+        /// thread; other threads' slots are unaffected.</summary>
+        public void SetThreadLocalGlobalValue(GlobalAddr addr, Value value)
+        {
+            _threadLocalGlobals ??= new Dictionary<GlobalAddr, Value>();
+            _threadLocalGlobals[addr] = value;
+        }
+
+        /// <summary>
         /// Legacy — unused after phase M. Was the native-recursion depth counter
         /// for the old switch-runtime model where every WASM <c>call</c> grew the
         /// native thread stack. Phase M replaced native recursion with

--- a/Wacs.Core/Runtime/ExecContext.cs
+++ b/Wacs.Core/Runtime/ExecContext.cs
@@ -50,17 +50,35 @@ namespace Wacs.Core.Runtime
 
         private readonly Stack<BlockTarget> _linkLabelStack = new();
         private readonly ArrayPool<Value> _localsDataPool;
-        public readonly RuntimeAttributes Attributes;
         public readonly Stopwatch InstructionTimer = new();
 
-        public readonly InstructionSequence linkedInstructions = new();
         public readonly OpStack OpStack;
 
         public readonly Stopwatch ProcessTimer = new();
 
-        public readonly Store Store;
+        /// <summary>
+        /// Shared runtime state owned by the <see cref="WasmRuntime"/> and referenced
+        /// by every <see cref="ExecContext"/> bound to it. Contains the <see cref="Store"/>,
+        /// <see cref="RuntimeAttributes"/>, and linked-instruction arrays — all treated as
+        /// read-only post-instantiation so multiple per-thread ExecContexts (Layer 1c)
+        /// can share it safely without locks.
+        /// </summary>
+        internal readonly SharedRuntimeState Shared;
 
-        public InstructionBase[] _currentSequence;
+        public Store Store => Shared.Store;
+        public RuntimeAttributes Attributes => Shared.Attributes;
+        public InstructionSequence linkedInstructions => Shared.LinkedInstructions;
+
+        /// <summary>
+        /// Hot-path dispatch reads this property; the JIT inlines the Shared-field
+        /// delegation into a single load. Set once by <see cref="CacheInstructions"/>
+        /// during instantiation.
+        /// </summary>
+        public InstructionBase[] _currentSequence
+        {
+            get => Shared.CurrentSequence!;
+            set => Shared.CurrentSequence = value;
+        }
         // public List<InstructionBase> _sequenceInstructions;
 
 
@@ -129,25 +147,35 @@ namespace Wacs.Core.Runtime
         /// </summary>
         internal System.Collections.Generic.Stack<Compilation.SwitchCallFrame> _switchCallStack;
 
+        /// <summary>
+        /// Legacy constructor — builds a fresh <see cref="SharedRuntimeState"/> from
+        /// the given store/attributes. Used by callers that haven't been migrated to
+        /// hold a SharedRuntimeState directly.
+        /// </summary>
         public ExecContext(Store store, RuntimeAttributes? attributes = default)
+            : this(new SharedRuntimeState(store, attributes ?? new RuntimeAttributes()))
         {
-            Store = store;
-            Attributes = attributes ?? new RuntimeAttributes();
+        }
+
+        /// <summary>
+        /// Primary constructor — per-thread <see cref="ExecContext"/> instances
+        /// (Layer 1c) will call this with a SharedRuntimeState owned by the runtime
+        /// so each thread has its own operand stack, frame pool, locals pool, and
+        /// call stack while sharing the Store, Attributes, and linked-instruction
+        /// arrays.
+        /// </summary>
+        public ExecContext(SharedRuntimeState shared)
+        {
+            Shared = shared;
 
             _framePool = new DefaultObjectPool<Frame>(new StackPoolPolicy<Frame>(), Attributes.MaxCallStack)
                 .Prime(Attributes.InitialCallStack);
-            
+
             _localsDataPool = ArrayPool<Value>.Create(Attributes.MaxFunctionLocals, Attributes.LocalPoolSize);
-            
+
             _callStack = new (Attributes.InitialCallStack);
             _switchCallStack = new System.Collections.Generic.Stack<Compilation.SwitchCallFrame>(Attributes.InitialCallStack);
-            
-            // _hostReturnSequence = InstructionSequence.Empty;
-            
-            // _currentSequence = _hostReturnSequence;
-            
-            // _sequenceCount = _currentSequence.Count;
-            // _sequenceInstructions = _currentSequence._instructions;
+
             InstructionPointer = -1;
 
             OpStack = new(Attributes.MaxOpStack);

--- a/Wacs.Core/Runtime/RuntimeAttributes.cs
+++ b/Wacs.Core/Runtime/RuntimeAttributes.cs
@@ -39,6 +39,25 @@ namespace Wacs.Core.Runtime
         /// </summary>
         public bool RelaxAtomicSharedCheck { get; set; } = false;
 
+        /// <summary>
+        /// Enable parsing + validation of the shared-everything-threads
+        /// Phase-1 proposal subset (Layer 5): <c>shared</c> annotations on
+        /// globals and tables, thread-local globals, <c>global.atomic.*</c>
+        /// opcodes, and <c>pause</c>.
+        ///
+        /// <para>Default <c>false</c> so baseline wasm binaries reject the
+        /// new encoding bits as invalid — the proposal is pre-standard
+        /// (Phase 1 at time of writing, github.com/WebAssembly/shared-everything-threads)
+        /// and its binary/text format may shift before standardization.
+        /// Opt-in per runtime when working with shared-everything-aware
+        /// toolchains.</para>
+        ///
+        /// <para>Does <em>not</em> enable Component-Model canonical
+        /// builtins like <c>thread.spawn_ref</c> — those ship via a
+        /// future Component Threads adapter, not at the core wasm level.</para>
+        /// </summary>
+        public bool EnableSharedEverythingThreads { get; set; } = false;
+
         // Cache the Unity detection result to avoid reflecting on every
         // new RuntimeAttributes().
         private static readonly bool _isUnity = ProbeUnity();

--- a/Wacs.Core/Runtime/SharedRuntimeState.cs
+++ b/Wacs.Core/Runtime/SharedRuntimeState.cs
@@ -1,0 +1,54 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Wacs.Core.Instructions;
+
+namespace Wacs.Core.Runtime
+{
+    /// <summary>
+    /// Per-runtime state shared across every <see cref="ExecContext"/> bound to the
+    /// runtime. Built up during module instantiation (single-threaded) and
+    /// treated as read-only once instantiation completes — the data here is what
+    /// future per-thread <see cref="ExecContext"/> instances (Layer 1c) will share
+    /// by reference while keeping their own operand stack, frame pool, locals
+    /// pool, and call stack private.
+    ///
+    /// <para>The <see cref="LinkedInstructions"/> sequence is appended to by
+    /// <see cref="ExecContext.LinkFunction"/> during module linking; after
+    /// <see cref="ExecContext.CacheInstructions"/> runs it is snapshotted into
+    /// <see cref="CurrentSequence"/> and no further mutation occurs on the
+    /// execution path. The invariant "one writer during init, many readers at
+    /// runtime" is what makes sharing safe without locks.</para>
+    /// </summary>
+    public sealed class SharedRuntimeState
+    {
+        public readonly Store Store;
+        public readonly RuntimeAttributes Attributes;
+        public readonly InstructionSequence LinkedInstructions = new();
+
+        /// <summary>
+        /// Frozen array snapshot of <see cref="LinkedInstructions"/> produced by
+        /// <see cref="ExecContext.CacheInstructions"/>. Null until the first
+        /// <c>CacheInstructions</c> call; never written after instantiation.
+        /// Hot-path dispatch reads this through <see cref="ExecContext._currentSequence"/>.
+        /// </summary>
+        public InstructionBase[]? CurrentSequence;
+
+        public SharedRuntimeState(Store store, RuntimeAttributes attributes)
+        {
+            Store = store;
+            Attributes = attributes;
+        }
+    }
+}

--- a/Wacs.Core/Runtime/Store.cs
+++ b/Wacs.Core/Runtime/Store.cs
@@ -70,6 +70,17 @@ namespace Wacs.Core.Runtime
         /// Replace the function instance at the given address.
         /// Used by the AOT transpiler to swap interpreter-backed functions
         /// with transpiled implementations.
+        ///
+        /// <para>Not thread-safe against concurrent execution. The sole caller
+        /// is <c>Wacs.Transpiler.AOT</c> during module-load, before any host
+        /// thread has had a chance to invoke the module — no reader-writer
+        /// race is possible in the supported call pattern. A runtime that
+        /// wants to swap function instances while concurrent host threads are
+        /// already executing would need to extend this to take the same
+        /// per-instance lock pattern <see cref="Runtime.Types.MemoryInstance"/>,
+        /// <see cref="Runtime.Types.GlobalInstance"/>, and
+        /// <see cref="Runtime.Types.TableInstance"/> use for their shared paths
+        /// (Layers 2c/2d).</para>
         /// </summary>
         public void ReplaceFunction(FuncAddr addr, IFunctionInstance replacement) =>
             Funcs[addr.Value] = replacement;

--- a/Wacs.Core/Runtime/Types/FunctionInstance.cs
+++ b/Wacs.Core/Runtime/Types/FunctionInstance.cs
@@ -27,8 +27,6 @@ namespace Wacs.Core.Runtime.Types
     /// </summary>
     public class FunctionInstance : IFunctionInstance
     {
-        private static Stack<Value> _asideVals = new();
-
         private readonly static ByteCode LabelInst = OpCode.Func;
 
         /// <summary>
@@ -129,9 +127,6 @@ namespace Wacs.Core.Runtime.Types
 #if STRICT_EXECUTION
             context.Assert( context.OpStack.Count >= funcType.ParameterTypes.Arity,
                 $"Function invocation failed. Operand Stack underflow.");
-            //7.
-            context.Assert(_asideVals.Count == 0,
-                $"Shared temporary stack had values left in it.");
 #endif
             //8.
             //Push the frame and operate on the frame on the stack.

--- a/Wacs.Core/Runtime/Types/FunctionInstance.cs
+++ b/Wacs.Core/Runtime/Types/FunctionInstance.cs
@@ -117,6 +117,8 @@ namespace Wacs.Core.Runtime.Types
 
         public void Invoke(ExecContext context)
         {
+            context.CheckInterrupt();
+
             //3.
             var funcType = Type;
             //4.

--- a/Wacs.Core/Runtime/Types/GlobalInstance.cs
+++ b/Wacs.Core/Runtime/Types/GlobalInstance.cs
@@ -26,6 +26,22 @@ namespace Wacs.Core.Runtime.Types
         private Value _value;
 
         /// <summary>
+        /// Per-instance lock used to serialize reads and writes of
+        /// <see cref="Value"/> on shared globals. Null until
+        /// <see cref="EnableConcurrentAccess"/> fires — non-shared globals pay
+        /// nothing on the hot path.
+        ///
+        /// <para>Why a lock at all: <see cref="Value"/> is a 24-byte struct
+        /// (ValType + DUnion + GcRef). A plain field assignment is not atomic on
+        /// any supported platform — concurrent writer and reader can observe a
+        /// mix of bytes from two different values (torn read). Future: narrow
+        /// numeric globals to <see cref="Volatile.Read{T}"/> on the 8-byte data
+        /// union for a lock-free fast path; v128 and ref-typed globals stay
+        /// under lock.</para>
+        /// </summary>
+        private object? _lock;
+
+        /// <summary>
         /// True when this global is reachable from host threads running concurrently
         /// against the owning runtime. Set by
         /// <see cref="EnableConcurrentAccess"/> at module instantiation time —
@@ -47,20 +63,37 @@ namespace Wacs.Core.Runtime.Types
         /// <summary>
         /// Mark this global as shared across host threads. Idempotent. Must be
         /// called during instantiation, before any concurrent execution can begin.
-        /// Layer 2c will wire the per-instance lock used by the Value property.
         /// </summary>
         internal void EnableConcurrentAccess()
         {
-            IsShared = true;
+            if (_lock == null)
+            {
+                _lock = new object();
+                IsShared = true;
+            }
         }
 
         public Value Value
         {
-            get => _value;
-            set {
+            get
+            {
+                var l = _lock;
+                if (l == null) return _value;
+                lock (l) return _value;
+            }
+            set
+            {
                 if (Type.Mutability == Mutability.Immutable)
                     throw new InvalidOperationException("Global is immutable");
-                _value = value;
+                var l = _lock;
+                if (l == null)
+                {
+                    _value = value;
+                }
+                else
+                {
+                    lock (l) _value = value;
+                }
             }
         }
     }

--- a/Wacs.Core/Runtime/Types/GlobalInstance.cs
+++ b/Wacs.Core/Runtime/Types/GlobalInstance.cs
@@ -25,10 +25,33 @@ namespace Wacs.Core.Runtime.Types
         public readonly GlobalType Type;
         private Value _value;
 
+        /// <summary>
+        /// True when this global is reachable from host threads running concurrently
+        /// against the owning runtime. Set by
+        /// <see cref="EnableConcurrentAccess"/> at module instantiation time —
+        /// currently driven by "the module declares a shared memory" as a
+        /// threads-1.0 approximation; shared-everything-threads will flip this
+        /// per-declaration when that proposal lands.
+        /// <para>While false, the hot-path <see cref="Value"/> getter/setter bypass
+        /// the synchronization machinery entirely — non-threaded modules pay
+        /// nothing.</para>
+        /// </summary>
+        public bool IsShared { get; private set; }
+
         public GlobalInstance(GlobalType type, Value initialValue)
         {
             Type = type;
             _value = initialValue;
+        }
+
+        /// <summary>
+        /// Mark this global as shared across host threads. Idempotent. Must be
+        /// called during instantiation, before any concurrent execution can begin.
+        /// Layer 2c will wire the per-instance lock used by the Value property.
+        /// </summary>
+        internal void EnableConcurrentAccess()
+        {
+            IsShared = true;
         }
 
         public Value Value

--- a/Wacs.Core/Runtime/Types/GlobalInstance.cs
+++ b/Wacs.Core/Runtime/Types/GlobalInstance.cs
@@ -54,6 +54,17 @@ namespace Wacs.Core.Runtime.Types
         /// </summary>
         public bool IsShared { get; private set; }
 
+        /// <summary>
+        /// Shared-everything-threads (Layer 5c): when true, each host
+        /// thread sees its own copy of this global, initialized from
+        /// the declared initializer on first access. Cannot be both
+        /// shared and thread-local; validated at parse time.
+        /// <para>Storage lives on <see cref="ExecContext"/> (keyed by
+        /// global address); <see cref="Value"/> on the instance holds
+        /// the initializer value that every new thread starts with.</para>
+        /// </summary>
+        public bool IsThreadLocal => Type.ThreadLocal;
+
         public GlobalInstance(GlobalType type, Value initialValue)
         {
             Type = type;

--- a/Wacs.Core/Runtime/Types/TableInstance.cs
+++ b/Wacs.Core/Runtime/Types/TableInstance.cs
@@ -14,6 +14,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using FluentValidation;
 using Wacs.Core.Types;
 using Wacs.Core.Utilities;
@@ -69,13 +70,32 @@ namespace Wacs.Core.Runtime.Types
         public TableInstance Clone() => new(Type, Elements);
 
         /// <summary>
+        /// Serializes concurrent <see cref="Grow"/> calls against each other and
+        /// against readers that happen to race with a grow. Null until
+        /// <see cref="EnableConcurrentAccess"/> fires — non-shared tables pay
+        /// zero overhead (direct List operations, no lock acquisition).
+        ///
+        /// <para>Readers never take this lock. Grow is designed to be
+        /// reader-safe: it pre-allocates the underlying <c>List{T}._items</c>
+        /// array before appending, so a reader indexing into <see cref="Elements"/>
+        /// during a concurrent grow sees either the pre-grow array (with the
+        /// pre-grow size and content at valid indices) or the grown array
+        /// (with extra slots beyond what any current <c>idx &lt; Elements.Count</c>
+        /// check would have allowed). Neither case OOBs.</para>
+        /// </summary>
+        private object? _growLock;
+
+        /// <summary>
         /// Mark this table as shared across host threads. Idempotent. Must be
         /// called during instantiation, before any concurrent execution begins.
-        /// Layer 2d will wire the grow-time lock used by <see cref="Grow"/>.
         /// </summary>
         internal void EnableConcurrentAccess()
         {
-            IsShared = true;
+            if (_growLock == null)
+            {
+                _growLock = new object();
+                IsShared = true;
+            }
         }
 
         /// <summary>
@@ -84,32 +104,56 @@ namespace Wacs.Core.Runtime.Types
         /// <returns>true on succes</returns>
         public bool Grow(long numEntries, Value refInit)
         {
-            long len = numEntries + Elements.Count;
-            if (len > Constants.MaxTableSize)
-                return false;
-
-            var newLimits = new Limits(Type.Limits)
-            {
-                Minimum = (uint)len
-            };
-            var validator = TableType.Validator.Limits;
+            var lk = _growLock;
+            if (lk != null) Monitor.Enter(lk);
             try
             {
-                validator.ValidateAndThrow(newLimits);
-            }
-            catch (ValidationException exc)
-            {
-                _ = exc;
-                return false;
-            }
+                long len = numEntries + Elements.Count;
+                if (len > Constants.MaxTableSize)
+                    return false;
 
-            Type.Limits = newLimits;
-            for (int i = 0; i < numEntries; i++)
-            {
-                Elements.Add(refInit);
-            }
+                var newLimits = new Limits(Type.Limits)
+                {
+                    Minimum = (uint)len
+                };
+                var validator = TableType.Validator.Limits;
+                try
+                {
+                    validator.ValidateAndThrow(newLimits);
+                }
+                catch (ValidationException exc)
+                {
+                    _ = exc;
+                    return false;
+                }
 
-            return true;
+                // Pre-allocate the List's backing array to the final size in a single
+                // atomic field-swap (via List<T>.Capacity setter: allocate new T[len],
+                // Array.Copy from old, replace `_items`). Readers indexing into
+                // Elements during this step see either the old backing array or the
+                // new one — both contain identical data at indices [0, Count-1], so
+                // bounds-checked reads never OOB. Without this, List<T>.Add's
+                // internal on-demand doubling could expose a reader to an array that
+                // hasn't yet been sized to hold a concurrent-reader-visible Count.
+                if ((int)len > Elements.Capacity)
+                    Elements.Capacity = (int)len;
+
+                for (int i = 0; i < numEntries; i++)
+                {
+                    Elements.Add(refInit);
+                }
+
+                // Type.Limits updated last; readers gating on Type.Limits.Minimum
+                // (rather than Elements.Count) see the post-grow size only after
+                // every new slot is populated.
+                Type.Limits = newLimits;
+
+                return true;
+            }
+            finally
+            {
+                if (lk != null) Monitor.Exit(lk);
+            }
         }
     }
 }

--- a/Wacs.Core/Runtime/Types/TableInstance.cs
+++ b/Wacs.Core/Runtime/Types/TableInstance.cs
@@ -31,6 +31,19 @@ namespace Wacs.Core.Runtime.Types
         public readonly TableType Type;
 
         /// <summary>
+        /// True when this table is reachable from host threads running concurrently
+        /// against the owning runtime. Set at module instantiation time by
+        /// <see cref="EnableConcurrentAccess"/> — currently driven by "the module
+        /// declares a shared memory" as a threads-1.0 approximation.
+        /// Shared-everything-threads will carry a per-declaration shared annotation
+        /// that flips this flag directly; the consumer API (<see cref="Grow"/>,
+        /// <see cref="Elements"/> readers) is unchanged.
+        /// <para>While false, <see cref="Grow"/> skips lock acquisition — zero
+        /// overhead for non-threaded modules.</para>
+        /// </summary>
+        public bool IsShared { get; private set; }
+
+        /// <summary>
         /// @Spec 4.5.3.3. Tables
         /// @Spec 4.5.3.10. Modules
         /// </summary>
@@ -54,6 +67,16 @@ namespace Wacs.Core.Runtime.Types
             (Type, Elements) = ((TableType)type.Clone(), elems.ToList());
 
         public TableInstance Clone() => new(Type, Elements);
+
+        /// <summary>
+        /// Mark this table as shared across host threads. Idempotent. Must be
+        /// called during instantiation, before any concurrent execution begins.
+        /// Layer 2d will wire the grow-time lock used by <see cref="Grow"/>.
+        /// </summary>
+        internal void EnableConcurrentAccess()
+        {
+            IsShared = true;
+        }
 
         /// <summary>
         /// @Spec 4.5.3.8. Growing tables

--- a/Wacs.Core/Runtime/WasmRuntimeBinding.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeBinding.cs
@@ -114,9 +114,9 @@ namespace Wacs.Core.Runtime
 
         public IFunctionInstance GetFunction(FuncAddr addr)
         {
-            if (!Context.Store.Contains(addr))
+            if (!GetExecContext().Store.Contains(addr))
                 throw new WasmRuntimeException($"Runtime context did not contain function at address {addr.Value}");
-            return Context.Store[addr];
+            return GetExecContext().Store[addr];
         }
 
         // ==================================================================
@@ -143,9 +143,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Memory>()
                 .Select(m => m.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                memory = Context.Store[addrs[^1]];
+                memory = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             memory = null!;
@@ -154,9 +154,9 @@ namespace Wacs.Core.Runtime
 
         public bool TryGetExportedMemory((string module, string entity) id, out MemoryInstance memory)
         {
-            if (GetBoundEntity(id) is MemAddr addr && Context.Store.Contains(addr))
+            if (GetBoundEntity(id) is MemAddr addr && GetExecContext().Store.Contains(addr))
             {
-                memory = Context.Store[addr];
+                memory = GetExecContext().Store[addr];
                 return true;
             }
             var addrs = _moduleInstances
@@ -167,9 +167,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Memory>()
                 .Select(m => m.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                memory = Context.Store[addrs[^1]];
+                memory = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             memory = null!;
@@ -191,9 +191,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Table>()
                 .Select(t => t.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                table = Context.Store[addrs[^1]];
+                table = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             table = null!;
@@ -202,9 +202,9 @@ namespace Wacs.Core.Runtime
 
         public bool TryGetExportedTable((string module, string entity) id, out TableInstance table)
         {
-            if (GetBoundEntity(id) is TableAddr addr && Context.Store.Contains(addr))
+            if (GetBoundEntity(id) is TableAddr addr && GetExecContext().Store.Contains(addr))
             {
-                table = Context.Store[addr];
+                table = GetExecContext().Store[addr];
                 return true;
             }
             var addrs = _moduleInstances
@@ -215,9 +215,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Table>()
                 .Select(t => t.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                table = Context.Store[addrs[^1]];
+                table = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             table = null!;
@@ -239,9 +239,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Global>()
                 .Select(g => g.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                global = Context.Store[addrs[^1]];
+                global = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             global = null!;
@@ -250,9 +250,9 @@ namespace Wacs.Core.Runtime
 
         public bool TryGetExportedGlobal((string module, string entity) id, out GlobalInstance global)
         {
-            if (GetBoundEntity(id) is GlobalAddr addr && Context.Store.Contains(addr))
+            if (GetBoundEntity(id) is GlobalAddr addr && GetExecContext().Store.Contains(addr))
             {
-                global = Context.Store[addr];
+                global = GetExecContext().Store[addr];
                 return true;
             }
             var addrs = _moduleInstances
@@ -263,9 +263,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Global>()
                 .Select(g => g.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                global = Context.Store[addrs[^1]];
+                global = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             global = null!;
@@ -287,9 +287,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Tag>()
                 .Select(t => t.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                tag = Context.Store[addrs[^1]];
+                tag = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             tag = null!;
@@ -298,9 +298,9 @@ namespace Wacs.Core.Runtime
 
         public bool TryGetExportedTag((string module, string entity) id, out TagInstance tag)
         {
-            if (GetBoundEntity(id) is TagAddr addr && Context.Store.Contains(addr))
+            if (GetBoundEntity(id) is TagAddr addr && GetExecContext().Store.Contains(addr))
             {
-                tag = Context.Store[addr];
+                tag = GetExecContext().Store[addr];
                 return true;
             }
             var addrs = _moduleInstances
@@ -311,9 +311,9 @@ namespace Wacs.Core.Runtime
                 .OfType<ExternalValue.Tag>()
                 .Select(t => t.Address)
                 .ToList();
-            if (addrs.Count > 0 && Context.Store.Contains(addrs[^1]))
+            if (addrs.Count > 0 && GetExecContext().Store.Contains(addrs[^1]))
             {
-                tag = Context.Store[addrs[^1]];
+                tag = GetExecContext().Store[addrs[^1]];
                 return true;
             }
             tag = null!;
@@ -333,9 +333,9 @@ namespace Wacs.Core.Runtime
         /// </summary>
         public void ReplaceFunction(FuncAddr addr, IFunctionInstance replacement)
         {
-            if (!Context.Store.Contains(addr))
+            if (!GetExecContext().Store.Contains(addr))
                 throw new WasmRuntimeException($"Runtime context did not contain function at address {addr.Value}");
-            Context.Store.ReplaceFunction(addr, replacement);
+            GetExecContext().Store.ReplaceFunction(addr, replacement);
         }
 
         private IAddress? GetBoundEntity((string module, string entity) id) =>
@@ -409,17 +409,17 @@ namespace Wacs.Core.Runtime
 
         public string GetFunctionName(FuncAddr funcAddr)
         {
-            if (!Context.Store.Contains(funcAddr))
+            if (!GetExecContext().Store.Contains(funcAddr))
                 throw new ArgumentException($"Runtime did not contain function address.");
-            var funcInst = Context.Store[funcAddr];
+            var funcInst = GetExecContext().Store[funcAddr];
             return funcInst.Id;
         }
 
         public FunctionType GetFunctionType(FuncAddr funcAddr)
         {
-            if (!Context.Store.Contains(funcAddr))
+            if (!GetExecContext().Store.Contains(funcAddr))
                 throw new ArgumentException($"Runtime did not contain function address.");
-            var funcInst = Context.Store[funcAddr];
+            var funcInst = GetExecContext().Store[funcAddr];
             return funcInst.Type;
         }
 

--- a/Wacs.Core/Runtime/WasmRuntimeExecution.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeExecution.cs
@@ -34,7 +34,7 @@ namespace Wacs.Core.Runtime
         private Delegate CreateInvokerInternal(FuncAddr funcAddr, Type delegateType, bool returnsResult, InvokerOptions? options = default)
         {
             options ??= new InvokerOptions();
-            var funcInst = Context.Store[funcAddr];
+            var funcInst = GetExecContext().Store[funcAddr];
             var funcType = funcInst.Type;
             
             Delegates.ValidateFunctionTypeCompatibility(funcType, delegateType);
@@ -93,7 +93,7 @@ namespace Wacs.Core.Runtime
         public Action CreateInvokerAction(FuncAddr funcAddr, InvokerOptions? options = default) =>
             () =>
             {
-                var funcInst = Context.Store[funcAddr];
+                var funcInst = GetExecContext().Store[funcAddr];
                 var invoker = CreateInvokerInternal(funcAddr, typeof(Action), false, options);
                 invoker.DynamicInvoke();
             };
@@ -130,7 +130,7 @@ namespace Wacs.Core.Runtime
         {
             options ??= new InvokerOptions();
             var invoker = CreateInvoker(funcAddr, options);
-            var funcInst = Context.Store[funcAddr];
+            var funcInst = GetExecContext().Store[funcAddr];
             var funcType = funcInst.Type;
             object[] p = new object[funcType.ParameterTypes.Arity];
             
@@ -157,24 +157,24 @@ namespace Wacs.Core.Runtime
             return GenericDelegateAsync;
             async Task<Value[]> GenericDelegateAsync(params Value[] args)
             {
-                var funcInst = Context.Store[funcAddr];
+                var funcInst = GetExecContext().Store[funcAddr];
                 var funcType = funcInst.Type;
                 
-                Context.OpStack.PushValues(args);
+                GetExecContext().OpStack.PushValues(args);
 
                 if (options.CollectStats != StatsDetail.None)
                 {
-                    Context.ResetStats();
-                    Context.InstructionTimer.Reset();
+                    GetExecContext().ResetStats();
+                    GetExecContext().InstructionTimer.Reset();
                 }
 
-                Context.ProcessTimer.Restart();
-                Context.InstructionTimer.Restart();
-                Context.InstructionPointer = ExecContext.AbortSequence;
+                GetExecContext().ProcessTimer.Restart();
+                GetExecContext().InstructionTimer.Restart();
+                GetExecContext().InstructionPointer = ExecContext.AbortSequence;
                 
-                await Context.InvokeAsync(funcAddr);
+                await GetExecContext().InvokeAsync(funcAddr);
                 
-                Context.steps = 0;
+                GetExecContext().steps = 0;
                 bool fastPath = options.UseFastPath();
                 try
                 {
@@ -190,74 +190,74 @@ namespace Wacs.Core.Runtime
                 catch (AggregateException agg)
                 {
                     var exc = agg.InnerException;
-                    Context.ProcessTimer.Stop();
-                    Context.InstructionTimer.Stop();
+                    GetExecContext().ProcessTimer.Stop();
+                    GetExecContext().InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{Context.steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
                     }
 
                     //Flush the stack before throwing...
-                    Context.FlushCallStack();
+                    GetExecContext().FlushCallStack();
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (TrapException exc)
                 {
-                    Context.ProcessTimer.Stop();
-                    Context.InstructionTimer.Stop();
+                    GetExecContext().ProcessTimer.Stop();
+                    GetExecContext().InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{Context.steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
                     }
 
                     //Flush the stack before throwing...
-                    Context.FlushCallStack();
+                    GetExecContext().FlushCallStack();
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (SignalException exc)
                 {
-                    Context.ProcessTimer.Stop();
-                    Context.InstructionTimer.Stop();
+                    GetExecContext().ProcessTimer.Stop();
+                    GetExecContext().InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                     string message = exc.Message;
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
-                        message = exc.Message + $":line {line} instruction #{Context.steps}\n{path}";
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        message = exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}";
                     }
 
                     //Flush the stack before throwing...
-                    Context.FlushCallStack();
+                    GetExecContext().FlushCallStack();
 
                     var exType = exc.GetType();
                     var ctr = exType.GetConstructor(new Type[] { typeof(int), typeof(string) });
@@ -266,18 +266,18 @@ namespace Wacs.Core.Runtime
                 catch (WasmRuntimeException)
                 {
                     //Maybe Log?
-                    Context.FlushCallStack();
+                    GetExecContext().FlushCallStack();
                     throw;
                 }
                 
-                Context.ProcessTimer.Stop();
-                Context.InstructionTimer.Stop();
+                GetExecContext().ProcessTimer.Stop();
+                GetExecContext().InstructionTimer.Stop();
                 if (options.LogProgressEvery > 0) Console.Error.WriteLine("done.");
                 if (options.CollectStats != StatsDetail.None) PrintStats(options);
-                if (options.LogGas) Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                if (options.LogGas) Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                 Value[] results = new Value[funcType.ResultType.Arity];
-                Context.OpStack.PopScalars(funcType.ResultType, results);
+                GetExecContext().OpStack.PopScalars(funcType.ResultType, results);
 
                 return results;
             }
@@ -288,7 +288,7 @@ namespace Wacs.Core.Runtime
             return GenericDelegate;
             Value[] GenericDelegate(params object[] args)
             {
-                var funcInst = Context.Store[funcAddr];
+                var funcInst = GetExecContext().Store[funcAddr];
                 var funcType = funcInst.Type;
 
                 // Opt-in switch-runtime short-circuit: top-level WASM function invocations
@@ -297,42 +297,42 @@ namespace Wacs.Core.Runtime
                 // can't dispatch them. Nested calls also fall through for now; mixing the
                 // two dispatchers mid-call stack is possible but adds bookkeeping we don't
                 // need for the primary correctness/benchmark use cases.
-                if (UseSwitchRuntime && Context.OpStack.Count == 0 && funcInst is FunctionInstance wasmFn)
+                if (UseSwitchRuntime && GetExecContext().OpStack.Count == 0 && funcInst is FunctionInstance wasmFn)
                 {
                     return InvokeViaSwitch(wasmFn, funcType, args);
                 }
 
                 // Detect if this is a nested call by checking if stack has values
-                bool isNestedCall = Context.OpStack.Count > 0;
+                bool isNestedCall = GetExecContext().OpStack.Count > 0;
 
                 // Only enforce empty stack for top-level calls
 
-                Context.OpStack.PushScalars(funcType.ParameterTypes, args);
+                GetExecContext().OpStack.PushScalars(funcType.ParameterTypes, args);
 
                 if (options.CollectStats != StatsDetail.None)
                 {
-                    Context.ResetStats();
-                    Context.InstructionTimer.Reset();
+                    GetExecContext().ResetStats();
+                    GetExecContext().InstructionTimer.Reset();
                 }
 
-                Context.ProcessTimer.Restart();
-                Context.InstructionTimer.Restart();
+                GetExecContext().ProcessTimer.Restart();
+                GetExecContext().InstructionTimer.Restart();
 
                 // Save instruction pointer for nested calls
-                int savedInstructionPointer = Context.InstructionPointer;
-                Context.InstructionPointer = ExecContext.AbortSequence;
+                int savedInstructionPointer = GetExecContext().InstructionPointer;
+                GetExecContext().InstructionPointer = ExecContext.AbortSequence;
 
-                Context.steps = 0;
+                GetExecContext().steps = 0;
                 bool fastPath = options.UseFastPath();
                 try
                 {
                     if (options.SynchronousExecution)
                     {
-                        Context.Invoke(funcAddr);
+                        GetExecContext().Invoke(funcAddr);
                     }
                     else
                     {
-                        var task = Context.InvokeAsync(funcAddr);
+                        var task = GetExecContext().InvokeAsync(funcAddr);
                         task.Wait();
                     }
                     if (fastPath)
@@ -349,92 +349,92 @@ namespace Wacs.Core.Runtime
                 catch (AggregateException agg)
                 {
                     var exc = agg.InnerException;
-                    Context.ProcessTimer.Stop();
-                    Context.InstructionTimer.Stop();
+                    GetExecContext().ProcessTimer.Stop();
+                    GetExecContext().InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{Context.steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
                     }
 
                     // For nested calls, restore state; for top-level, flush
                     if (isNestedCall)
                     {
-                        Context.InstructionPointer = savedInstructionPointer;
+                        GetExecContext().InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        Context.FlushCallStack();
+                        GetExecContext().FlushCallStack();
                     }
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (TrapException exc)
                 {
-                    Context.ProcessTimer.Stop();
-                    Context.InstructionTimer.Stop();
+                    GetExecContext().ProcessTimer.Stop();
+                    GetExecContext().InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{Context.steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
                     }
 
                     if (isNestedCall)
                     {
-                        Context.InstructionPointer = savedInstructionPointer;
+                        GetExecContext().InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        Context.FlushCallStack();
+                        GetExecContext().FlushCallStack();
                     }
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (SignalException exc)
                 {
-                    Context.ProcessTimer.Stop();
-                    Context.InstructionTimer.Stop();
+                    GetExecContext().ProcessTimer.Stop();
+                    GetExecContext().InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                     string message = exc.Message;
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
-                        message = exc.Message + $":line {line} instruction #{Context.steps}\n{path}";
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        message = exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}";
                     }
 
                     if (isNestedCall)
                     {
-                        Context.InstructionPointer = savedInstructionPointer;
+                        GetExecContext().InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        Context.FlushCallStack();
+                        GetExecContext().FlushCallStack();
                     }
 
                     var exType = exc.GetType();
@@ -445,26 +445,26 @@ namespace Wacs.Core.Runtime
                 {
                     if (isNestedCall)
                     {
-                        Context.InstructionPointer = savedInstructionPointer;
+                        GetExecContext().InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        Context.FlushCallStack();
+                        GetExecContext().FlushCallStack();
                     }
                     throw;
                 }
 
-                Context.ProcessTimer.Stop();
-                Context.InstructionTimer.Stop();
+                GetExecContext().ProcessTimer.Stop();
+                GetExecContext().InstructionTimer.Stop();
                 if (options.LogProgressEvery > 0) Console.Error.WriteLine("done.");
                 if (options.CollectStats != StatsDetail.None) PrintStats(options);
-                if (options.LogGas) Console.Error.WriteLine($"Process used {Context.steps} gas. {Context.ProcessTimer.Elapsed}");
+                if (options.LogGas) Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
 
                 Value[] results = new Value[funcType.ResultType.Arity];
                 var span = results.AsSpan();
-                Context.OpStack.PopScalars(funcType.ResultType, span);
+                GetExecContext().OpStack.PopScalars(funcType.ResultType, span);
 
-                Context.GetModule(funcAddr)?.DerefTypes(span);
+                GetExecContext().GetModule(funcAddr)?.DerefTypes(span);
 
                 if (isNestedCall)
                 {
@@ -484,8 +484,8 @@ namespace Wacs.Core.Runtime
         /// </summary>
         private void RestoreInstructionPointer(int savedInstructionPointer, Value[] results)
             {
-                Context.OpStack.PushValues(results);
-                Context.InstructionPointer = savedInstructionPointer;
+                GetExecContext().OpStack.PushValues(results);
+                GetExecContext().InstructionPointer = savedInstructionPointer;
             }
 
         /// <summary>
@@ -493,8 +493,8 @@ namespace Wacs.Core.Runtime
         /// </summary>
         private void FlushCallStack()
         {
-            while (Context.OpStack.HasValue)
-                Context.OpStack.PopAny();
+            while (GetExecContext().OpStack.HasValue)
+                GetExecContext().OpStack.PopAny();
         }
 
         public async Task ProcessThreadAsync(long gasLimit)
@@ -502,11 +502,11 @@ namespace Wacs.Core.Runtime
             InstructionBase inst;
             if (gasLimit <= 0)
             {
-                while (++Context.InstructionPointer >= 0)
+                while (++GetExecContext().InstructionPointer >= 0)
                 {
-                    inst = Context._currentSequence[Context.InstructionPointer];
+                    inst = GetExecContext()._currentSequence[GetExecContext().InstructionPointer];
                     if (inst.PointerAdvance > 0)
-                        Context.InstructionPointer += inst.PointerAdvance;
+                        GetExecContext().InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
                     
@@ -522,13 +522,13 @@ namespace Wacs.Core.Runtime
             }
             else
             {
-                while (++Context.InstructionPointer >= 0)
+                while (++GetExecContext().InstructionPointer >= 0)
                 {
-                    inst = Context._currentSequence[Context.InstructionPointer];
+                    inst = GetExecContext()._currentSequence[GetExecContext().InstructionPointer];
                     //Counting gas costs about 18% throughput!
-                    Context.steps += inst.Size;
+                    GetExecContext().steps += inst.Size;
                     if (inst.PointerAdvance > 0)
-                        Context.InstructionPointer += inst.PointerAdvance;
+                        GetExecContext().InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
                     
@@ -541,7 +541,7 @@ namespace Wacs.Core.Runtime
                         inst.Execute(Context);
                     }
                     
-                    if (Context.steps >= gasLimit)
+                    if (GetExecContext().steps >= gasLimit)
                     {
                         throw new InsufficientGasException($"Invocation ran out of gas (limit:{gasLimit}).");
                     }
@@ -555,9 +555,9 @@ namespace Wacs.Core.Runtime
             long gasLimit = options.GasLimit > 0 ? options.GasLimit : long.MaxValue;
             InstructionBase inst;
             
-            while (++Context.InstructionPointer >= 0)
+            while (++GetExecContext().InstructionPointer >= 0)
             {
-                inst = Context._currentSequence[Context.InstructionPointer];
+                inst = GetExecContext()._currentSequence[GetExecContext().InstructionPointer];
             
                 //Trace execution
                 if (options.LogInstructionExecution != InstructionLogging.None)
@@ -567,9 +567,9 @@ namespace Wacs.Core.Runtime
 
                 if (options.CollectStats == StatsDetail.Instruction)
                 {
-                    Context.InstructionTimer.Restart();
+                    GetExecContext().InstructionTimer.Restart();
                     if (inst.PointerAdvance > 0)
-                        Context.InstructionPointer += inst.PointerAdvance;
+                        GetExecContext().InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
                     
@@ -578,19 +578,19 @@ namespace Wacs.Core.Runtime
                     else
                         inst.Execute(Context);
 
-                    Context.InstructionTimer.Stop();
-                    Context.steps += inst.Size;
+                    GetExecContext().InstructionTimer.Stop();
+                    GetExecContext().steps += inst.Size;
 
-                    var st = Context.Stats[(ushort)inst.Op];
+                    var st = GetExecContext().Stats[(ushort)inst.Op];
                     st.count += inst.Size;
-                    st.duration += Context.InstructionTimer.ElapsedTicks;
-                    Context.Stats[(ushort)inst.Op] = st;
+                    st.duration += GetExecContext().InstructionTimer.ElapsedTicks;
+                    GetExecContext().Stats[(ushort)inst.Op] = st;
                 }
                 else if (options.CollectStats == StatsDetail.Function)
                 {
-                    Context.InstructionTimer.Restart();
+                    GetExecContext().InstructionTimer.Restart();
                     if (inst.PointerAdvance > 0)
-                        Context.InstructionPointer += inst.PointerAdvance;
+                        GetExecContext().InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
                     
@@ -599,19 +599,19 @@ namespace Wacs.Core.Runtime
                     else
                         inst.Execute(Context);
 
-                    Context.InstructionTimer.Stop();
-                    Context.steps += inst.Size;
+                    GetExecContext().InstructionTimer.Stop();
+                    GetExecContext().steps += inst.Size;
 
-                    var st = Context.Stats[Context.Frame.FuncAddr];
+                    var st = GetExecContext().Stats[GetExecContext().Frame.FuncAddr];
                     st.count += inst.Size;
-                    st.duration += Context.InstructionTimer.ElapsedTicks;
-                    Context.Stats[Context.Frame.FuncAddr] = st;
+                    st.duration += GetExecContext().InstructionTimer.ElapsedTicks;
+                    GetExecContext().Stats[GetExecContext().Frame.FuncAddr] = st;
                 }
                 else
                 {
-                    Context.InstructionTimer.Start();
+                    GetExecContext().InstructionTimer.Start();
                     if (inst.PointerAdvance > 0)
-                        Context.InstructionPointer += inst.PointerAdvance;
+                        GetExecContext().InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
                     
@@ -619,8 +619,8 @@ namespace Wacs.Core.Runtime
                         await inst.ExecuteAsync(Context);
                     else
                         inst.Execute(Context);
-                    Context.InstructionTimer.Stop();
-                    Context.steps += inst.Size;
+                    GetExecContext().InstructionTimer.Stop();
+                    GetExecContext().steps += inst.Size;
                 }
 
                 if (((int)options.LogInstructionExecution & (int)InstructionLogging.Computes) != 0)
@@ -630,7 +630,7 @@ namespace Wacs.Core.Runtime
             
                 lastInstruction = inst;
                 
-                if (Context.steps >= gasLimit)
+                if (GetExecContext().steps >= gasLimit)
                     throw new InsufficientGasException($"Invocation ran out of gas (limit:{gasLimit}).");
                 
                 if (options.LogProgressEvery > 0)
@@ -664,13 +664,13 @@ namespace Wacs.Core.Runtime
                 case OpCode.Return when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
                 case OpCode.ReturnCallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
                 case OpCode.ReturnCall when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
-                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0 && Context.GetEndFor() == OpCode.Func:
+                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0 && GetExecContext().GetEndFor() == OpCode.Func:
                         
                 case OpCode.Block when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
                 case OpCode.Loop when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
                 case OpCode.If when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
                 case OpCode.Else when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
-                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0 && Context.GetEndFor() == OpCode.Block:
+                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0 && GetExecContext().GetEndFor() == OpCode.Block:
                             
                 case OpCode.Br when ((int)options.LogInstructionExecution&(int)InstructionLogging.Branches)!=0:
                 case OpCode.BrIf when ((int)options.LogInstructionExecution&(int)InstructionLogging.Branches)!=0:
@@ -681,9 +681,9 @@ namespace Wacs.Core.Runtime
                     string location = "";
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
                         location = $"line {line.ToString().PadLeft(7,' ')}";
                         if (options.ShowPath)
                             location += $":{path}";
@@ -693,7 +693,7 @@ namespace Wacs.Core.Runtime
                     }
                     else
                     {
-                        var log = $"Inst[0x{Context.InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
+                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
                         Console.Error.WriteLine(log);
                     }
                     break; 
@@ -713,9 +713,9 @@ namespace Wacs.Core.Runtime
                     string location = "";
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = Context.ComputePointerPath();
+                        var ptr = GetExecContext().ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
                         location = $"line {line.ToString().PadLeft(7,' ')}";
                         if (options.ShowPath)
                             location += $":{path}";
@@ -725,7 +725,7 @@ namespace Wacs.Core.Runtime
                     }
                     else
                     {
-                        var log = $"Inst[0x{Context.InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
+                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
                         Console.Error.WriteLine(log);
                     }
                     break; 
@@ -735,13 +735,13 @@ namespace Wacs.Core.Runtime
 
         private void PrintStats(InvokerOptions options)
         {
-            long procTicks = Context.ProcessTimer.ElapsedTicks;
+            long procTicks = GetExecContext().ProcessTimer.ElapsedTicks;
             long totalExecs = options.CollectStats is StatsDetail.Instruction or StatsDetail.Function
-                ? Context.Stats.Values.Sum(dc => dc.count)
-                : Context.steps;
+                ? GetExecContext().Stats.Values.Sum(dc => dc.count)
+                : GetExecContext().steps;
             long execTicks = options.CollectStats is StatsDetail.Instruction or StatsDetail.Function
-                ? Context.Stats.Values.Sum(dc => dc.duration)
-                : Context.InstructionTimer.ElapsedTicks;
+                ? GetExecContext().Stats.Values.Sum(dc => dc.duration)
+                : GetExecContext().InstructionTimer.ElapsedTicks;
             long overheadTicks = procTicks - execTicks;
 
             long scale = Stopwatch.Frequency / 1000_000_0; //100ns ticks
@@ -768,7 +768,7 @@ namespace Wacs.Core.Runtime
             
             Console.Error.WriteLine($"Execution Stats:");
             Console.Error.WriteLine($"{totalLabel}: {totalInst}|{totalPercent} {execTime.TotalSeconds:#0.###}s {avgTime} {velocity}{overheadLabel} proctime:{totalTime.TotalSeconds:#0.###}s");
-            var orderedStats = Context.Stats
+            var orderedStats = GetExecContext().Stats
                 .Where(bdc => bdc.Value.count != 0)
                 .OrderBy(bdc => -bdc.Value.count);
             
@@ -783,7 +783,7 @@ namespace Wacs.Core.Runtime
                 string instAve;
                 if (options.CollectStats == StatsDetail.Function)
                 {
-                    if (Context.Store[new FuncAddr(opcode)] is FunctionInstance func)
+                    if (GetExecContext().Store[new FuncAddr(opcode)] is FunctionInstance func)
                     {
                         count = func.CallCount;
                         label = $"{func.ModuleName}[{func.Index.Value}]".PadLeft(totalLabel.Length, ' ');

--- a/Wacs.Core/Runtime/WasmRuntimeExecution.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeExecution.cs
@@ -512,11 +512,11 @@ namespace Wacs.Core.Runtime
                     
                     if (inst.IsAsync)
                     {
-                        await inst.ExecuteAsync(Context);
+                        await inst.ExecuteAsync(GetExecContext());
                     }
                     else
                     {
-                        inst.Execute(Context);
+                        inst.Execute(GetExecContext());
                     }
                 }
             }
@@ -534,11 +534,11 @@ namespace Wacs.Core.Runtime
                     
                     if (inst.IsAsync)
                     {
-                        await inst.ExecuteAsync(Context);
+                        await inst.ExecuteAsync(GetExecContext());
                     }
                     else
                     {
-                        inst.Execute(Context);
+                        inst.Execute(GetExecContext());
                     }
                     
                     if (GetExecContext().steps >= gasLimit)
@@ -574,9 +574,9 @@ namespace Wacs.Core.Runtime
                         continue;
                     
                     if (inst.IsAsync)
-                        await inst.ExecuteAsync(Context);
+                        await inst.ExecuteAsync(GetExecContext());
                     else
-                        inst.Execute(Context);
+                        inst.Execute(GetExecContext());
 
                     GetExecContext().InstructionTimer.Stop();
                     GetExecContext().steps += inst.Size;
@@ -595,9 +595,9 @@ namespace Wacs.Core.Runtime
                         continue;
                     
                     if (inst.IsAsync)
-                        await inst.ExecuteAsync(Context);
+                        await inst.ExecuteAsync(GetExecContext());
                     else
-                        inst.Execute(Context);
+                        inst.Execute(GetExecContext());
 
                     GetExecContext().InstructionTimer.Stop();
                     GetExecContext().steps += inst.Size;
@@ -616,9 +616,9 @@ namespace Wacs.Core.Runtime
                         continue;
                     
                     if (inst.IsAsync)
-                        await inst.ExecuteAsync(Context);
+                        await inst.ExecuteAsync(GetExecContext());
                     else
-                        inst.Execute(Context);
+                        inst.Execute(GetExecContext());
                     GetExecContext().InstructionTimer.Stop();
                     GetExecContext().steps += inst.Size;
                 }
@@ -654,9 +654,9 @@ namespace Wacs.Core.Runtime
                 case var _ when InstructionBase.IsVar(inst): break;
                 case var _ when InstructionBase.IsLoad(inst): break;
                 
-                case OpCode.Call when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(Context, inst):
-                case OpCode.CallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(Context, inst):
-                // case OpCode.CallRef when options.LogInstructionExecution&(int)InstructionLogging.Binds) && InstructionBase.IsBound(Context, inst):
+                case OpCode.Call when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(GetExecContext(), inst):
+                case OpCode.CallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(GetExecContext(), inst):
+                // case OpCode.CallRef when options.LogInstructionExecution&(int)InstructionLogging.Binds) && InstructionBase.IsBound(GetExecContext(), inst):
                 
                 case OpCode.Call when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
                 case OpCode.CallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
@@ -688,12 +688,12 @@ namespace Wacs.Core.Runtime
                         if (options.ShowPath)
                             location += $":{path}";
                             
-                        var log = $"{location}: {inst.RenderText(Context)}".PadRight(40, ' ');
+                        var log = $"{location}: {inst.RenderText(GetExecContext())}".PadRight(40, ' ');
                         Console.Error.WriteLine(log);
                     }
                     else
                     {
-                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
+                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(GetExecContext())}".PadRight(40, ' ') + location;
                         Console.Error.WriteLine(log);
                     }
                     break; 
@@ -720,12 +720,12 @@ namespace Wacs.Core.Runtime
                         if (options.ShowPath)
                             location += $":{path}";
                             
-                        var log = $"{location}: {inst.RenderText(Context)}".PadRight(40, ' ');
+                        var log = $"{location}: {inst.RenderText(GetExecContext())}".PadRight(40, ' ');
                         Console.Error.WriteLine(log);
                     }
                     else
                     {
-                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
+                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(GetExecContext())}".PadRight(40, ' ') + location;
                         Console.Error.WriteLine(log);
                     }
                     break; 

--- a/Wacs.Core/Runtime/WasmRuntimeExecution.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeExecution.cs
@@ -34,7 +34,7 @@ namespace Wacs.Core.Runtime
         private Delegate CreateInvokerInternal(FuncAddr funcAddr, Type delegateType, bool returnsResult, InvokerOptions? options = default)
         {
             options ??= new InvokerOptions();
-            var funcInst = GetExecContext().Store[funcAddr];
+            var funcInst = Context.Store[funcAddr];
             var funcType = funcInst.Type;
             
             Delegates.ValidateFunctionTypeCompatibility(funcType, delegateType);
@@ -93,7 +93,7 @@ namespace Wacs.Core.Runtime
         public Action CreateInvokerAction(FuncAddr funcAddr, InvokerOptions? options = default) =>
             () =>
             {
-                var funcInst = GetExecContext().Store[funcAddr];
+                var funcInst = Context.Store[funcAddr];
                 var invoker = CreateInvokerInternal(funcAddr, typeof(Action), false, options);
                 invoker.DynamicInvoke();
             };
@@ -130,7 +130,7 @@ namespace Wacs.Core.Runtime
         {
             options ??= new InvokerOptions();
             var invoker = CreateInvoker(funcAddr, options);
-            var funcInst = GetExecContext().Store[funcAddr];
+            var funcInst = Context.Store[funcAddr];
             var funcType = funcInst.Type;
             object[] p = new object[funcType.ParameterTypes.Arity];
             
@@ -157,107 +157,110 @@ namespace Wacs.Core.Runtime
             return GenericDelegateAsync;
             async Task<Value[]> GenericDelegateAsync(params Value[] args)
             {
-                var funcInst = GetExecContext().Store[funcAddr];
+                // Per-thread ExecContext resolved once at entry; see GenericDelegate
+                // for rationale. All `ctx.X` references below rebind via this local.
+                var ctx = GetExecContext();
+                var funcInst = ctx.Store[funcAddr];
                 var funcType = funcInst.Type;
-                
-                GetExecContext().OpStack.PushValues(args);
+
+                ctx.OpStack.PushValues(args);
 
                 if (options.CollectStats != StatsDetail.None)
                 {
-                    GetExecContext().ResetStats();
-                    GetExecContext().InstructionTimer.Reset();
+                    ctx.ResetStats();
+                    ctx.InstructionTimer.Reset();
                 }
 
-                GetExecContext().ProcessTimer.Restart();
-                GetExecContext().InstructionTimer.Restart();
-                GetExecContext().InstructionPointer = ExecContext.AbortSequence;
+                ctx.ProcessTimer.Restart();
+                ctx.InstructionTimer.Restart();
+                ctx.InstructionPointer = ExecContext.AbortSequence;
                 
-                await GetExecContext().InvokeAsync(funcAddr);
+                await ctx.InvokeAsync(funcAddr);
                 
-                GetExecContext().steps = 0;
+                ctx.steps = 0;
                 bool fastPath = options.UseFastPath();
                 try
                 {
                     if (fastPath)
                     {
-                        await ProcessThreadAsync(options.GasLimit);
+                        await ProcessThreadAsync(ctx, options.GasLimit);
                     }
                     else
                     {
-                        await ProcessThreadWithOptions(options);
+                        await ProcessThreadWithOptions(ctx, options);
                     }
                 }
                 catch (AggregateException agg)
                 {
                     var exc = agg.InnerException;
-                    GetExecContext().ProcessTimer.Stop();
-                    GetExecContext().InstructionTimer.Stop();
+                    ctx.ProcessTimer.Stop();
+                    ctx.InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = ctx.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = ctx.Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{ctx.steps}\n{path}"));
                     }
 
                     //Flush the stack before throwing...
-                    GetExecContext().FlushCallStack();
+                    ctx.FlushCallStack();
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (TrapException exc)
                 {
-                    GetExecContext().ProcessTimer.Stop();
-                    GetExecContext().InstructionTimer.Stop();
+                    ctx.ProcessTimer.Stop();
+                    ctx.InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = ctx.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = ctx.Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{ctx.steps}\n{path}"));
                     }
 
                     //Flush the stack before throwing...
-                    GetExecContext().FlushCallStack();
+                    ctx.FlushCallStack();
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (SignalException exc)
                 {
-                    GetExecContext().ProcessTimer.Stop();
-                    GetExecContext().InstructionTimer.Stop();
+                    ctx.ProcessTimer.Stop();
+                    ctx.InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                     string message = exc.Message;
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = ctx.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
-                        message = exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}";
+                        (int line, string instruction) = ctx.Frame.Module.Repr.CalculateLine(path);
+                        message = exc.Message + $":line {line} instruction #{ctx.steps}\n{path}";
                     }
 
                     //Flush the stack before throwing...
-                    GetExecContext().FlushCallStack();
+                    ctx.FlushCallStack();
 
                     var exType = exc.GetType();
                     var ctr = exType.GetConstructor(new Type[] { typeof(int), typeof(string) });
@@ -266,18 +269,18 @@ namespace Wacs.Core.Runtime
                 catch (WasmRuntimeException)
                 {
                     //Maybe Log?
-                    GetExecContext().FlushCallStack();
+                    ctx.FlushCallStack();
                     throw;
                 }
                 
-                GetExecContext().ProcessTimer.Stop();
-                GetExecContext().InstructionTimer.Stop();
+                ctx.ProcessTimer.Stop();
+                ctx.InstructionTimer.Stop();
                 if (options.LogProgressEvery > 0) Console.Error.WriteLine("done.");
                 if (options.CollectStats != StatsDetail.None) PrintStats(options);
-                if (options.LogGas) Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                if (options.LogGas) Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                 Value[] results = new Value[funcType.ResultType.Arity];
-                GetExecContext().OpStack.PopScalars(funcType.ResultType, results);
+                ctx.OpStack.PopScalars(funcType.ResultType, results);
 
                 return results;
             }
@@ -288,7 +291,14 @@ namespace Wacs.Core.Runtime
             return GenericDelegate;
             Value[] GenericDelegate(params object[] args)
             {
-                var funcInst = GetExecContext().Store[funcAddr];
+                // Resolve per-thread ExecContext once at entry (Layer 1c). Every
+                // reference inside this delegate binds to `ctx` — not to the
+                // runtime-singleton `Context` field (which is only safe for the
+                // constructing thread) and not to repeated `GetExecContext()` calls
+                // (which would incur a dictionary lookup per-instruction in the
+                // dispatch loop below).
+                var ctx = GetExecContext();
+                var funcInst = ctx.Store[funcAddr];
                 var funcType = funcInst.Type;
 
                 // Opt-in switch-runtime short-circuit: top-level WASM function invocations
@@ -297,144 +307,144 @@ namespace Wacs.Core.Runtime
                 // can't dispatch them. Nested calls also fall through for now; mixing the
                 // two dispatchers mid-call stack is possible but adds bookkeeping we don't
                 // need for the primary correctness/benchmark use cases.
-                if (UseSwitchRuntime && GetExecContext().OpStack.Count == 0 && funcInst is FunctionInstance wasmFn)
+                if (UseSwitchRuntime && ctx.OpStack.Count == 0 && funcInst is FunctionInstance wasmFn)
                 {
-                    return InvokeViaSwitch(wasmFn, funcType, args);
+                    return InvokeViaSwitch(ctx, wasmFn, funcType, args);
                 }
 
                 // Detect if this is a nested call by checking if stack has values
-                bool isNestedCall = GetExecContext().OpStack.Count > 0;
+                bool isNestedCall = ctx.OpStack.Count > 0;
 
                 // Only enforce empty stack for top-level calls
 
-                GetExecContext().OpStack.PushScalars(funcType.ParameterTypes, args);
+                ctx.OpStack.PushScalars(funcType.ParameterTypes, args);
 
                 if (options.CollectStats != StatsDetail.None)
                 {
-                    GetExecContext().ResetStats();
-                    GetExecContext().InstructionTimer.Reset();
+                    ctx.ResetStats();
+                    ctx.InstructionTimer.Reset();
                 }
 
-                GetExecContext().ProcessTimer.Restart();
-                GetExecContext().InstructionTimer.Restart();
+                ctx.ProcessTimer.Restart();
+                ctx.InstructionTimer.Restart();
 
                 // Save instruction pointer for nested calls
-                int savedInstructionPointer = GetExecContext().InstructionPointer;
-                GetExecContext().InstructionPointer = ExecContext.AbortSequence;
+                int savedInstructionPointer = ctx.InstructionPointer;
+                ctx.InstructionPointer = ExecContext.AbortSequence;
 
-                GetExecContext().steps = 0;
+                ctx.steps = 0;
                 bool fastPath = options.UseFastPath();
                 try
                 {
                     if (options.SynchronousExecution)
                     {
-                        GetExecContext().Invoke(funcAddr);
+                        ctx.Invoke(funcAddr);
                     }
                     else
                     {
-                        var task = GetExecContext().InvokeAsync(funcAddr);
+                        var task = ctx.InvokeAsync(funcAddr);
                         task.Wait();
                     }
                     if (fastPath)
                     {
-                        Task thread = ProcessThreadAsync(options.GasLimit);
+                        Task thread = ProcessThreadAsync(ctx, options.GasLimit);
                         thread.Wait();
                     }
                     else
                     {
-                        Task thread = ProcessThreadWithOptions(options);
+                        Task thread = ProcessThreadWithOptions(ctx, options);
                         thread.Wait();
                     }
                 }
                 catch (AggregateException agg)
                 {
                     var exc = agg.InnerException;
-                    GetExecContext().ProcessTimer.Stop();
-                    GetExecContext().InstructionTimer.Stop();
+                    ctx.ProcessTimer.Stop();
+                    ctx.InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = ctx.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = ctx.Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{ctx.steps}\n{path}"));
                     }
 
                     // For nested calls, restore state; for top-level, flush
                     if (isNestedCall)
                     {
-                        GetExecContext().InstructionPointer = savedInstructionPointer;
+                        ctx.InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        GetExecContext().FlushCallStack();
+                        ctx.FlushCallStack();
                     }
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (TrapException exc)
                 {
-                    GetExecContext().ProcessTimer.Stop();
-                    GetExecContext().InstructionTimer.Stop();
+                    ctx.ProcessTimer.Stop();
+                    ctx.InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = ctx.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = ctx.Frame.Module.Repr.CalculateLine(path);
 
-                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}"));
+                        ExceptionDispatchInfo.Throw(new TrapException(exc.Message + $":line {line} instruction #{ctx.steps}\n{path}"));
                     }
 
                     if (isNestedCall)
                     {
-                        GetExecContext().InstructionPointer = savedInstructionPointer;
+                        ctx.InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        GetExecContext().FlushCallStack();
+                        ctx.FlushCallStack();
                     }
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 catch (SignalException exc)
                 {
-                    GetExecContext().ProcessTimer.Stop();
-                    GetExecContext().InstructionTimer.Stop();
+                    ctx.ProcessTimer.Stop();
+                    ctx.InstructionTimer.Stop();
                     if (options.LogProgressEvery > 0)
                         Console.Error.WriteLine();
                     if (options.CollectStats != StatsDetail.None)
                         PrintStats(options);
                     if (options.LogGas)
-                        Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                        Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                     string message = exc.Message;
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = ctx.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
-                        message = exc.Message + $":line {line} instruction #{GetExecContext().steps}\n{path}";
+                        (int line, string instruction) = ctx.Frame.Module.Repr.CalculateLine(path);
+                        message = exc.Message + $":line {line} instruction #{ctx.steps}\n{path}";
                     }
 
                     if (isNestedCall)
                     {
-                        GetExecContext().InstructionPointer = savedInstructionPointer;
+                        ctx.InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        GetExecContext().FlushCallStack();
+                        ctx.FlushCallStack();
                     }
 
                     var exType = exc.GetType();
@@ -445,34 +455,34 @@ namespace Wacs.Core.Runtime
                 {
                     if (isNestedCall)
                     {
-                        GetExecContext().InstructionPointer = savedInstructionPointer;
+                        ctx.InstructionPointer = savedInstructionPointer;
                     }
                     else
                     {
-                        GetExecContext().FlushCallStack();
+                        ctx.FlushCallStack();
                     }
                     throw;
                 }
 
-                GetExecContext().ProcessTimer.Stop();
-                GetExecContext().InstructionTimer.Stop();
+                ctx.ProcessTimer.Stop();
+                ctx.InstructionTimer.Stop();
                 if (options.LogProgressEvery > 0) Console.Error.WriteLine("done.");
                 if (options.CollectStats != StatsDetail.None) PrintStats(options);
-                if (options.LogGas) Console.Error.WriteLine($"Process used {GetExecContext().steps} gas. {GetExecContext().ProcessTimer.Elapsed}");
+                if (options.LogGas) Console.Error.WriteLine($"Process used {ctx.steps} gas. {ctx.ProcessTimer.Elapsed}");
 
                 Value[] results = new Value[funcType.ResultType.Arity];
                 var span = results.AsSpan();
-                GetExecContext().OpStack.PopScalars(funcType.ResultType, span);
+                ctx.OpStack.PopScalars(funcType.ResultType, span);
 
-                GetExecContext().GetModule(funcAddr)?.DerefTypes(span);
+                ctx.GetModule(funcAddr)?.DerefTypes(span);
 
                 if (isNestedCall)
                 {
-                    RestoreInstructionPointer(savedInstructionPointer, results);
+                    RestoreInstructionPointer(ctx, savedInstructionPointer, results);
                 }
                 else
                 {
-                    FlushCallStack();
+                    FlushCallStack(ctx);
                 }
 
                 return results;
@@ -482,66 +492,74 @@ namespace Wacs.Core.Runtime
         /// <summary>
         /// Restores the instruction pointer and pushes results back onto the stack for nested calls.
         /// </summary>
-        private void RestoreInstructionPointer(int savedInstructionPointer, Value[] results)
-            {
-                GetExecContext().OpStack.PushValues(results);
-                GetExecContext().InstructionPointer = savedInstructionPointer;
-            }
+        private void RestoreInstructionPointer(ExecContext ctx, int savedInstructionPointer, Value[] results)
+        {
+            ctx.OpStack.PushValues(results);
+            ctx.InstructionPointer = savedInstructionPointer;
+        }
 
         /// <summary>
         /// Clears any remaining stack values for top-level calls.
         /// </summary>
-        private void FlushCallStack()
+        private void FlushCallStack(ExecContext ctx)
         {
-            while (GetExecContext().OpStack.HasValue)
-                GetExecContext().OpStack.PopAny();
+            while (ctx.OpStack.HasValue)
+                ctx.OpStack.PopAny();
         }
 
-        public async Task ProcessThreadAsync(long gasLimit)
+        public Task ProcessThreadAsync(long gasLimit) =>
+            ProcessThreadAsync(GetExecContext(), gasLimit);
+
+        public async Task ProcessThreadAsync(ExecContext ctx, long gasLimit)
         {
+            // Hot dispatch loop. The caller (invoker delegate body) resolves the
+            // per-thread ExecContext once and passes it in — referencing `ctx` here
+            // rather than calling GetExecContext() per-instruction is mandatory for
+            // concurrent invocation (avoids repeated dictionary lookups on every
+            // wasm instruction) and for sequential instantiation (avoids waste).
             InstructionBase inst;
             if (gasLimit <= 0)
             {
-                while (++GetExecContext().InstructionPointer >= 0)
+                while (++ctx.InstructionPointer >= 0)
                 {
-                    inst = GetExecContext()._currentSequence[GetExecContext().InstructionPointer];
+                    inst = ctx._currentSequence[ctx.InstructionPointer];
                     if (inst.PointerAdvance > 0)
-                        GetExecContext().InstructionPointer += inst.PointerAdvance;
+                        ctx.InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
-                    
+
                     if (inst.IsAsync)
                     {
-                        await inst.ExecuteAsync(GetExecContext());
+                        await inst.ExecuteAsync(ctx);
                     }
                     else
                     {
-                        inst.Execute(GetExecContext());
+                        inst.Execute(ctx);
                     }
                 }
             }
             else
             {
-                while (++GetExecContext().InstructionPointer >= 0)
+                while (++ctx.InstructionPointer >= 0)
                 {
-                    inst = GetExecContext()._currentSequence[GetExecContext().InstructionPointer];
+                    inst = ctx._currentSequence[ctx.InstructionPointer];
                     //Counting gas costs about 18% throughput!
-                    GetExecContext().steps += inst.Size;
+                    ctx.steps += inst.Size;
                     if (inst.PointerAdvance > 0)
-                        GetExecContext().InstructionPointer += inst.PointerAdvance;
+                        ctx.InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
-                    
+
                     if (inst.IsAsync)
                     {
-                        await inst.ExecuteAsync(GetExecContext());
+                        await inst.ExecuteAsync(ctx);
                     }
                     else
                     {
-                        inst.Execute(GetExecContext());
+                        inst.Execute(ctx);
                     }
-                    
-                    if (GetExecContext().steps >= gasLimit)
+
+                    if (ctx.steps >= gasLimit)
                     {
                         throw new InsufficientGasException($"Invocation ran out of gas (limit:{gasLimit}).");
                     }
@@ -549,16 +567,22 @@ namespace Wacs.Core.Runtime
             }
         }
 
-        public async Task ProcessThreadWithOptions(InvokerOptions options) 
+        public Task ProcessThreadWithOptions(InvokerOptions options) =>
+            ProcessThreadWithOptions(GetExecContext(), options);
+
+        public async Task ProcessThreadWithOptions(ExecContext ctx, InvokerOptions options)
         {
+            // Hot dispatch loop — ctx is passed in so we don't pay per-instruction
+            // dictionary lookups when resolving per-thread ExecContext. See
+            // <see cref="ProcessThreadAsync(ExecContext,long)"/> for rationale.
             long highwatermark = 0;
             long gasLimit = options.GasLimit > 0 ? options.GasLimit : long.MaxValue;
             InstructionBase inst;
-            
-            while (++GetExecContext().InstructionPointer >= 0)
+
+            while (++ctx.InstructionPointer >= 0)
             {
-                inst = GetExecContext()._currentSequence[GetExecContext().InstructionPointer];
-            
+                inst = ctx._currentSequence[ctx.InstructionPointer];
+
                 //Trace execution
                 if (options.LogInstructionExecution != InstructionLogging.None)
                 {
@@ -567,72 +591,72 @@ namespace Wacs.Core.Runtime
 
                 if (options.CollectStats == StatsDetail.Instruction)
                 {
-                    GetExecContext().InstructionTimer.Restart();
+                    ctx.InstructionTimer.Restart();
                     if (inst.PointerAdvance > 0)
-                        GetExecContext().InstructionPointer += inst.PointerAdvance;
+                        ctx.InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
-                    
+
                     if (inst.IsAsync)
-                        await inst.ExecuteAsync(GetExecContext());
+                        await inst.ExecuteAsync(ctx);
                     else
-                        inst.Execute(GetExecContext());
+                        inst.Execute(ctx);
 
-                    GetExecContext().InstructionTimer.Stop();
-                    GetExecContext().steps += inst.Size;
+                    ctx.InstructionTimer.Stop();
+                    ctx.steps += inst.Size;
 
-                    var st = GetExecContext().Stats[(ushort)inst.Op];
+                    var st = ctx.Stats[(ushort)inst.Op];
                     st.count += inst.Size;
-                    st.duration += GetExecContext().InstructionTimer.ElapsedTicks;
-                    GetExecContext().Stats[(ushort)inst.Op] = st;
+                    st.duration += ctx.InstructionTimer.ElapsedTicks;
+                    ctx.Stats[(ushort)inst.Op] = st;
                 }
                 else if (options.CollectStats == StatsDetail.Function)
                 {
-                    GetExecContext().InstructionTimer.Restart();
+                    ctx.InstructionTimer.Restart();
                     if (inst.PointerAdvance > 0)
-                        GetExecContext().InstructionPointer += inst.PointerAdvance;
+                        ctx.InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
-                    
+
                     if (inst.IsAsync)
-                        await inst.ExecuteAsync(GetExecContext());
+                        await inst.ExecuteAsync(ctx);
                     else
-                        inst.Execute(GetExecContext());
+                        inst.Execute(ctx);
 
-                    GetExecContext().InstructionTimer.Stop();
-                    GetExecContext().steps += inst.Size;
+                    ctx.InstructionTimer.Stop();
+                    ctx.steps += inst.Size;
 
-                    var st = GetExecContext().Stats[GetExecContext().Frame.FuncAddr];
+                    var st = ctx.Stats[ctx.Frame.FuncAddr];
                     st.count += inst.Size;
-                    st.duration += GetExecContext().InstructionTimer.ElapsedTicks;
-                    GetExecContext().Stats[GetExecContext().Frame.FuncAddr] = st;
+                    st.duration += ctx.InstructionTimer.ElapsedTicks;
+                    ctx.Stats[ctx.Frame.FuncAddr] = st;
                 }
                 else
                 {
-                    GetExecContext().InstructionTimer.Start();
+                    ctx.InstructionTimer.Start();
                     if (inst.PointerAdvance > 0)
-                        GetExecContext().InstructionPointer += inst.PointerAdvance;
+                        ctx.InstructionPointer += inst.PointerAdvance;
                     if (inst.Nop)
                         continue;
-                    
+
                     if (inst.IsAsync)
-                        await inst.ExecuteAsync(GetExecContext());
+                        await inst.ExecuteAsync(ctx);
                     else
-                        inst.Execute(GetExecContext());
-                    GetExecContext().InstructionTimer.Stop();
-                    GetExecContext().steps += inst.Size;
+                        inst.Execute(ctx);
+                    ctx.InstructionTimer.Stop();
+                    ctx.steps += inst.Size;
                 }
 
                 if (((int)options.LogInstructionExecution & (int)InstructionLogging.Computes) != 0)
                 {
                     LogPostInstruction(options, inst);
                 }
-            
+
                 lastInstruction = inst;
-                
-                if (GetExecContext().steps >= gasLimit)
+
+                if (ctx.steps >= gasLimit)
                     throw new InsufficientGasException($"Invocation ran out of gas (limit:{gasLimit}).");
-                
+
                 if (options.LogProgressEvery > 0)
                 {
                     highwatermark += inst.Size;
@@ -654,9 +678,9 @@ namespace Wacs.Core.Runtime
                 case var _ when InstructionBase.IsVar(inst): break;
                 case var _ when InstructionBase.IsLoad(inst): break;
                 
-                case OpCode.Call when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(GetExecContext(), inst):
-                case OpCode.CallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(GetExecContext(), inst):
-                // case OpCode.CallRef when options.LogInstructionExecution&(int)InstructionLogging.Binds) && InstructionBase.IsBound(GetExecContext(), inst):
+                case OpCode.Call when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(Context, inst):
+                case OpCode.CallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Binds)!=0 && InstructionBase.IsBound(Context, inst):
+                // case OpCode.CallRef when options.LogInstructionExecution&(int)InstructionLogging.Binds) && InstructionBase.IsBound(Context, inst):
                 
                 case OpCode.Call when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
                 case OpCode.CallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
@@ -664,13 +688,13 @@ namespace Wacs.Core.Runtime
                 case OpCode.Return when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
                 case OpCode.ReturnCallIndirect when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
                 case OpCode.ReturnCall when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0:
-                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0 && GetExecContext().GetEndFor() == OpCode.Func:
+                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Calls)!=0 && Context.GetEndFor() == OpCode.Func:
                         
                 case OpCode.Block when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
                 case OpCode.Loop when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
                 case OpCode.If when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
                 case OpCode.Else when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0:
-                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0 && GetExecContext().GetEndFor() == OpCode.Block:
+                case OpCode.End when ((int)options.LogInstructionExecution&(int)InstructionLogging.Blocks)!=0 && Context.GetEndFor() == OpCode.Block:
                             
                 case OpCode.Br when ((int)options.LogInstructionExecution&(int)InstructionLogging.Branches)!=0:
                 case OpCode.BrIf when ((int)options.LogInstructionExecution&(int)InstructionLogging.Branches)!=0:
@@ -681,19 +705,19 @@ namespace Wacs.Core.Runtime
                     string location = "";
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = Context.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
                         location = $"line {line.ToString().PadLeft(7,' ')}";
                         if (options.ShowPath)
                             location += $":{path}";
                             
-                        var log = $"{location}: {inst.RenderText(GetExecContext())}".PadRight(40, ' ');
+                        var log = $"{location}: {inst.RenderText(Context)}".PadRight(40, ' ');
                         Console.Error.WriteLine(log);
                     }
                     else
                     {
-                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(GetExecContext())}".PadRight(40, ' ') + location;
+                        var log = $"Inst[0x{Context.InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
                         Console.Error.WriteLine(log);
                     }
                     break; 
@@ -713,19 +737,19 @@ namespace Wacs.Core.Runtime
                     string location = "";
                     if (options.CalculateLineNumbers)
                     {
-                        var ptr = GetExecContext().ComputePointerPath();
+                        var ptr = Context.ComputePointerPath();
                         var path = string.Join(".", ptr.Select(t => $"{t.Item1.Capitalize()}[{t.Item2}]"));
-                        (int line, string instruction) = GetExecContext().Frame.Module.Repr.CalculateLine(path);
+                        (int line, string instruction) = Context.Frame.Module.Repr.CalculateLine(path);
                         location = $"line {line.ToString().PadLeft(7,' ')}";
                         if (options.ShowPath)
                             location += $":{path}";
                             
-                        var log = $"{location}: {inst.RenderText(GetExecContext())}".PadRight(40, ' ');
+                        var log = $"{location}: {inst.RenderText(Context)}".PadRight(40, ' ');
                         Console.Error.WriteLine(log);
                     }
                     else
                     {
-                        var log = $"Inst[0x{GetExecContext().InstructionPointer:x8}]: {inst.RenderText(GetExecContext())}".PadRight(40, ' ') + location;
+                        var log = $"Inst[0x{Context.InstructionPointer:x8}]: {inst.RenderText(Context)}".PadRight(40, ' ') + location;
                         Console.Error.WriteLine(log);
                     }
                     break; 
@@ -735,13 +759,13 @@ namespace Wacs.Core.Runtime
 
         private void PrintStats(InvokerOptions options)
         {
-            long procTicks = GetExecContext().ProcessTimer.ElapsedTicks;
+            long procTicks = Context.ProcessTimer.ElapsedTicks;
             long totalExecs = options.CollectStats is StatsDetail.Instruction or StatsDetail.Function
-                ? GetExecContext().Stats.Values.Sum(dc => dc.count)
-                : GetExecContext().steps;
+                ? Context.Stats.Values.Sum(dc => dc.count)
+                : Context.steps;
             long execTicks = options.CollectStats is StatsDetail.Instruction or StatsDetail.Function
-                ? GetExecContext().Stats.Values.Sum(dc => dc.duration)
-                : GetExecContext().InstructionTimer.ElapsedTicks;
+                ? Context.Stats.Values.Sum(dc => dc.duration)
+                : Context.InstructionTimer.ElapsedTicks;
             long overheadTicks = procTicks - execTicks;
 
             long scale = Stopwatch.Frequency / 1000_000_0; //100ns ticks
@@ -768,7 +792,7 @@ namespace Wacs.Core.Runtime
             
             Console.Error.WriteLine($"Execution Stats:");
             Console.Error.WriteLine($"{totalLabel}: {totalInst}|{totalPercent} {execTime.TotalSeconds:#0.###}s {avgTime} {velocity}{overheadLabel} proctime:{totalTime.TotalSeconds:#0.###}s");
-            var orderedStats = GetExecContext().Stats
+            var orderedStats = Context.Stats
                 .Where(bdc => bdc.Value.count != 0)
                 .OrderBy(bdc => -bdc.Value.count);
             
@@ -783,7 +807,7 @@ namespace Wacs.Core.Runtime
                 string instAve;
                 if (options.CollectStats == StatsDetail.Function)
                 {
-                    if (GetExecContext().Store[new FuncAddr(opcode)] is FunctionInstance func)
+                    if (Context.Store[new FuncAddr(opcode)] is FunctionInstance func)
                     {
                         count = func.CallCount;
                         label = $"{func.ModuleName}[{func.Index.Value}]".PadLeft(totalLabel.Length, ' ');

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -38,6 +38,7 @@ namespace Wacs.Core.Runtime
         private readonly List<ModuleInstance> _moduleInstances = new();
         private readonly Dictionary<string, ModuleInstance> _registeredModules = new();
 
+        private readonly SharedRuntimeState _shared;
         private readonly ExecContext Context;
         public ExecContext ExecContext => GetExecContext();
 
@@ -55,8 +56,8 @@ namespace Wacs.Core.Runtime
         /// </summary>
         private ExecContext GetExecContext() => Context;
 
-        private readonly Store Store;
-        public Store RuntimeStore => Store;
+        private Store Store => _shared.Store;
+        public Store RuntimeStore => _shared.Store;
 
         //Cached instructions for module initialization
         private readonly InstElemDrop _dropInst;
@@ -67,9 +68,9 @@ namespace Wacs.Core.Runtime
 
         public WasmRuntime(RuntimeAttributes? attributes = null)
         {
-            Store = new Store();
-            Context = new ExecContext(Store, attributes);
-            
+            _shared = new SharedRuntimeState(new Store(), attributes ?? new RuntimeAttributes());
+            Context = new ExecContext(_shared);
+
             //Cached instructions for module initialization
             _dropInst = SpecFactory.Factory.CreateInstruction<InstElemDrop>(ExtCode.ElemDrop);
             _i32ConstInst = SpecFactory.Factory.CreateInstruction<InstI32Const>(OpCode.I32Const);

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -39,7 +39,21 @@ namespace Wacs.Core.Runtime
         private readonly Dictionary<string, ModuleInstance> _registeredModules = new();
 
         private readonly ExecContext Context;
-        public ExecContext ExecContext => Context;
+        public ExecContext ExecContext => GetExecContext();
+
+        /// <summary>
+        /// Abstraction point for per-thread <see cref="ExecContext"/> lookup. Layer 1a
+        /// introduces this helper as a single-point-of-change; later subphases swap it
+        /// for a <see cref="System.Threading.ThreadLocal{T}"/> so concurrent host threads
+        /// each get their own operand/frame/locals state without colliding on the
+        /// runtime-singleton <see cref="Context"/> field.
+        ///
+        /// <para>The polymorphic dispatch loop doesn't call this — handlers take
+        /// <c>ExecContext ctx</c> as a parameter and stay on one thread for the duration
+        /// of a call. This helper is only for the runtime's outer entry points
+        /// (CreateInvoker, InstantiateModule glue, binding lookups).</para>
+        /// </summary>
+        private ExecContext GetExecContext() => Context;
 
         private readonly Store Store;
         public Store RuntimeStore => Store;
@@ -293,7 +307,7 @@ namespace Wacs.Core.Runtime
             {
                 //1
                 if (!options.SkipModuleValidation)
-                    module.ValidateAndThrow(Context.Attributes);
+                    module.ValidateAndThrow(GetExecContext().Attributes);
             }
             catch (ValidationException exc)
             {
@@ -305,16 +319,16 @@ namespace Wacs.Core.Runtime
             {
                 Store.OpenTransaction();
                 
-                if (Context.OpStack.Count != 0)
+                if (GetExecContext().OpStack.Count != 0)
                     throw new WasmRuntimeException("OpStack should be empty");
 
                 //2, 3, 4 Checks if imports are satisfied
                 moduleInstance = AllocateModule(module);
 
                 //12.
-                var auxFrame = Context.ReserveFrame(moduleInstance, 0);
+                var auxFrame = GetExecContext().ReserveFrame(moduleInstance, 0);
                 //13.
-                Context.PushFrame(auxFrame);
+                GetExecContext().PushFrame(auxFrame);
                 try
                 {
                     //14, 15
@@ -360,7 +374,7 @@ namespace Wacs.Core.Runtime
                     //Linking may succeed, so we commit the transaction
                     Store.CommitTransaction();
                     Store.OpenTransaction();
-                    Context.FlushCallStack();
+                    GetExecContext().FlushCallStack();
                     ExceptionDispatchInfo.Throw(exc);
                 }
                 finally
@@ -370,7 +384,7 @@ namespace Wacs.Core.Runtime
 
                     LinkModule(moduleInstance);
 
-                    Context.CacheInstructions();
+                    GetExecContext().CacheInstructions();
                 }
                 
                 //17. 
@@ -380,7 +394,7 @@ namespace Wacs.Core.Runtime
                         throw new ValidationException("Module StartFunction index was invalid");
                     
                     var startAddr = moduleInstance.FuncAddrs[module.StartIndex];
-                    if (!Context.Store.Contains(startAddr))
+                    if (!GetExecContext().Store.Contains(startAddr))
                         throw new WasmRuntimeException("Module StartFunction address not found in the Store.");
 
                     moduleInstance.StartFunc = startAddr;
@@ -405,10 +419,10 @@ namespace Wacs.Core.Runtime
                 }
 
                 //18.
-                if (Context.Frame != auxFrame)
+                if (GetExecContext().Frame != auxFrame)
                     throw new InstantiationException("Execution fault in Module Instantiation.");
                 //19.
-                Context.PopFrame();
+                GetExecContext().PopFrame();
 
                 _moduleInstances.Add(moduleInstance);
                 
@@ -417,7 +431,7 @@ namespace Wacs.Core.Runtime
             {
                 Store.DiscardTransaction();
                 Store.OpenTransaction();
-                Context.FlushCallStack();
+                GetExecContext().FlushCallStack();
                 ExceptionDispatchInfo.Throw(exc);
             }
             catch (OutOfBoundsTableAccessException exc)
@@ -426,7 +440,7 @@ namespace Wacs.Core.Runtime
                 // see linking.wast:264
                 Store.CommitTransaction();
                 Store.OpenTransaction();
-                Context.FlushCallStack();
+                GetExecContext().FlushCallStack();
                 ExceptionDispatchInfo.Throw(exc);
             }
             catch (TrapException exc)
@@ -434,7 +448,7 @@ namespace Wacs.Core.Runtime
                 //Linking may succeed, so we commit the transaction
                 Store.CommitTransaction();
                 Store.OpenTransaction();
-                Context.FlushCallStack();
+                GetExecContext().FlushCallStack();
                 ExceptionDispatchInfo.Throw(exc);
             }
             catch (NotSupportedException exc)
@@ -442,7 +456,7 @@ namespace Wacs.Core.Runtime
                 //Unlinkable
                 Store.DiscardTransaction();
                 Store.OpenTransaction();
-                Context.FlushCallStack();
+                GetExecContext().FlushCallStack();
                 ExceptionDispatchInfo.Throw(exc);
             }
             finally
@@ -478,7 +492,7 @@ namespace Wacs.Core.Runtime
                 {
                     if (functionInstance.Module != moduleInstance)
                         continue;
-                    Context.LinkFunction(functionInstance);
+                    GetExecContext().LinkFunction(functionInstance);
 
                     if (eagerCompile && functionInstance.SwitchCompiled == null)
                     {
@@ -486,7 +500,7 @@ namespace Wacs.Core.Runtime
                             functionInstance.Body.Instructions.Flatten().ToArray(),
                             functionInstance.Type,
                             localsCount: functionInstance.Type.ParameterTypes.Arity + functionInstance.Locals.Length,
-                            useSuperInstructions: Context.Attributes.UseSwitchSuperInstructions,
+                            useSuperInstructions: GetExecContext().Attributes.UseSwitchSuperInstructions,
                             declaredLocalTypes: functionInstance.Locals);
                     }
                 }
@@ -573,15 +587,15 @@ namespace Wacs.Core.Runtime
         /// </summary>
         private Value EvaluateInitializer(ModuleInstance module, Expression ini)
         {
-            Frame initFrame = Context.ReserveFrame(module, 1);
-            Context.PushFrame(initFrame);
+            Frame initFrame = GetExecContext().ReserveFrame(module, 1);
+            GetExecContext().PushFrame(initFrame);
 
             ini.ExecuteInitializer(Context);
-            var value = Context.OpStack.PopAny();
-            if (Context.OpStack.Count > 0)
+            var value = GetExecContext().OpStack.PopAny();
+            if (GetExecContext().OpStack.Count > 0)
                 throw new WasmRuntimeException("Values left on stack");
             
-            Context.FlushCallStack();
+            GetExecContext().FlushCallStack();
             return value;
         }
 

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -23,6 +23,7 @@ using FluentValidation;
 using Wacs.Core.Instructions;
 using Wacs.Core.Instructions.Numeric;
 using Wacs.Core.OpCodes;
+using Wacs.Core.Runtime.Concurrency;
 using Wacs.Core.Runtime.Exceptions;
 using Wacs.Core.Runtime.Types;
 using Wacs.Core.Types;
@@ -68,6 +69,24 @@ namespace Wacs.Core.Runtime
         private readonly ThreadLocal<ExecContext> _threadContext;
 
         public ExecContext ExecContext => GetExecContext();
+
+        private IWasmThreadHost? _threadHost;
+
+        /// <summary>
+        /// Spawn wasm threads against this runtime. Lazily creates a default
+        /// <see cref="ThreadBasedHost"/> on first access; hosts that need a custom
+        /// thread strategy (e.g. a Unity main-thread-aware host, or a pooled
+        /// thread-dispatching host) can assign their own implementation.
+        ///
+        /// <para>Both wasi-threads (via a <c>thread-spawn</c> host import adapter
+        /// that calls into this) and shared-everything's future <c>thread.spawn</c>
+        /// instruction dispatch through the same primitive.</para>
+        /// </summary>
+        public IWasmThreadHost ThreadHost
+        {
+            get => _threadHost ??= new ThreadBasedHost(this);
+            set => _threadHost = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         /// <summary>
         /// Returns the calling thread's <see cref="ExecContext"/>, lazily creating

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -337,7 +337,34 @@ namespace Wacs.Core.Runtime
                 }
             }
 
+            // Layer 2b: mark globals/tables as shared if the module declares any
+            // shared memory. Threads-1.0 doesn't define "shared global" or
+            // "shared table" — this is the pragmatic approximation that lets
+            // concurrent host threads safely reach any global/table in a module
+            // whose memory they can also reach. Shared-everything-threads
+            // (future) will flip IsShared per-declaration from the wasm binary.
+            // Only activates when the host policy supports concurrency at all;
+            // NotSupportedPolicy modules (IL2CPP default) pay nothing.
+            if (_shared.Attributes.ConcurrencyPolicy.Mode == Concurrency.ConcurrencyPolicyMode.HostDefined
+                && ModuleHasSharedMemory(moduleInstance))
+            {
+                for (int i = 0; i < moduleInstance.GlobalAddrs.Count; i++)
+                    Store[moduleInstance.GlobalAddrs[(GlobalIdx)(uint)i]].EnableConcurrentAccess();
+                for (int i = 0; i < moduleInstance.TableAddrs.Count; i++)
+                    Store[moduleInstance.TableAddrs[(TableIdx)(uint)i]].EnableConcurrentAccess();
+            }
+
             return moduleInstance;
+        }
+
+        private bool ModuleHasSharedMemory(ModuleInstance moduleInstance)
+        {
+            for (int i = 0; i < moduleInstance.MemAddrs.Count; i++)
+            {
+                if (Store[moduleInstance.MemAddrs.At(i)].Type.Limits.Shared)
+                    return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -337,10 +337,10 @@ namespace Wacs.Core.Runtime
                 }
             }
 
-            // Layer 5a: shared-everything-threads declared-per-global flag.
-            // Rejects globals that advertise `shared` or `thread_local`
-            // without the runtime opting into the proposal. Preserves
-            // baseline behavior when the flag is off.
+            // Layer 5a/5b: shared-everything-threads declared-per-instance flags.
+            // Rejects globals/tables that advertise `shared` or
+            // `thread_local` without the runtime opting into the proposal.
+            // Preserves baseline behavior when the flag is off.
             for (int i = 0; i < moduleInstance.GlobalAddrs.Count; i++)
             {
                 var g = Store[moduleInstance.GlobalAddrs[(GlobalIdx)(uint)i]];
@@ -352,9 +352,20 @@ namespace Wacs.Core.Runtime
                         "but the runtime has not opted in via RuntimeAttributes.EnableSharedEverythingThreads.");
                 }
             }
+            for (int i = 0; i < moduleInstance.TableAddrs.Count; i++)
+            {
+                var t = Store[moduleInstance.TableAddrs[(TableIdx)(uint)i]];
+                if (t.Type.Limits.Shared
+                    && !_shared.Attributes.EnableSharedEverythingThreads)
+                {
+                    throw new NotSupportedException(
+                        $"Table {i} is declared shared but the runtime has not opted in " +
+                        "via RuntimeAttributes.EnableSharedEverythingThreads.");
+                }
+            }
 
             // Mark globals/tables as shared based on:
-            //   - Layer 5a: declared-per-global `shared` flag (authoritative when present).
+            //   - Layer 5a/5b: declared-per-instance `shared` flag (authoritative when present).
             //   - Layer 2b: module-has-shared-memory approximation (fallback for
             //     threads-1.0 modules that predate per-declaration annotations).
             // Either source flips IsShared; declaration-driven instances are
@@ -369,10 +380,11 @@ namespace Wacs.Core.Runtime
                 if (g.Type.Shared || moduleThreadingActive)
                     g.EnableConcurrentAccess();
             }
-            if (moduleThreadingActive)
+            for (int i = 0; i < moduleInstance.TableAddrs.Count; i++)
             {
-                for (int i = 0; i < moduleInstance.TableAddrs.Count; i++)
-                    Store[moduleInstance.TableAddrs[(TableIdx)(uint)i]].EnableConcurrentAccess();
+                var t = Store[moduleInstance.TableAddrs[(TableIdx)(uint)i]];
+                if (t.Type.Limits.Shared || moduleThreadingActive)
+                    t.EnableConcurrentAccess();
             }
 
             return moduleInstance;

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -18,6 +18,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using FluentValidation;
 using Wacs.Core.Instructions;
 using Wacs.Core.Instructions.Numeric;
@@ -39,22 +40,43 @@ namespace Wacs.Core.Runtime
         private readonly Dictionary<string, ModuleInstance> _registeredModules = new();
 
         private readonly SharedRuntimeState _shared;
+
+        /// <summary>
+        /// Instantiation-time <see cref="ExecContext"/>. Owns the link-time state
+        /// (<c>_linkLabelStack</c>, <c>LinkConstants</c>, etc.) and is the slot bound
+        /// to the thread that constructed the <see cref="WasmRuntime"/>.
+        /// <para>Module instantiation is single-threaded and always runs against this
+        /// context; see <see cref="InstantiateModule"/>.</para>
+        /// </summary>
         private readonly ExecContext Context;
+
+        /// <summary>
+        /// Per-thread <see cref="ExecContext"/> slots. Each host thread that enters
+        /// the runtime (e.g. via <c>CreateInvoker</c>) lazily gets its own context
+        /// on first access — with its own operand stack, frame pool, locals pool,
+        /// call stack — while sharing <see cref="_shared"/> (Store, Attributes,
+        /// linked instruction arrays) by reference.
+        ///
+        /// <para>The constructing thread's slot is pre-bound to <see cref="Context"/>
+        /// so the single-threaded case preserves existing behavior exactly.</para>
+        ///
+        /// <para><c>trackAllValues</c> is off here; Layer 1d adds a separate tracked
+        /// thread-handle list (on <see cref="IWasmThreadHost"/>) if cancellation
+        /// broadcast needs it. Keeping it off avoids the GC root that ThreadLocal's
+        /// tracking imposes.</para>
+        /// </summary>
+        private readonly ThreadLocal<ExecContext> _threadContext;
+
         public ExecContext ExecContext => GetExecContext();
 
         /// <summary>
-        /// Abstraction point for per-thread <see cref="ExecContext"/> lookup. Layer 1a
-        /// introduces this helper as a single-point-of-change; later subphases swap it
-        /// for a <see cref="System.Threading.ThreadLocal{T}"/> so concurrent host threads
-        /// each get their own operand/frame/locals state without colliding on the
-        /// runtime-singleton <see cref="Context"/> field.
-        ///
-        /// <para>The polymorphic dispatch loop doesn't call this — handlers take
-        /// <c>ExecContext ctx</c> as a parameter and stay on one thread for the duration
-        /// of a call. This helper is only for the runtime's outer entry points
-        /// (CreateInvoker, InstantiateModule glue, binding lookups).</para>
+        /// Returns the calling thread's <see cref="ExecContext"/>, lazily creating
+        /// one on first access for non-constructing threads. Handlers take
+        /// <c>ExecContext ctx</c> as a parameter and stay on one thread — this helper
+        /// is only called from the runtime's outer entry points (CreateInvoker,
+        /// InstantiateModule glue, binding lookups).
         /// </summary>
-        private ExecContext GetExecContext() => Context;
+        private ExecContext GetExecContext() => _threadContext.Value!;
 
         private Store Store => _shared.Store;
         public Store RuntimeStore => _shared.Store;
@@ -70,6 +92,13 @@ namespace Wacs.Core.Runtime
         {
             _shared = new SharedRuntimeState(new Store(), attributes ?? new RuntimeAttributes());
             Context = new ExecContext(_shared);
+
+            // Per-thread ExecContext factory. Constructing thread's slot is pre-bound
+            // to Context (below) so existing single-threaded behavior is unchanged;
+            // any other thread that calls into the runtime gets its own fresh
+            // ExecContext on first access, sharing _shared by reference.
+            _threadContext = new ThreadLocal<ExecContext>(() => new ExecContext(_shared));
+            _threadContext.Value = Context;
 
             //Cached instructions for module initialization
             _dropInst = SpecFactory.Factory.CreateInstruction<InstElemDrop>(ExtCode.ElemDrop);

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -61,12 +61,15 @@ namespace Wacs.Core.Runtime
         /// <para>The constructing thread's slot is pre-bound to <see cref="Context"/>
         /// so the single-threaded case preserves existing behavior exactly.</para>
         ///
-        /// <para><c>trackAllValues</c> is off here; Layer 1d adds a separate tracked
-        /// thread-handle list (on <see cref="IWasmThreadHost"/>) if cancellation
-        /// broadcast needs it. Keeping it off avoids the GC root that ThreadLocal's
-        /// tracking imposes.</para>
+        /// <para>Keyed by <see cref="Thread.CurrentThread.ManagedThreadId"/> rather
+        /// than using <see cref="ThreadLocal{T}"/> — the latter's managed-slot
+        /// allocation crashed .NET's test host when many short-lived
+        /// <see cref="WasmRuntime"/> instances were created in sequence
+        /// (observed during spec-suite runs). The dictionary approach has the
+        /// same per-thread lookup semantics with bounded-lifetime storage.</para>
         /// </summary>
-        private readonly ThreadLocal<ExecContext> _threadContext;
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<int, ExecContext> _threadContext
+            = new();
 
         public ExecContext ExecContext => GetExecContext();
 
@@ -95,7 +98,8 @@ namespace Wacs.Core.Runtime
         /// is only called from the runtime's outer entry points (CreateInvoker,
         /// InstantiateModule glue, binding lookups).
         /// </summary>
-        private ExecContext GetExecContext() => _threadContext.Value!;
+        private ExecContext GetExecContext() =>
+            _threadContext.GetOrAdd(Thread.CurrentThread.ManagedThreadId, _ => new ExecContext(_shared));
 
         private Store Store => _shared.Store;
         public Store RuntimeStore => _shared.Store;
@@ -112,12 +116,10 @@ namespace Wacs.Core.Runtime
             _shared = new SharedRuntimeState(new Store(), attributes ?? new RuntimeAttributes());
             Context = new ExecContext(_shared);
 
-            // Per-thread ExecContext factory. Constructing thread's slot is pre-bound
-            // to Context (below) so existing single-threaded behavior is unchanged;
-            // any other thread that calls into the runtime gets its own fresh
-            // ExecContext on first access, sharing _shared by reference.
-            _threadContext = new ThreadLocal<ExecContext>(() => new ExecContext(_shared));
-            _threadContext.Value = Context;
+            // Pre-bind the constructing thread's slot to Context so existing
+            // single-threaded use sees identical behavior; any other thread gets
+            // its own fresh ExecContext on first access, sharing _shared by reference.
+            _threadContext[Thread.CurrentThread.ManagedThreadId] = Context;
 
             //Cached instructions for module initialization
             _dropInst = SpecFactory.Factory.CreateInstruction<InstElemDrop>(ExtCode.ElemDrop);

--- a/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -337,19 +337,40 @@ namespace Wacs.Core.Runtime
                 }
             }
 
-            // Layer 2b: mark globals/tables as shared if the module declares any
-            // shared memory. Threads-1.0 doesn't define "shared global" or
-            // "shared table" — this is the pragmatic approximation that lets
-            // concurrent host threads safely reach any global/table in a module
-            // whose memory they can also reach. Shared-everything-threads
-            // (future) will flip IsShared per-declaration from the wasm binary.
-            // Only activates when the host policy supports concurrency at all;
-            // NotSupportedPolicy modules (IL2CPP default) pay nothing.
-            if (_shared.Attributes.ConcurrencyPolicy.Mode == Concurrency.ConcurrencyPolicyMode.HostDefined
-                && ModuleHasSharedMemory(moduleInstance))
+            // Layer 5a: shared-everything-threads declared-per-global flag.
+            // Rejects globals that advertise `shared` or `thread_local`
+            // without the runtime opting into the proposal. Preserves
+            // baseline behavior when the flag is off.
+            for (int i = 0; i < moduleInstance.GlobalAddrs.Count; i++)
             {
-                for (int i = 0; i < moduleInstance.GlobalAddrs.Count; i++)
-                    Store[moduleInstance.GlobalAddrs[(GlobalIdx)(uint)i]].EnableConcurrentAccess();
+                var g = Store[moduleInstance.GlobalAddrs[(GlobalIdx)(uint)i]];
+                if ((g.Type.Shared || g.Type.ThreadLocal)
+                    && !_shared.Attributes.EnableSharedEverythingThreads)
+                {
+                    throw new NotSupportedException(
+                        $"Global {i} uses a shared-everything-threads annotation (shared/thread_local) " +
+                        "but the runtime has not opted in via RuntimeAttributes.EnableSharedEverythingThreads.");
+                }
+            }
+
+            // Mark globals/tables as shared based on:
+            //   - Layer 5a: declared-per-global `shared` flag (authoritative when present).
+            //   - Layer 2b: module-has-shared-memory approximation (fallback for
+            //     threads-1.0 modules that predate per-declaration annotations).
+            // Either source flips IsShared; declaration-driven instances are
+            // also concurrent-accessible under threads-1.0 runtimes.
+            bool moduleThreadingActive =
+                _shared.Attributes.ConcurrencyPolicy.Mode == Concurrency.ConcurrencyPolicyMode.HostDefined
+                && ModuleHasSharedMemory(moduleInstance);
+
+            for (int i = 0; i < moduleInstance.GlobalAddrs.Count; i++)
+            {
+                var g = Store[moduleInstance.GlobalAddrs[(GlobalIdx)(uint)i]];
+                if (g.Type.Shared || moduleThreadingActive)
+                    g.EnableConcurrentAccess();
+            }
+            if (moduleThreadingActive)
+            {
                 for (int i = 0; i < moduleInstance.TableAddrs.Count; i++)
                     Store[moduleInstance.TableAddrs[(TableIdx)(uint)i]].EnableConcurrentAccess();
             }

--- a/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
@@ -50,7 +50,7 @@ namespace Wacs.Core.Runtime
 
             try
             {
-                ControlHandlers.InvokeWasm(Context, func);
+                ControlHandlers.InvokeWasm(GetExecContext(), func);
             }
             catch (WasmException we)
             {

--- a/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
@@ -45,12 +45,14 @@ namespace Wacs.Core.Runtime
         /// </summary>
         internal Value[] InvokeViaSwitch(FunctionInstance func, FunctionType funcType, object[] args)
         {
-            GetExecContext().OpStack.PushScalars(funcType.ParameterTypes, args);
-            GetExecContext().SwitchCallDepth = 0;
+            var ctx = GetExecContext();
+            ctx.CheckInterrupt();
+            ctx.OpStack.PushScalars(funcType.ParameterTypes, args);
+            ctx.SwitchCallDepth = 0;
 
             try
             {
-                ControlHandlers.InvokeWasm(GetExecContext(), func);
+                ControlHandlers.InvokeWasm(ctx, func);
             }
             catch (WasmException we)
             {

--- a/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
@@ -43,9 +43,11 @@ namespace Wacs.Core.Runtime
         /// call occupies a normal-sized method frame, so the default process stack is
         /// enough for the spec suite.</para>
         /// </summary>
-        internal Value[] InvokeViaSwitch(FunctionInstance func, FunctionType funcType, object[] args)
+        internal Value[] InvokeViaSwitch(ExecContext ctx, FunctionInstance func, FunctionType funcType, object[] args)
         {
-            var ctx = GetExecContext();
+            // Caller passes the per-thread ExecContext resolved once at the invoker
+            // entry point — see GenericDelegate in WasmRuntimeExecution.cs. Avoids
+            // repeated dictionary lookups on the hot switch-dispatch path.
             ctx.CheckInterrupt();
             ctx.OpStack.PushScalars(funcType.ParameterTypes, args);
             ctx.SwitchCallDepth = 0;
@@ -56,7 +58,7 @@ namespace Wacs.Core.Runtime
             }
             catch (WasmException we)
             {
-                FlushCallStackForSwitch();
+                FlushCallStackForSwitch(ctx);
                 throw new UnhandledWasmException($"Unhandled exception {we.Exn}");
             }
             catch (IndexOutOfRangeException ioe)
@@ -65,30 +67,30 @@ namespace Wacs.Core.Runtime
                 // a fixed-size Value[] rather than going through the polymorphic
                 // throw-on-overflow path. Re-surface as a WasmRuntimeException so
                 // assert_exhaustion tests see the type they expect.
-                FlushCallStackForSwitch();
+                FlushCallStackForSwitch(ctx);
                 throw new Wacs.Core.Runtime.Exceptions.WasmRuntimeException(
                     "Operand stack exhausted: " + ioe.Message);
             }
             catch
             {
-                FlushCallStackForSwitch();
+                FlushCallStackForSwitch(ctx);
                 throw;
             }
 
             Value[] results = new Value[funcType.ResultType.Arity];
             var span = results.AsSpan();
-            GetExecContext().OpStack.PopScalars(funcType.ResultType, span);
+            ctx.OpStack.PopScalars(funcType.ResultType, span);
 
-            GetExecContext().GetModule(func.Address)?.DerefTypes(span);
+            ctx.GetModule(func.Address)?.DerefTypes(span);
 
             // Drain any leftover stack values (shouldn't happen for well-formed modules,
             // but the polymorphic path does the same defensive flush for top-level calls).
-            FlushCallStackForSwitch();
+            FlushCallStackForSwitch(ctx);
 
             return results;
         }
 
-        private void FlushCallStackForSwitch()
+        private void FlushCallStackForSwitch(ExecContext ctx)
         {
             // A push-overflow (hit during the iterative recursion path — each active
             // frame leaves its leftover stack values on the shared OpStack, so deep
@@ -96,7 +98,7 @@ namespace Wacs.Core.Runtime
             // or any other check fires) leaves Count in an out-of-range state. The
             // naïve PopAny loop would re-throw IOOR on the first read. Zero the stack
             // unconditionally here — we're on an abort path, the data is already gone.
-            GetExecContext().OpStack.Count = 0;
+            ctx.OpStack.Count = 0;
         }
     }
 }

--- a/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeSwitch.cs
@@ -45,8 +45,8 @@ namespace Wacs.Core.Runtime
         /// </summary>
         internal Value[] InvokeViaSwitch(FunctionInstance func, FunctionType funcType, object[] args)
         {
-            Context.OpStack.PushScalars(funcType.ParameterTypes, args);
-            Context.SwitchCallDepth = 0;
+            GetExecContext().OpStack.PushScalars(funcType.ParameterTypes, args);
+            GetExecContext().SwitchCallDepth = 0;
 
             try
             {
@@ -75,9 +75,9 @@ namespace Wacs.Core.Runtime
 
             Value[] results = new Value[funcType.ResultType.Arity];
             var span = results.AsSpan();
-            Context.OpStack.PopScalars(funcType.ResultType, span);
+            GetExecContext().OpStack.PopScalars(funcType.ResultType, span);
 
-            Context.GetModule(func.Address)?.DerefTypes(span);
+            GetExecContext().GetModule(func.Address)?.DerefTypes(span);
 
             // Drain any leftover stack values (shouldn't happen for well-formed modules,
             // but the polymorphic path does the same defensive flush for top-level calls).
@@ -94,7 +94,7 @@ namespace Wacs.Core.Runtime
             // or any other check fires) leaves Count in an out-of-range state. The
             // naïve PopAny loop would re-throw IOOR on the first read. Zero the stack
             // unconditionally here — we're on an abort path, the data is already gone.
-            Context.OpStack.Count = 0;
+            GetExecContext().OpStack.Count = 0;
         }
     }
 }

--- a/Wacs.Core/Text/TextModuleParser.Sections.cs
+++ b/Wacs.Core/Text/TextModuleParser.Sections.cs
@@ -717,6 +717,33 @@ namespace Wacs.Core.Text
         {
             if (index >= parent.Children.Count)
                 throw new FormatException($"line {parent.Token.Line}: globaltype missing");
+
+            // Layer 5a/5c: shared-everything-threads globaltype qualifiers.
+            //   (global (shared) ...)         — sharable across host threads
+            //   (global (thread_local) ...)   — per-host-thread instance
+            // Mutually exclusive; at most one appears before the valtype / (mut ...) form.
+            // Feature-flag enforcement happens at module allocation time
+            // (WasmRuntimeInstantiation) — the parser just records the annotation.
+            bool shared = false;
+            bool threadLocal = false;
+            var head = parent.Children[index];
+            if (head.IsForm("shared"))
+            {
+                if (head.Children.Count != 1)
+                    throw new FormatException($"line {head.Token.Line}: (shared) takes no operands");
+                shared = true;
+                index++;
+            }
+            else if (head.IsForm("thread_local"))
+            {
+                if (head.Children.Count != 1)
+                    throw new FormatException($"line {head.Token.Line}: (thread_local) takes no operands");
+                threadLocal = true;
+                index++;
+            }
+
+            if (index >= parent.Children.Count)
+                throw new FormatException($"line {parent.Token.Line}: globaltype missing valtype after qualifier");
             var child = parent.Children[index];
             if (child.IsForm("mut"))
             {
@@ -724,11 +751,11 @@ namespace Wacs.Core.Text
                     throw new FormatException($"line {child.Token.Line}: (mut …) must wrap one valtype");
                 var vt = ParseValType(ctx, child.Children[1]);
                 index++;
-                return new GlobalType(vt, Mutability.Mutable);
+                return new GlobalType(vt, Mutability.Mutable, shared, threadLocal);
             }
             var constType = ParseValType(ctx, child);
             index++;
-            return new GlobalType(constType, Mutability.Immutable);
+            return new GlobalType(constType, Mutability.Immutable, shared, threadLocal);
         }
 
         // ---- (export "name" (kind idx)) -----------------------------------

--- a/Wacs.Core/Types/GlobalType.cs
+++ b/Wacs.Core/Types/GlobalType.cs
@@ -36,21 +36,45 @@ namespace Wacs.Core.Types
         /// </summary>
         public readonly Mutability Mutability;
 
-        public GlobalType(ValType valtype, Mutability mut) =>
-            (ContentType, Mutability) = (valtype, mut);
+        /// <summary>
+        /// Shared-everything-threads (Layer 5a): when true, this global is
+        /// shared across host threads and must be accessed via the
+        /// <c>global.atomic.*</c> opcodes (Layer 5d). Parsed from bit 1 of
+        /// the global-flags byte. Validation rejects when the runtime has
+        /// not opted into the shared-everything-threads proposal subset.
+        /// </summary>
+        public readonly bool Shared;
+
+        /// <summary>
+        /// Shared-everything-threads (Layer 5c): when true, each host
+        /// thread sees its own copy of this global, initialized from the
+        /// module's declared initializer on first access. Parsed from
+        /// bit 2 of the global-flags byte. Mutually exclusive with
+        /// <see cref="Shared"/>.
+        /// </summary>
+        public readonly bool ThreadLocal;
+
+        public GlobalType(ValType valtype, Mutability mut, bool shared = false, bool threadLocal = false) =>
+            (ContentType, Mutability, Shared, ThreadLocal) = (valtype, mut, shared, threadLocal);
 
         public ResultType ResultType => new(ContentType);
 
-        public override string ToString() =>
-            $"GlobalType({(Mutability == Mutability.Immutable ? "const" : "var")} {ContentType})";
+        public override string ToString()
+        {
+            var mut = Mutability == Mutability.Immutable ? "const" : "var";
+            var qual = Shared ? "shared " : ThreadLocal ? "thread_local " : "";
+            return $"GlobalType({qual}{mut} {ContentType})";
+        }
 
         public override bool Equals(object obj) =>
             obj is GlobalType other &&
             ContentType == other.ContentType &&
-            Mutability == other.Mutability;
+            Mutability == other.Mutability &&
+            Shared == other.Shared &&
+            ThreadLocal == other.ThreadLocal;
 
         public override int GetHashCode() =>
-            HashCode.Combine(ContentType, Mutability);
+            HashCode.Combine(ContentType, Mutability, Shared, ThreadLocal);
 
         public static bool operator ==(GlobalType left, GlobalType right) =>
             Equals(left, right);
@@ -61,16 +85,31 @@ namespace Wacs.Core.Types
 
         /// <summary>
         /// @Spec 5.3.10. Global Types
+        /// Baseline: single mutability byte (0=const, 1=mut).
+        /// Shared-everything-threads extension (Layer 5):
+        /// bit 1 = shared, bit 2 = thread_local. Feature-flag check
+        /// happens at module-allocation time in WasmRuntimeInstantiation
+        /// — parsing accepts the raw bits so the binary can round-trip
+        /// cleanly.
         /// </summary>
-        public static GlobalType Parse(BinaryReader reader) => 
+        public static GlobalType Parse(BinaryReader reader) =>
             new(
                 valtype: ValTypeParser.Parse(reader),
-                mut: MutabilityParser.Parse(reader)
+                mut: MutabilityParser.Parse(reader, out var shared, out var threadLocal),
+                shared: shared,
+                threadLocal: threadLocal
             );
 
         public bool Matches(GlobalType other, TypesSpace? types)
         {
             if (Mutability != other.Mutability)
+                return false;
+            // Shared / thread-local must match exactly — a host providing a
+            // plain global can't satisfy a shared import (the synchronization
+            // discipline differs), and vice versa.
+            if (Shared != other.Shared)
+                return false;
+            if (ThreadLocal != other.ThreadLocal)
                 return false;
             if (!ContentType.Matches(other.ContentType, types))
                 return false;
@@ -105,6 +144,11 @@ namespace Wacs.Core.Types
     
     public static class MutabilityParser
     {
+        /// <summary>
+        /// Baseline-compatible parse: accepts only the bare 0/1 byte. Kept
+        /// for callers that don't participate in the shared-everything
+        /// extension.
+        /// </summary>
         public static Mutability Parse(BinaryReader reader) =>
             (Mutability)reader.ReadByte() switch
             {
@@ -112,6 +156,29 @@ namespace Wacs.Core.Types
                 Mutability.Mutable => Mutability.Mutable,     //var
                 var flag => throw new FormatException($"Invalid Mutability flag {flag} at offset {reader.BaseStream.Position}.")
             };
+
+        /// <summary>
+        /// Shared-everything-aware parse. Decodes bit 0 as mutability,
+        /// bit 1 as <c>shared</c>, bit 2 as <c>thread_local</c>. Rejects
+        /// any other bits as malformed. Feature-flag enforcement (reject
+        /// shared/thread_local when the runtime has not opted in) happens
+        /// downstream at module-allocation time; parsing is permissive so
+        /// the binary round-trips cleanly.
+        /// </summary>
+        public static Mutability Parse(BinaryReader reader, out bool shared, out bool threadLocal)
+        {
+            byte flags = reader.ReadByte();
+            if ((flags & ~0x07) != 0)
+                throw new FormatException($"Invalid global flags 0x{flags:X2} at offset {reader.BaseStream.Position}.");
+
+            shared = (flags & 0x02) != 0;
+            threadLocal = (flags & 0x04) != 0;
+
+            if (shared && threadLocal)
+                throw new FormatException($"Global cannot be both shared and thread_local (flags 0x{flags:X2}) at offset {reader.BaseStream.Position}.");
+
+            return (flags & 0x01) != 0 ? Mutability.Mutable : Mutability.Immutable;
+        }
     }
 
 }

--- a/Wacs.Core/Types/IndexSpace.cs
+++ b/Wacs.Core/Types/IndexSpace.cs
@@ -51,6 +51,8 @@ namespace Wacs.Core.Types
             set => _space[(int)idx.Value] = value;
         }
 
+        public int Count => _space.Count;
+
         public bool Contains(TableIdx idx) => idx.Value < _space.Count;
 
         public void Add(TableAddr element) => _space.Add(element);
@@ -63,6 +65,13 @@ namespace Wacs.Core.Types
         private MemAddr[]? _space;
 
         public MemAddr this[MemIdx idx] => _space![(int)idx.Value];
+
+        /// <summary>Count of allocated memory addresses. Only valid post-finalize.</summary>
+        public int Count => _space?.Length ?? _build!.Count;
+
+        /// <summary>Access by plain-int index (for iteration). Use the
+        /// <see cref="this[MemIdx]"/> indexer for typed access in hot paths.</summary>
+        public MemAddr At(int idx) => _space![idx];
 
         public bool Contains(MemIdx idx) => idx.Value < _space!.Length;
 
@@ -94,6 +103,8 @@ namespace Wacs.Core.Types
             get => _space[(int)idx.Value];
             set => _space[(int)idx.Value] = value;
         }
+
+        public int Count => _space.Count;
 
         public bool Contains(GlobalIdx idx) => idx.Value < _space.Count;
 

--- a/Wacs.Transpiler.Lib/AOT/TranspiledFunction.cs
+++ b/Wacs.Transpiler.Lib/AOT/TranspiledFunction.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 using System.Reflection;
 using Wacs.Core.Runtime;
 using Wacs.Core.Runtime.Exceptions;
@@ -36,7 +37,13 @@ namespace Wacs.Transpiler.AOT
         private readonly MethodInfo _method;
         public MethodInfo Method => _method;
         private readonly ThinContext _ctx;
-        private readonly object?[] _paramBuffer;
+        /// <summary>
+        /// Total slot count (1 ThinContext + _paramCount + _outParamCount). Used to
+        /// size the per-call buffer rented from <see cref="ArrayPool{T}.Shared"/>.
+        /// Previously this was a reused instance field — racy under concurrent
+        /// entry of the same function (Layer 2).
+        /// </summary>
+        private readonly int _bufferLength;
         private readonly int _paramCount;
         private readonly int _resultCount;
 
@@ -59,62 +66,81 @@ namespace Wacs.Transpiler.AOT
             _paramCount = type.ParameterTypes.Arity;
             _resultCount = type.ResultType.Arity;
             _outParamCount = _resultCount > 1 ? _resultCount - 1 : 0;
-            // +1 for ThinContext + out params
-            _paramBuffer = new object?[1 + _paramCount + _outParamCount];
-            _paramBuffer[0] = ctx;
+            // +1 for ThinContext + params + out params
+            _bufferLength = 1 + _paramCount + _outParamCount;
         }
 
         public void SetName(string name) => Name = name;
 
         public void Invoke(ExecContext context)
         {
-            // Pop parameters from the interpreter's OpStack (reverse order)
-            for (int i = _paramCount; i > 0; i--)
-            {
-                var val = context.OpStack.PopAny();
-                _paramBuffer[i] = ConvertFromValue(val, Type.ParameterTypes.Types[i - 1]);
-            }
-
-            // Invoke the transpiled method
-            object? result;
+            // Per-call param buffer (Layer 2e). Previously this was an instance
+            // field reused across invocations, which raced under concurrent entry
+            // of the same TranspiledFunction — thread A's PopAny could be
+            // overwritten by thread B mid-MethodInfo.Invoke. ArrayPool gives us
+            // bounded-lifetime per-call storage with no per-call allocation on
+            // the steady-state hot path (uncontended Rent/Return is ~10ns).
+            //
+            // ArrayPool.Rent may return a larger array than requested — we only
+            // index the prefix [0, _bufferLength). clearArray: true on return
+            // wipes the references so GC can reclaim any boxed values we wrote.
+            var paramBuffer = ArrayPool<object?>.Shared.Rent(_bufferLength);
             try
             {
-                result = _method.Invoke(null, _paramBuffer);
-            }
-            catch (System.Reflection.TargetInvocationException tie)
-            {
-                var inner = tie.InnerException;
-                if (inner is TrapException or WasmRuntimeException)
-                {
-                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(inner);
-                }
-                // Wrap CLR arithmetic/memory exceptions as WASM traps
-                if (inner is DivideByZeroException)
-                    throw new TrapException("integer divide by zero");
-                if (inner is OverflowException)
-                    throw new TrapException("integer overflow");
-                if (inner is IndexOutOfRangeException)
-                    throw new TrapException("out of bounds memory access");
+                paramBuffer[0] = _ctx;
 
-                if (inner != null)
-                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(inner);
-                throw;
-            }
-
-            // Push results back onto OpStack
-            if (_resultCount >= 1)
-            {
-                if (result == null)
-                    throw new System.InvalidOperationException(
-                        $"TranspiledFunction '{Name}' expected {_resultCount} result(s) but method returned null");
-                // Result 0 is the CLR return value
-                context.OpStack.PushValue(ConvertToValue(result, Type.ResultType.Types[0]));
-                // Results 1..N are in the out param slots of _paramBuffer
-                for (int i = 0; i < _outParamCount; i++)
+                // Pop parameters from the interpreter's OpStack (reverse order)
+                for (int i = _paramCount; i > 0; i--)
                 {
-                    var outVal = _paramBuffer[1 + _paramCount + i];
-                    context.OpStack.PushValue(ConvertToValue(outVal!, Type.ResultType.Types[i + 1]));
+                    var val = context.OpStack.PopAny();
+                    paramBuffer[i] = ConvertFromValue(val, Type.ParameterTypes.Types[i - 1]);
                 }
+
+                // Invoke the transpiled method
+                object? result;
+                try
+                {
+                    result = _method.Invoke(null, paramBuffer);
+                }
+                catch (System.Reflection.TargetInvocationException tie)
+                {
+                    var inner = tie.InnerException;
+                    if (inner is TrapException or WasmRuntimeException)
+                    {
+                        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(inner);
+                    }
+                    // Wrap CLR arithmetic/memory exceptions as WASM traps
+                    if (inner is DivideByZeroException)
+                        throw new TrapException("integer divide by zero");
+                    if (inner is OverflowException)
+                        throw new TrapException("integer overflow");
+                    if (inner is IndexOutOfRangeException)
+                        throw new TrapException("out of bounds memory access");
+
+                    if (inner != null)
+                        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(inner);
+                    throw;
+                }
+
+                // Push results back onto OpStack
+                if (_resultCount >= 1)
+                {
+                    if (result == null)
+                        throw new System.InvalidOperationException(
+                            $"TranspiledFunction '{Name}' expected {_resultCount} result(s) but method returned null");
+                    // Result 0 is the CLR return value
+                    context.OpStack.PushValue(ConvertToValue(result, Type.ResultType.Types[0]));
+                    // Results 1..N are in the out param slots of paramBuffer
+                    for (int i = 0; i < _outParamCount; i++)
+                    {
+                        var outVal = paramBuffer[1 + _paramCount + i];
+                        context.OpStack.PushValue(ConvertToValue(outVal!, Type.ResultType.Types[i + 1]));
+                    }
+                }
+            }
+            finally
+            {
+                ArrayPool<object?>.Shared.Return(paramBuffer, clearArray: true);
             }
         }
 

--- a/Wacs.WASI.Threads/Wacs.WASI.Threads.csproj
+++ b/Wacs.WASI.Threads/Wacs.WASI.Threads.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <LangVersion>9</LangVersion>
+        <Nullable>enable</Nullable>
+        <Title>Wacs WASI Threads</Title>
+        <PackageId>WACS.WASI.Threads</PackageId>
+        <Authors>Kelvin Nishikawa</Authors>
+        <Description>wasi-threads host-import adapter for WACS. Binds `wasi:thread-spawn` onto the core IWasmThreadHost primitive so wasm modules with shared memory can spawn worker threads.</Description>
+        <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
+        <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <AssemblyName>Wacs.WASI.Threads</AssemblyName>
+        <AssemblyVersion>0.1.0</AssemblyVersion>
+        <Version>0.1.0</Version>
+        <RepositoryType>git</RepositoryType>
+        <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+        <IsAotCompatible>true</IsAotCompatible>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+      <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Wacs.Core\Wacs.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Wacs.WASI.Threads/WasiThreads.cs
+++ b/Wacs.WASI.Threads/WasiThreads.cs
@@ -1,0 +1,129 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+using System;
+using System.Threading;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+
+namespace Wacs.WASI.Threads
+{
+    /// <summary>
+    /// wasi-threads host-import adapter. Binds the
+    /// <c>wasi:thread-spawn</c> import onto the core
+    /// <see cref="Wacs.Core.Runtime.Concurrency.IWasmThreadHost"/> primitive so
+    /// wasm modules with shared memory can spawn worker threads that share
+    /// the module's linear memory, tables, and globals.
+    ///
+    /// <para>Usage (wire before module instantiation so the import resolves):</para>
+    /// <code>
+    ///     var runtime = new WasmRuntime();
+    ///     new WasiThreads().BindToRuntime(runtime);
+    ///     var inst = runtime.InstantiateModule(module);
+    /// </code>
+    ///
+    /// <para>Spec: <a href="https://github.com/WebAssembly/wasi-threads">github.com/WebAssembly/wasi-threads</a>.
+    /// Module contract:</para>
+    /// <list type="bullet">
+    /// <item>Declares or imports shared memory (no spec-level check here — the
+    /// first atomic op traps if memory isn't shared).</item>
+    /// <item>Exports <c>wasi_thread_start (param i32 i32)</c> — the per-thread
+    /// entry point that the host invokes with <c>(tid, start_arg)</c>.</item>
+    /// <item>Imports <c>(wasi) (thread-spawn) (param i32) (result i32)</c> —
+    /// call with <c>start_arg</c>; get back a positive tid, or a negative value
+    /// on failure.</item>
+    /// </list>
+    ///
+    /// <para>A future shared-everything-threads <c>thread.spawn</c> *instruction*
+    /// would dispatch through the same
+    /// <see cref="Wacs.Core.Runtime.Concurrency.IWasmThreadHost"/> primitive —
+    /// the wasm-host-import surface (this class) and the wasm-instruction
+    /// surface remain two clients of one core, by design.</para>
+    /// </summary>
+    public sealed class WasiThreads : IBindable
+    {
+        private const string ModuleName = "wasi";
+        private const string SpawnFunctionName = "thread-spawn";
+
+        /// <summary>
+        /// Name of the exported entry function the spec requires on any module
+        /// that calls <c>thread-spawn</c>. Signature: <c>(param i32 i32)</c> —
+        /// <c>(tid, start_arg)</c>. Missing export → spawn returns -1.
+        /// </summary>
+        public const string ThreadStartExport = "wasi_thread_start";
+
+        private WasmRuntime? _runtime;
+
+        /// <summary>
+        /// Monotonic source of positive-i32 thread ids. Starts at 0, first
+        /// <see cref="Interlocked.Increment(ref int)"/> yields tid 1. No
+        /// recycling — if a process spawns &gt;int.MaxValue threads over its
+        /// lifetime, subsequent spawns return -1. Recycling can be added
+        /// as an additive change when a real workload needs it.
+        /// </summary>
+        private int _nextTid;
+
+        public void BindToRuntime(WasmRuntime runtime)
+        {
+            if (runtime == null) throw new ArgumentNullException(nameof(runtime));
+            _runtime = runtime;
+            runtime.BindHostFunction<Func<ExecContext, int, int>>(
+                (ModuleName, SpawnFunctionName), ThreadSpawn);
+        }
+
+        /// <summary>
+        /// Handler for <c>wasi:thread-spawn</c>. Returns a positive tid on
+        /// success, or -1 on any failure (no <c>wasi_thread_start</c> export,
+        /// runtime not bound, tid counter exhausted, spawn machinery threw).
+        /// </summary>
+        private int ThreadSpawn(ExecContext ctx, int startArg)
+        {
+            var runtime = _runtime;
+            if (runtime == null) return -1;
+
+            // Resolve wasi_thread_start on the module that called thread-spawn.
+            // Using ctx.Frame.Module avoids an explicit RegisterModule step —
+            // the calling module's own exports are the source of truth.
+            var entry = FindThreadStart(ctx.Frame.Module);
+            if (entry == null) return -1;
+
+            int tid = Interlocked.Increment(ref _nextTid);
+            if (tid <= 0) return -1; // exhaustion / wraparound
+
+            try
+            {
+                runtime.ThreadHost.Spawn(
+                    entry.Value,
+                    new[] { (Value)tid, (Value)startArg });
+            }
+            catch
+            {
+                return -1;
+            }
+
+            return tid;
+        }
+
+        private static FuncAddr? FindThreadStart(ModuleInstance module)
+        {
+            foreach (var export in module.Exports)
+            {
+                if (export.Name == ThreadStartExport
+                    && export.Value is ExternalValue.Function f)
+                {
+                    return f.Address;
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Five stacked layers, 25 commits, making WACS reentrant under concurrent host threads and positioning for shared-everything-threads/Component Model adoption.

**Layer 1 — Per-thread execution substrate.** `WasmRuntime.Context` singleton → `ConcurrentDictionary<ThreadId, ExecContext>`. Each host thread gets its own operand stack / frame pool / locals pool / call stack; `SharedRuntimeState` holds Store + Attributes + linked instruction arrays by reference. New `IWasmThreadHost` / `WasmThread` / `ThreadBasedHost` primitives in `Wacs.Core.Runtime.Concurrency`. Task-based completion, `CancellationToken` observed at call boundaries, `InterruptedException : TrapException`.

**Layer 2 — Shared-mutable state hardening.** Lock-when-shared / direct-when-unshared pattern:
- `GlobalInstance.Value` (24-byte struct) serializes concurrent read/write through a lazy per-instance lock when `IsShared`.
- `TableInstance.Grow` pre-allocates `List<T>.Capacity` in a single atomic field-swap before appending — readers of valid indices stay lock-free, never see a mid-resize state.
- `TranspiledFunction` swaps its reused `_paramBuffer` for `ArrayPool<object?>.Shared.Rent`/`Return` per call.
- Dead `_asideVals` static stacks removed; `Store.ReplaceFunction` documented as init-only.

**Layer 3 — wasi-threads adapter.** New sibling project `Wacs.WASI.Threads` with `WasiThreads : IBindable` wiring `wasi:thread-spawn` onto `IWasmThreadHost.Spawn`. Monotonic positive-i32 tid allocation; `wasi_thread_start` resolved via `ctx.Frame.Module.Exports`.

**Layer 4 — Soak + integration tests.** 13 new tests: atomic-op variety matrix (every RMW family × i32/i64 + subword under 16-thread × 1k-iter contention), wait/notify producer-consumer through `HostDefinedPolicy` (with timeout + not-equal precheck), 60-runtime soak regression gate.

**Layer 5 — Shared-everything-threads foundation.** Feature-flagged (`RuntimeAttributes.EnableSharedEverythingThreads`, default off):
- `(global (shared) ...)` / `(global (thread_local) ...)` parsed from binary (bits 1 and 2 of mutability byte) and text.
- `(table ... shared)` wired through.
- Per-declaration `IsShared` / `IsThreadLocal`; Layer 2b's module-level approximation stays as fallback.
- Thread-local globals stored on per-thread `ExecContext`.
- Import-type matching enforces shared/thread_local equality.

Deferred for opcode stability: `global.atomic.*` instructions, `pause`. Shared globals still work correctly through regular `global.get`/`global.set` via the lock foundation.

## Design principles

- **One primitive, multiple clients.** `IWasmThreadHost.Spawn` is the single thread-spawn primitive. wasi-threads (L3) is client #1; a future Component Threads adapter for `thread.spawn_ref`/`thread.spawn_indirect` canonical builtins will be client #2. No rewiring when Component Model lands.
- **Lock when shared; direct when unshared.** Non-threaded modules and IL2CPP (`NotSupportedPolicy` default) pay zero overhead — `IsShared` gates every bit of synchronization.
- **Movable `ExecContext`.** Nothing stack-allocated or pinned to a native thread. Today: one Thread per wasm thread, blocking `atomic.wait`. Future: async wait can yield the host thread and resume on a different one without rearchitecture.
- **AOT-compatible throughout.** No runtime `Reflection.Emit`. `ConcurrentDictionary`, `Interlocked`, `Volatile`, `ReaderWriterLockSlim` only.
- **Feature-flag pre-standard bits.** Layer 5 shares-everything parsing gated behind an opt-in so proposal churn can't break baseline wasm.

## Test plan

- [x] Wacs.Core.Test: **366/366** (was 338 — +28 new concurrent-execution tests)
- [x] Wacs.Transpiler.Test: 561/561
- [x] Spec.Test (full wasm-3.0 suite): 723/723
- [x] AOT publish (`osx-arm64`, `-p:PublishAot=true`): clean 15MB native binary
- [x] `ConcurrentInvokeTests`: 8 threads × 1000 iters atomic RMW on shared memory; sum exact
- [x] `ConcurrentAtomicMatrixTests`: op × width matrix under contention
- [x] `ConcurrentWaitNotifyTests`: producer/consumer via spawned wasm threads
- [x] `MultiRuntimeSoakTests`: 60 short-lived runtimes sequentially with GC checkpoints
- [x] `WasiThreadsTests`: end-to-end wasm-spawns-threads workload
- [x] `SharedEverythingTests`: feature-flag enforcement, shared-global tear-free under contention, thread-local per-thread scoping

## Commit layout

24 per-subphase commits + 1 CHANGELOG. Stacked structure:
```
main
└── L1: exec-context (8 commits) — 1a..1g + ctx-cache fix
    └── L2: shared-state (7 commits) — 2a..2g
        └── L3: wasi-threads (1 commit)
            └── L4: soak (3 commits) — 4a..4c
                └── L5: shared-everything (5 commits) — 5f, 5a, 5b, 5c, 5g
                    └── CHANGELOG
```

Each commit body documents rationale; each subphase builds cleanly. Happy to split into separate PRs if preferred.

## Out of scope / future work

- **Emscripten pthreads ABI** — Web Workers–flavored runtime surface; much larger than wasi-threads. Most new threaded wasm workflows are converging on wasi-threads, so deferred unless demand emerges.
- **`global.atomic.*` + `pause`** — shared-everything-threads proposal hasn't assigned opcode bytes. Shared globals still work through the lock path; atomic ops are a perf refinement.
- **Shared structs/arrays, shared function references** — type-system discipline still evolving in the proposal.
- **Component Model canonical builtins** — separate program; will wire onto `IWasmThreadHost.Spawn` as a new adapter when Component Model support lands.
- **Async `atomic.wait`** — `IConcurrencyPolicy.Wait32Async` default-method surface exists (L1e); a yielding implementation needs the invoke loop to be async-aware.
- **Switch-runtime + AOT codegen** for atomic-global opcodes (when they're opcode-stabilized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)