### PR TITLE
Release: WACS 0.9.0 + Transpiler(.Lib) 0.3.0 + WASI.Threads 0.1.0

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -6,6 +6,7 @@ on:
       - 'WACS-v*.*.*'
       - 'WASIp1-v*.*.*'
       - 'WACS-Transpiler-v*.*.*'
+      - 'WACS-WASI-Threads-v*.*.*'
 
 jobs:
   build-and-publish:
@@ -29,6 +30,9 @@ jobs:
           - path: Wacs.Transpiler.Lib
             package_name: WACS.Transpiler.Lib
             tag_prefix: WACS-Transpiler-v
+          - path: Wacs.WASI.Threads
+            package_name: WACS.WASI.Threads
+            tag_prefix: WACS-WASI-Threads-v
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Concurrent wasm execution
+## [0.9.0] + WACS.Transpiler / Transpiler.Lib [0.3.0] + WACS.WASI.Threads [0.1.0] — Concurrent wasm execution
 
 Makes the WACS runtime reentrant under concurrent host threads,
 hardens shared-mutable state, adds a wasi-threads host adapter, and

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Harnessed results from [wasm-feature-detect](https://github.com/GoogleChromeLabs
 
 |Proposal |Features|    |
 |------|-------|----|
-|**Finished — merged to wasm-3.0 core spec**|
+|**Phase 5 – Standardized**|
 |[Branch Hinting](https://github.com/WebAssembly/branch-hinting)||<span title="Custom section ignored; no behavior impact">✅</span>|
 |[Bulk memory operations](https://github.com/webassembly/bulk-memory-operations)||✅|
 |[Custom Annotation Syntax in the Text Format](https://github.com/WebAssembly/annotations)||✅|
@@ -85,16 +85,14 @@ Harnessed results from [wasm-feature-detect](https://github.com/GoogleChromeLabs
 |[Sign-extension operators](https://github.com/WebAssembly/sign-extension-ops)||✅|
 |[Tail call](https://github.com/webassembly/tail-call)|tail_call|✅|
 |[Typed Function References](https://github.com/WebAssembly/function-references)|function-references|✅|
-|**Phase 5 — Standardized (not yet merged)**|
-|_(no current entries — proposals progress directly from Phase 4 to merged)_|
-|**Phase 4 — Standardize**|
+|**Phase 4 – Standardize**|
 |[JS Promise Integration](https://github.com/WebAssembly/js-promise-integration)|jspi|<span title="Browser idiom, but conceptually supported">✳️</span>|
 |[Threads](https://github.com/webassembly/threads)|threads|✅|
 |[Web Content Security Policy](https://github.com/WebAssembly/content-security-policy)||<span title="Browser idioms, not directly supported">🌐</span>|
 
 Legend: ✅ supported · ❌ not yet · ✳️ conceptually supported (browser idiom) · 🌐 browser-only / N/A for non-web hosts
 
-###### Table limited to Phase 4, Phase 5, and merged proposals. Phase assignments cross-checked against [WebAssembly/proposals@1584fdf](https://github.com/WebAssembly/proposals/commit/1584fdf) (2026-03-24) and [WebAssembly/proposals/finished-proposals.md](https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md). Browser-idiom ✳️/🌐 results harnessed from [wasm-feature-detect](https://github.com/GoogleChromeLabs/wasm-feature-detect) via the [Feature.Detect](./Feature.Detect) test harness.
+###### Grouping follows [webassembly.org/features](https://webassembly.org/features/): Phase 5 is the combined standardized set (including finished proposals merged to the core spec) and Phase 4 is the active standardize queue. Phase assignments cross-checked against [WebAssembly/proposals@1584fdf](https://github.com/WebAssembly/proposals/commit/1584fdf) (2026-03-24) and [WebAssembly/proposals/finished-proposals.md](https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md). Browser-idiom ✳️/🌐 results harnessed from [wasm-feature-detect](https://github.com/GoogleChromeLabs/wasm-feature-detect) via the [Feature.Detect](./Feature.Detect) test harness.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -85,43 +85,16 @@ Harnessed results from [wasm-feature-detect](https://github.com/GoogleChromeLabs
 |[Sign-extension operators](https://github.com/WebAssembly/sign-extension-ops)||✅|
 |[Tail call](https://github.com/webassembly/tail-call)|tail_call|✅|
 |[Typed Function References](https://github.com/WebAssembly/function-references)|function-references|✅|
+|**Phase 5 — Standardized (not yet merged)**|
+|_(no current entries — proposals progress directly from Phase 4 to merged)_|
 |**Phase 4 — Standardize**|
 |[JS Promise Integration](https://github.com/WebAssembly/js-promise-integration)|jspi|<span title="Browser idiom, but conceptually supported">✳️</span>|
 |[Threads](https://github.com/webassembly/threads)|threads|✅|
 |[Web Content Security Policy](https://github.com/WebAssembly/content-security-policy)||<span title="Browser idioms, not directly supported">🌐</span>|
-|**Phase 3 — Implementation**|
-|[Compact Import Section](https://github.com/WebAssembly/compact-import-section)||❌|
-|[Custom Descriptors and JS Interop](https://github.com/WebAssembly/custom-descriptors)||<span title="Browser idioms, not directly supported">🌐</span>|
-|[Custom Page Sizes](https://github.com/WebAssembly/custom-page-sizes)||❌|
-|[ESM Integration](https://github.com/WebAssembly/esm-integration)||<span title="Browser idioms, not directly supported">🌐</span>|
-|[Stack Switching](https://github.com/WebAssembly/stack-switching)||❌|
-|[Wide Arithmetic](https://github.com/WebAssembly/wide-arithmetic)||❌|
-|**Phase 2 — Proposed Spec Text**|
-|[Compilation Hints](https://github.com/WebAssembly/compilation-hints)||❌|
-|[Extended Name Section](https://github.com/WebAssembly/extended-name-section)||❌|
-|[JS Primitive Builtins](https://github.com/WebAssembly/js-primitive-builtins)||<span title="Browser idioms, not directly supported">🌐</span>|
-|[Numeric Values in WAT Data Segments](https://github.com/WebAssembly/wat-numeric-values)||❌|
-|[Relaxed dead code validation](https://github.com/WebAssembly/relaxed-dead-code-validation)||❌|
-|[Rounding Variants](https://github.com/WebAssembly/rounding-mode-control)||❌|
-|**Phase 1 — Feature Proposal**|
-|[Component Model](https://github.com/WebAssembly/component-model)||❌|
-|[Flexible Vectors](https://github.com/WebAssembly/flexible-vectors)||❌|
-|[Frozen Values](https://github.com/WebAssembly/frozen-values)||❌|
-|[Half Precision](https://github.com/WebAssembly/half-precision)||❌|
-|[Memory control](https://github.com/WebAssembly/memory-control)||❌|
-|[More Array Constructors](https://github.com/WebAssembly/more-array-constructors)||❌|
-|[Multibyte Array Access](https://github.com/WebAssembly/multibyte-array-access)||❌|
-|[Reference-Typed Strings](https://github.com/WebAssembly/stringref)||❌|
-|[Shared-Everything Threads](https://github.com/WebAssembly/shared-everything-threads)||<span title="Foundation shipped: shared/thread_local annotations, IsShared wiring, lock discipline. Canonical instructions (global.atomic.*, pause) deferred until the proposal assigns opcode bytes.">🟡</span>|
-|[Type Imports](https://github.com/WebAssembly/type-imports)||❌|
-|[Type Reflection for WebAssembly JavaScript API](https://github.com/WebAssembly/js-types)|type-reflection|<span title="Browser idioms, not directly supported">🌐</span>|
-|**Not a proposal (WACS out-of-scope)**|
-|[Legacy Exception Handling](https://github.com/WebAssembly/exception-handling)|exceptions|❌|
-|[Streaming Compilation](https://webassembly.github.io/spec/web-api/index.html#streaming-modules)|streaming_compilation|<span title="Browser idioms, not directly supported">🌐</span>|
 
-Legend: ✅ supported · 🟡 partial · ❌ not yet · ✳️ conceptually supported (browser idiom) · 🌐 browser-only / N/A for non-web hosts
+Legend: ✅ supported · ❌ not yet · ✳️ conceptually supported (browser idiom) · 🌐 browser-only / N/A for non-web hosts
 
-###### Phase assignments cross-checked against [WebAssembly/proposals@1584fdf](https://github.com/WebAssembly/proposals/commit/1584fdf) (2026-03-24) and [WebAssembly/proposals/finished-proposals.md](https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md). Browser-idiom ✳️/🌐 results harnessed from [wasm-feature-detect](https://github.com/GoogleChromeLabs/wasm-feature-detect) via the [Feature.Detect](./Feature.Detect) test harness.
+###### Table limited to Phase 4, Phase 5, and merged proposals. Phase assignments cross-checked against [WebAssembly/proposals@1584fdf](https://github.com/WebAssembly/proposals/commit/1584fdf) (2026-03-24) and [WebAssembly/proposals/finished-proposals.md](https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md). Browser-idiom ✳️/🌐 results harnessed from [wasm-feature-detect](https://github.com/GoogleChromeLabs/wasm-feature-detect) via the [Feature.Detect](./Feature.Detect) test harness.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ WACS supports the latest standardized webassembly feature extensions including *
 - **Godot Compatibility**: Compatible with **Godot Engine - [.NET](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_basics.html)**. 
 - **Pure C# Implementation**: Written in C# 9.0/.NET Standard 2.1. (No `unsafe` keyword blocks, no raw pointer arithmetic — see [notes on `System.Runtime.CompilerServices.Unsafe` in the switch dispatcher](#running-wacsconsole).)
 - **No Complex Dependencies**: Uses [FluentValidation](https://github.com/FluentValidation/FluentValidation) and [Microsoft.Extensions.ObjectPool](https://www.nuget.org/packages/Microsoft.Extensions.ObjectPool) as its only dependencies.
-- **WebAssembly 3.0 Spec Compliance**: Passes the [WebAssembly 3.0](https://webassembly.github.io/spec/versions/core/WebAssembly-3.0-draft.pdf) spec [test suite](https://github.com/WebAssembly/spec/tree/wasm-3.0).
+- **WebAssembly 3.0 Spec Compliance**: Passes the [WebAssembly 3.0](https://webassembly.github.io/spec/versions/core/WebAssembly-3.0.pdf) spec [test suite](https://github.com/WebAssembly/spec/tree/wasm-3.0).
 - **First-class WAT / WAST**: Pure-C# reader and writer for the WebAssembly text format. `Wacs.Console` takes `.wat` directly; the spec `.wast` suite parses natively with no external `wast2json` / wabt dependency.
 - **Magical Interop**: Host bindings are validated with reflection, no boilerplate code required.
 - **Async Tasks**: [JSPI](https://github.com/WebAssembly/js-promise-integration)-like non-blocking calls for async functions.
@@ -57,7 +57,7 @@ Because WebAssembly is memory-safe and can be ahead-of-time validated, WACS make
 UGC, DLC, or plugin systems that include executable logic.
 
 ## WebAssembly Feature Extensions
-WACS is based on the [WebAssembly Core 3 draft spec](https://webassembly.github.io/spec/versions/core/WebAssembly-3.0-draft.pdf) and passes the associated [test suite](https://github.com/WebAssembly/spec/tree/wasm-3.0).
+WACS is based on the [WebAssembly Core 3 spec](https://webassembly.github.io/spec/versions/core/WebAssembly-3.0.pdf) and passes the associated [test suite](https://github.com/WebAssembly/spec/tree/wasm-3.0).
 
 Support for all standardized extensions is listed below.
 
@@ -65,34 +65,63 @@ Harnessed results from [wasm-feature-detect](https://github.com/GoogleChromeLabs
 
 |Proposal |Features|    |
 |------|-------|----|
-|Phase 5|
-|[JavaScript BigInt to WebAssembly i64 integration](https://github.com/WebAssembly/JS-BigInt-integration)||<span title="Browser idiom, but conceptually supported">✳️</span>|
+|**Finished — merged to wasm-3.0 core spec**|
+|[Branch Hinting](https://github.com/WebAssembly/branch-hinting)||<span title="Custom section ignored; no behavior impact">✅</span>|
 |[Bulk memory operations](https://github.com/webassembly/bulk-memory-operations)||✅|
+|[Custom Annotation Syntax in the Text Format](https://github.com/WebAssembly/annotations)||✅|
+|[Exception handling](https://github.com/WebAssembly/exception-handling)|exceptions|✅|
 |[Extended Constant Expressions](https://github.com/WebAssembly/extended-const)|extended_const|✅|
+|[Fixed-width SIMD](https://github.com/webassembly/simd)||✅|
 |[Garbage collection](https://github.com/WebAssembly/gc)|gc|✅|
+|[Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global)||✅|
+|[JavaScript BigInt to WebAssembly i64 integration](https://github.com/WebAssembly/JS-BigInt-integration)||<span title="Browser idiom, but conceptually supported">✳️</span>|
+|[JS String Builtins](https://github.com/WebAssembly/js-string-builtins)||<span title="Browser idioms, not directly supported">🌐</span>|
+|[Memory64](https://github.com/WebAssembly/memory64)|memory64|✅|
 |[Multiple memories](https://github.com/WebAssembly/multi-memory)|multi-memory|✅|
 |[Multi-value](https://github.com/WebAssembly/multi-value)|multi_value|✅|
-|[Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global)||✅|
+|[Non-trapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)||✅|
 |[Reference Types](https://github.com/WebAssembly/reference-types)||✅|
 |[Relaxed SIMD](https://github.com/webassembly/relaxed-simd)|relaxed_simd|✅|
-|[Non-trapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)||✅|
 |[Sign-extension operators](https://github.com/WebAssembly/sign-extension-ops)||✅|
-|[Fixed-width SIMD](https://github.com/webassembly/simd)||✅|
 |[Tail call](https://github.com/webassembly/tail-call)|tail_call|✅|
 |[Typed Function References](https://github.com/WebAssembly/function-references)|function-references|✅|
-|Phase 4|
-|[Exception handling](https://github.com/WebAssembly/exception-handling)|exceptions|✅|
-|[JS String Builtins](https://github.com/WebAssembly/js-string-builtins)||❌|
-|[Memory64](https://github.com/WebAssembly/memory64)|memory64|✅|
-|[Threads](https://github.com/webassembly/threads)|threads|✅|
-|Phase 3|
+|**Phase 4 — Standardize**|
 |[JS Promise Integration](https://github.com/WebAssembly/js-promise-integration)|jspi|<span title="Browser idiom, but conceptually supported">✳️</span>|
+|[Threads](https://github.com/webassembly/threads)|threads|✅|
+|[Web Content Security Policy](https://github.com/WebAssembly/content-security-policy)||<span title="Browser idioms, not directly supported">🌐</span>|
+|**Phase 3 — Implementation**|
+|[Compact Import Section](https://github.com/WebAssembly/compact-import-section)||❌|
+|[Custom Descriptors and JS Interop](https://github.com/WebAssembly/custom-descriptors)||<span title="Browser idioms, not directly supported">🌐</span>|
+|[Custom Page Sizes](https://github.com/WebAssembly/custom-page-sizes)||❌|
+|[ESM Integration](https://github.com/WebAssembly/esm-integration)||<span title="Browser idioms, not directly supported">🌐</span>|
+|[Stack Switching](https://github.com/WebAssembly/stack-switching)||❌|
+|[Wide Arithmetic](https://github.com/WebAssembly/wide-arithmetic)||❌|
+|**Phase 2 — Proposed Spec Text**|
+|[Compilation Hints](https://github.com/WebAssembly/compilation-hints)||❌|
+|[Extended Name Section](https://github.com/WebAssembly/extended-name-section)||❌|
+|[JS Primitive Builtins](https://github.com/WebAssembly/js-primitive-builtins)||<span title="Browser idioms, not directly supported">🌐</span>|
+|[Numeric Values in WAT Data Segments](https://github.com/WebAssembly/wat-numeric-values)||❌|
+|[Relaxed dead code validation](https://github.com/WebAssembly/relaxed-dead-code-validation)||❌|
+|[Rounding Variants](https://github.com/WebAssembly/rounding-mode-control)||❌|
+|**Phase 1 — Feature Proposal**|
+|[Component Model](https://github.com/WebAssembly/component-model)||❌|
+|[Flexible Vectors](https://github.com/WebAssembly/flexible-vectors)||❌|
+|[Frozen Values](https://github.com/WebAssembly/frozen-values)||❌|
+|[Half Precision](https://github.com/WebAssembly/half-precision)||❌|
+|[Memory control](https://github.com/WebAssembly/memory-control)||❌|
+|[More Array Constructors](https://github.com/WebAssembly/more-array-constructors)||❌|
+|[Multibyte Array Access](https://github.com/WebAssembly/multibyte-array-access)||❌|
+|[Reference-Typed Strings](https://github.com/WebAssembly/stringref)||❌|
+|[Shared-Everything Threads](https://github.com/WebAssembly/shared-everything-threads)||<span title="Foundation shipped: shared/thread_local annotations, IsShared wiring, lock discipline. Canonical instructions (global.atomic.*, pause) deferred until the proposal assigns opcode bytes.">🟡</span>|
+|[Type Imports](https://github.com/WebAssembly/type-imports)||❌|
 |[Type Reflection for WebAssembly JavaScript API](https://github.com/WebAssembly/js-types)|type-reflection|<span title="Browser idioms, not directly supported">🌐</span>|
-||
-|[Legacy Exception Handling]( https://github.com/WebAssembly/exception-handling)|exceptions|❌|
+|**Not a proposal (WACS out-of-scope)**|
+|[Legacy Exception Handling](https://github.com/WebAssembly/exception-handling)|exceptions|❌|
 |[Streaming Compilation](https://webassembly.github.io/spec/web-api/index.html#streaming-modules)|streaming_compilation|<span title="Browser idioms, not directly supported">🌐</span>|
 
-###### This table was generated with the Feature.Detect test harness.
+Legend: ✅ supported · 🟡 partial · ❌ not yet · ✳️ conceptually supported (browser idiom) · 🌐 browser-only / N/A for non-web hosts
+
+###### Phase assignments cross-checked against [WebAssembly/proposals@1584fdf](https://github.com/WebAssembly/proposals/commit/1584fdf) (2026-03-24) and [WebAssembly/proposals/finished-proposals.md](https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md). Browser-idiom ✳️/🌐 results harnessed from [wasm-feature-detect](https://github.com/GoogleChromeLabs/wasm-feature-detect) via the [Feature.Detect](./Feature.Detect) test harness.
 
 ## Getting Started
 

--- a/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.8.3</AssemblyVersion>
-    <Version>0.8.3</Version>
+    <AssemblyVersion>0.9.0</AssemblyVersion>
+    <Version>0.9.0</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -11,8 +11,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.2.1</Version>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.3.0</Version>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2025 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies.</Description>

--- a/Wacs.Transpiler/Wacs.Transpiler.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.csproj
@@ -13,8 +13,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler</PackageId>
         <Title>WACS Transpiler</Title>
-        <Version>0.2.1</Version>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.3.0</Version>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2025 Kelvin Nishikawa</Copyright>
         <Description>Ahead-of-time WebAssembly-to-.NET IL transpiler for WACS. Installs the `wasm-transpile` CLI tool. For programmatic use, reference WACS.Transpiler.Lib.</Description>


### PR DESCRIPTION
## Summary

Version bumps + CHANGELOG heading for the concurrent wasm execution work that landed in #83.

- **WACS** (Wacs.Core): 0.8.3 → **0.9.0**
- **WACS.Transpiler**: 0.2.1 → **0.3.0**
- **WACS.Transpiler.Lib**: 0.2.1 → **0.3.0**
- **WACS.WASI.Threads**: **0.1.0** (first release, new sibling package)
- **WACS.WASIp1**: unchanged (0.9.7 — not affected by the concurrent work)

Minor bumps (per semver): substantial new public API surface without breaking changes. Baseline wasm behavior unchanged; all new behavior is opt-in or host-visible primitive.

## Test plan

- [x] `dotnet build WACS.sln -c Release` — clean (0 errors, pre-existing warnings only)
- [x] All tests still green from #83 (Wacs.Core.Test 366/366, Transpiler 561/561, Spec.Test 723/723)
- [ ] Merge → tag `WACS-v0.9.0`, `WACS-Transpiler-v0.3.0`, `WACS-WASI-Threads-v0.1.0` → NuGet publishes via OIDC trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)