### PR TITLE
JS String Builtins: wasm:js-string backed by System.String

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Harnessed results from [wasm-feature-detect](https://github.com/GoogleChromeLabs
 |[Garbage collection](https://github.com/WebAssembly/gc)|gc|✅|
 |[Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global)||✅|
 |[JavaScript BigInt to WebAssembly i64 integration](https://github.com/WebAssembly/JS-BigInt-integration)||<span title="Browser idiom, but conceptually supported">✳️</span>|
-|[JS String Builtins](https://github.com/WebAssembly/js-string-builtins)||<span title="Browser idioms, not directly supported">🌐</span>|
+|[JS String Builtins](https://github.com/WebAssembly/js-string-builtins)||✅|
 |[Memory64](https://github.com/WebAssembly/memory64)|memory64|✅|
 |[Multiple memories](https://github.com/WebAssembly/multi-memory)|multi-memory|✅|
 |[Multi-value](https://github.com/WebAssembly/multi-value)|multi_value|✅|

--- a/Wacs.Core.Test/JsStringBuiltinsTests.cs
+++ b/Wacs.Core.Test/JsStringBuiltinsTests.cs
@@ -1,0 +1,431 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Builtins;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Wacs.Core.Types.Defs;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// End-to-end tests for the 11 simple (externref/i32) JS String Builtins
+    /// (wasm:js-string namespace), backed by .NET System.String.
+    ///
+    /// The 2 GC-array-typed builtins (fromCharCodeArray, intoCharCodeArray)
+    /// are implemented in <see cref="JsStringBuiltins"/> and covered by
+    /// direct-invoke unit tests further down — the WAT parser doesn't yet
+    /// support `array.new_fixed` / `array.new` (tracked as phase 1.4 scope),
+    /// so we can't round-trip them through a text module.
+    /// </summary>
+    public class JsStringBuiltinsTests
+    {
+        // Module importing the 11 simple builtins and re-exporting thin
+        // wrappers for test drivers. No GC array types involved.
+        private const string TestModule = @"
+            (module
+              (import ""wasm:js-string"" ""test""
+                (func $test (param externref) (result i32)))
+              (import ""wasm:js-string"" ""cast""
+                (func $cast (param externref) (result (ref extern))))
+              (import ""wasm:js-string"" ""length""
+                (func $length (param externref) (result i32)))
+              (import ""wasm:js-string"" ""concat""
+                (func $concat (param externref externref) (result (ref extern))))
+              (import ""wasm:js-string"" ""substring""
+                (func $substring (param externref i32 i32) (result (ref extern))))
+              (import ""wasm:js-string"" ""equals""
+                (func $equals (param externref externref) (result i32)))
+              (import ""wasm:js-string"" ""compare""
+                (func $compare (param externref externref) (result i32)))
+              (import ""wasm:js-string"" ""charCodeAt""
+                (func $charCodeAt (param externref i32) (result i32)))
+              (import ""wasm:js-string"" ""codePointAt""
+                (func $codePointAt (param externref i32) (result i32)))
+              (import ""wasm:js-string"" ""fromCharCode""
+                (func $fromCharCode (param i32) (result (ref extern))))
+              (import ""wasm:js-string"" ""fromCodePoint""
+                (func $fromCodePoint (param i32) (result (ref extern))))
+
+              (func (export ""call_test"") (param externref) (result i32)
+                local.get 0
+                call $test)
+              (func (export ""call_cast"") (param externref) (result externref)
+                local.get 0
+                call $cast)
+              (func (export ""call_length"") (param externref) (result i32)
+                local.get 0
+                call $length)
+              (func (export ""call_concat"") (param externref externref) (result externref)
+                local.get 0
+                local.get 1
+                call $concat)
+              (func (export ""call_substring"") (param externref i32 i32) (result externref)
+                local.get 0
+                local.get 1
+                local.get 2
+                call $substring)
+              (func (export ""call_equals"") (param externref externref) (result i32)
+                local.get 0
+                local.get 1
+                call $equals)
+              (func (export ""call_compare"") (param externref externref) (result i32)
+                local.get 0
+                local.get 1
+                call $compare)
+              (func (export ""call_charCodeAt"") (param externref i32) (result i32)
+                local.get 0
+                local.get 1
+                call $charCodeAt)
+              (func (export ""call_codePointAt"") (param externref i32) (result i32)
+                local.get 0
+                local.get 1
+                call $codePointAt)
+              (func (export ""call_fromCharCode"") (param i32) (result externref)
+                local.get 0
+                call $fromCharCode)
+              (func (export ""call_fromCodePoint"") (param i32) (result externref)
+                local.get 0
+                call $fromCodePoint)
+            )
+        ";
+
+        private static (WasmRuntime runtime, ModuleInstance inst) Build()
+        {
+            var runtime = new WasmRuntime();
+            JsStringBuiltins.BindTo(runtime);
+            var module = TextModuleParser.ParseWat(TestModule);
+            var inst = runtime.InstantiateModule(module);
+            runtime.RegisterModule("M", inst);
+            return (runtime, inst);
+        }
+
+        private static Value Extern(string s) =>
+            new(ValType.Extern, 0L, new JsStringRef(s));
+
+        private static Value NullExtern() => Value.NullExternRef;
+
+        private static Value[] Invoke(WasmRuntime runtime, string name, params Value[] args)
+        {
+            var addr = runtime.GetExportedFunction(("M", name));
+            var inv = runtime.CreateStackInvoker(addr);
+            return inv(args);
+        }
+
+        private static int InvokeI32(WasmRuntime runtime, string name, params Value[] args) =>
+            (int)Invoke(runtime, name, args)[0];
+
+        private static string InvokeString(WasmRuntime runtime, string name, params Value[] args)
+        {
+            var result = Invoke(runtime, name, args)[0];
+            var jsRef = Assert.IsType<JsStringRef>(result.GcRef);
+            return jsRef.Value;
+        }
+
+        // ---- test / cast ----------------------------------------------------
+
+        [Fact]
+        public void Test_Returns1ForJsString()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(1, InvokeI32(runtime, "call_test", Extern("hi")));
+        }
+
+        [Fact]
+        public void Test_Returns0ForNull()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(0, InvokeI32(runtime, "call_test", NullExtern()));
+        }
+
+        [Fact]
+        public void Cast_TrapsOnNonString()
+        {
+            var (runtime, _) = Build();
+            Assert.Throws<TrapException>(() => InvokeI32(runtime, "call_cast", NullExtern()));
+        }
+
+        [Fact]
+        public void Cast_PassesThroughJsString()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal("hello", InvokeString(runtime, "call_cast", Extern("hello")));
+        }
+
+        // ---- length ---------------------------------------------------------
+
+        [Fact]
+        public void Length_ReturnsUtf16CodeUnitCount()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(5, InvokeI32(runtime, "call_length", Extern("hello")));
+            Assert.Equal(0, InvokeI32(runtime, "call_length", Extern("")));
+            // Astral: 2 UTF-16 code units
+            Assert.Equal(2, InvokeI32(runtime, "call_length", Extern("😀")));
+        }
+
+        [Fact]
+        public void Length_TrapsOnNull()
+        {
+            var (runtime, _) = Build();
+            Assert.Throws<TrapException>(() => InvokeI32(runtime, "call_length", NullExtern()));
+        }
+
+        // ---- concat ---------------------------------------------------------
+
+        [Fact]
+        public void Concat_JoinsStrings()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal("foobar", InvokeString(runtime, "call_concat", Extern("foo"), Extern("bar")));
+            Assert.Equal("abc", InvokeString(runtime, "call_concat", Extern(""), Extern("abc")));
+        }
+
+        // ---- substring ------------------------------------------------------
+
+        [Theory]
+        [InlineData("hello", 0, 5, "hello")]
+        [InlineData("hello", 1, 4, "ell")]
+        [InlineData("hello", 2, 2, "")] // empty
+        [InlineData("hello", 3, 1, "")] // end <= start after clamp
+        [InlineData("hello", -5, 3, "hel")] // clamped start to 0
+        [InlineData("hello", 2, 999, "llo")] // clamped end to length
+        public void Substring_ClampsAndReturns(string input, int start, int end, string expected)
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(expected, InvokeString(runtime, "call_substring",
+                Extern(input), new Value(start), new Value(end)));
+        }
+
+        // ---- equals ---------------------------------------------------------
+
+        [Fact]
+        public void Equals_Ordinal()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(1, InvokeI32(runtime, "call_equals", Extern("abc"), Extern("abc")));
+            Assert.Equal(0, InvokeI32(runtime, "call_equals", Extern("abc"), Extern("ABC")));
+        }
+
+        [Fact]
+        public void Equals_AllowsNulls()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(1, InvokeI32(runtime, "call_equals", NullExtern(), NullExtern()));
+            Assert.Equal(0, InvokeI32(runtime, "call_equals", NullExtern(), Extern("x")));
+            Assert.Equal(0, InvokeI32(runtime, "call_equals", Extern("x"), NullExtern()));
+        }
+
+        // ---- compare --------------------------------------------------------
+
+        [Fact]
+        public void Compare_Ordinal()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(0, InvokeI32(runtime, "call_compare", Extern("abc"), Extern("abc")));
+            Assert.Equal(-1, InvokeI32(runtime, "call_compare", Extern("abc"), Extern("abd")));
+            Assert.Equal(1, InvokeI32(runtime, "call_compare", Extern("abd"), Extern("abc")));
+        }
+
+        // ---- charCodeAt / codePointAt --------------------------------------
+
+        [Theory]
+        [InlineData("abc", 0, 0x61)]
+        [InlineData("abc", 2, 0x63)]
+        [InlineData("abc", 99, -1)] // OOB → -1
+        [InlineData("abc", -1, -1)] // negative → -1 (unsigned comparison)
+        public void CharCodeAt_ReturnsCodeUnitOrSentinel(string s, int idx, int expected)
+        {
+            var (runtime, _) = Build();
+            Assert.Equal(expected, InvokeI32(runtime, "call_charCodeAt", Extern(s), new Value(idx)));
+        }
+
+        [Fact]
+        public void CodePointAt_DecodesSurrogatePairs()
+        {
+            var (runtime, _) = Build();
+            // "😀" encodes as U+D83D U+DE00 (code point U+1F600)
+            Assert.Equal(0x1F600, InvokeI32(runtime, "call_codePointAt",
+                Extern("😀"), new Value(0)));
+            // Index into low surrogate → returns the lone surrogate code unit
+            Assert.Equal(0xDE00, InvokeI32(runtime, "call_codePointAt",
+                Extern("😀"), new Value(1)));
+            // OOB
+            Assert.Equal(-1, InvokeI32(runtime, "call_codePointAt",
+                Extern("abc"), new Value(99)));
+        }
+
+        [Fact]
+        public void CharCodeAt_RoundTripsLoneSurrogate()
+        {
+            // Spec: unpaired surrogates must survive unchanged — critical for
+            // the "JS string" contract (and also what System.String does).
+            var (runtime, _) = Build();
+            Assert.Equal(0xD83D, InvokeI32(runtime, "call_charCodeAt",
+                Extern("\uD83D"), new Value(0)));
+        }
+
+        // ---- fromCharCode / fromCodePoint ----------------------------------
+
+        [Fact]
+        public void FromCharCode_BuildsSingleCodeUnit()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal("A", InvokeString(runtime, "call_fromCharCode", new Value(0x41)));
+            // High bits truncated
+            Assert.Equal("A", InvokeString(runtime, "call_fromCharCode", new Value(0x10041)));
+        }
+
+        [Fact]
+        public void FromCodePoint_BuildsBmpAndAstral()
+        {
+            var (runtime, _) = Build();
+            Assert.Equal("A", InvokeString(runtime, "call_fromCodePoint", new Value(0x41)));
+            Assert.Equal("😀", InvokeString(runtime, "call_fromCodePoint", new Value(0x1F600)));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0x110000)]
+        public void FromCodePoint_TrapsOnOutOfRange(int cp)
+        {
+            var (runtime, _) = Build();
+            Assert.Throws<TrapException>(() =>
+                InvokeString(runtime, "call_fromCodePoint", new Value(cp)));
+        }
+
+        // ---- integration: chain calls across externref ---------------------
+
+        [Fact]
+        public void RoundTrip_FromCharCodeThenLength()
+        {
+            // Produce a string via fromCharCode, pipe it back into length.
+            // The test walks the returned externref value through a second
+            // wasm call — proves the GcRef survives the host↔wasm boundary.
+            var (runtime, _) = Build();
+            var built = Invoke(runtime, "call_fromCharCode", new Value('Z'))[0];
+            Assert.Equal(1, InvokeI32(runtime, "call_length", built));
+        }
+
+        // ---- bind resolution -----------------------------------------------
+
+        [Fact]
+        public void BindTo_ModuleImportFailsWithoutBind()
+        {
+            // Sanity: if the host forgets to call BindTo, instantiation must
+            // fail cleanly with an unbound-import error rather than a silent
+            // mis-resolve.
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(TestModule);
+            Assert.ThrowsAny<System.Exception>(() => runtime.InstantiateModule(module));
+        }
+
+        // ---- fromCharCodeArray / intoCharCodeArray (direct invoke) ---------
+        //
+        // These two builtins take a GC-typed (ref null (array (mut i16)))
+        // parameter. WACS's text parser doesn't yet support `array.new` /
+        // `array.new_fixed`, so we can't round-trip them through a WAT module.
+        // Instead, drive the bound IFunctionInstance through CreateStackInvoker
+        // with a hand-built StoreArray wrapped as a Value — same on-the-stack
+        // encoding the GC instructions produce.
+
+        private static Value MakeI16Array(int length, params int[] seed)
+        {
+            var arrType = new Wacs.Core.Types.ArrayType(
+                new Wacs.Core.Types.FieldType(ValType.I16, Wacs.Core.Types.Mutability.Mutable));
+            var arr = new StoreArray(default, arrType, new Value(ValType.I32, 0), length);
+            for (int i = 0; i < seed.Length && i < length; i++)
+                arr[i] = new Value(seed[i]);
+            return new Value(ValType.Array, 0L, arr);
+        }
+
+        [Fact]
+        public void FromCharCodeArray_ReadsRange()
+        {
+            var (runtime, _) = Build();
+            var addr = runtime.GetExportedFunction((JsStringBuiltins.ModuleName, "fromCharCodeArray"));
+            var inv = runtime.CreateStackInvoker(addr);
+
+            var arr = MakeI16Array(5, 'H', 'e', 'l', 'l', 'o');
+            var r = inv(new[] { arr, new Value(0), new Value(5) });
+            Assert.Equal("Hello", Assert.IsType<JsStringRef>(r[0].GcRef).Value);
+        }
+
+        [Fact]
+        public void FromCharCodeArray_Slice()
+        {
+            var (runtime, _) = Build();
+            var addr = runtime.GetExportedFunction((JsStringBuiltins.ModuleName, "fromCharCodeArray"));
+            var inv = runtime.CreateStackInvoker(addr);
+
+            var arr = MakeI16Array(5, 'H', 'e', 'l', 'l', 'o');
+            var r = inv(new[] { arr, new Value(1), new Value(4) });
+            Assert.Equal("ell", Assert.IsType<JsStringRef>(r[0].GcRef).Value);
+        }
+
+        [Fact]
+        public void FromCharCodeArray_TrapsOnNull()
+        {
+            var (runtime, _) = Build();
+            var addr = runtime.GetExportedFunction((JsStringBuiltins.ModuleName, "fromCharCodeArray"));
+            var inv = runtime.CreateStackInvoker(addr);
+
+            var nullArr = new Value(ValType.Array);  // default → null
+            Assert.Throws<TrapException>(() =>
+                inv(new[] { nullArr, new Value(0), new Value(0) }));
+        }
+
+        [Fact]
+        public void FromCharCodeArray_TrapsOnOutOfBounds()
+        {
+            var (runtime, _) = Build();
+            var addr = runtime.GetExportedFunction((JsStringBuiltins.ModuleName, "fromCharCodeArray"));
+            var inv = runtime.CreateStackInvoker(addr);
+
+            var arr = MakeI16Array(3, 'a', 'b', 'c');
+            Assert.Throws<TrapException>(() =>
+                inv(new[] { arr, new Value(0), new Value(10) }));
+        }
+
+        [Fact]
+        public void IntoCharCodeArray_WritesBack()
+        {
+            var (runtime, _) = Build();
+            var addr = runtime.GetExportedFunction((JsStringBuiltins.ModuleName, "intoCharCodeArray"));
+            var inv = runtime.CreateStackInvoker(addr);
+
+            var arr = MakeI16Array(5);
+            var r = inv(new[] { Extern("Hi!"), arr, new Value(0) });
+            Assert.Equal(3, (int)r[0]);
+
+            var storeArr = (StoreArray)arr.GcRef!;
+            Assert.Equal('H', storeArr[0].Data.Int32);
+            Assert.Equal('i', storeArr[1].Data.Int32);
+            Assert.Equal('!', storeArr[2].Data.Int32);
+        }
+
+        [Fact]
+        public void IntoCharCodeArray_TrapsOnInsufficientCapacity()
+        {
+            var (runtime, _) = Build();
+            var addr = runtime.GetExportedFunction((JsStringBuiltins.ModuleName, "intoCharCodeArray"));
+            var inv = runtime.CreateStackInvoker(addr);
+
+            var arr = MakeI16Array(2);
+            Assert.Throws<TrapException>(() =>
+                inv(new[] { Extern("longer"), arr, new Value(0) }));
+        }
+    }
+}

--- a/Wacs.Core/Instructions/Control.cs
+++ b/Wacs.Core/Instructions/Control.cs
@@ -822,7 +822,12 @@ namespace Wacs.Core.Instructions
         public FuncIdx X;
         private bool IsHostFunction = false;
         private FunctionInstance? linkedFunctionInstance;
-        private HostFunction? linkedHostFunction;
+        // Any non-wasm callable. Holds a HostFunction for delegate-marshaled
+        // hosts (WASI, user BindHostFunction) and any other IFunctionInstance
+        // for recognized-import builtins (wasm:js-string) that access the
+        // OpStack directly. The async path casts back to HostFunction when
+        // it needs the delegate-based InvokeAsync.
+        private IFunctionInstance? linkedHostFunction;
 
         public InstCall() : base(ByteCode.Call)
         {
@@ -872,6 +877,14 @@ namespace Wacs.Core.Instructions
                     linkedHostFunction = hostFunction;
                     IsHostFunction = true;
                     break;
+                default:
+                    // Any other IFunctionInstance — recognized-import builtins
+                    // and similar. Dispatched through the IFunctionInstance
+                    // interface on the sync path.
+                    IsAsync = inst.IsAsync;
+                    linkedHostFunction = inst;
+                    IsHostFunction = true;
+                    break;
             }
 
             var funcType = inst.Type;
@@ -899,8 +912,10 @@ namespace Wacs.Core.Instructions
         {
             if (IsHostFunction)
             {
-                if (linkedHostFunction!.IsAsync)
-                    await linkedHostFunction!.InvokeAsync(context);
+                // InvokeAsync lives on HostFunction, not the interface.
+                // Generic IFunctionInstance builtins are always sync.
+                if (linkedHostFunction!.IsAsync && linkedHostFunction is HostFunction hf)
+                    await hf.InvokeAsync(context);
                 else
                     linkedHostFunction!.Invoke(context);
             }

--- a/Wacs.Core/Runtime/Builtins/JsStringBuiltins.cs
+++ b/Wacs.Core/Runtime/Builtins/JsStringBuiltins.cs
@@ -1,0 +1,336 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Text;
+using Wacs.Core.Runtime.Exceptions;
+using Wacs.Core.Runtime.GC;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
+using Wacs.Core.Types.Defs;
+
+namespace Wacs.Core.Runtime.Builtins
+{
+    /// <summary>
+    /// Implements the WebAssembly 3.0 JS String Builtins proposal
+    /// (https://github.com/WebAssembly/js-string-builtins) against .NET
+    /// System.String. Wasm modules that import from the "wasm:js-string"
+    /// namespace get optimized native string ops without having to marshal
+    /// through linear memory.
+    ///
+    /// The proposal is JS-flavored in name only — every operation is defined
+    /// against UTF-16 code units, which matches System.String exactly, so a
+    /// straightforward environment swap yields observably identical behavior.
+    ///
+    /// Host opt-in is explicit: call <see cref="BindTo"/> on a WasmRuntime
+    /// before instantiating a module that imports from "wasm:js-string".
+    /// Modules that don't import from this namespace are unaffected and pay
+    /// no cost.
+    ///
+    /// Import signatures follow the proposal's reference test fixtures at
+    /// https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/
+    /// js-string-builtins/Overview.md.
+    /// </summary>
+    public static class JsStringBuiltins
+    {
+        public const string ModuleName = "wasm:js-string";
+
+        /// <summary>
+        /// Register all 13 builtins under the "wasm:js-string" namespace.
+        /// Must be called before <c>InstantiateModule</c> for modules that
+        /// import from the namespace.
+        /// </summary>
+        public static void BindTo(WasmRuntime runtime)
+        {
+            // 11 simple externref / i32 functions.
+            Bind(runtime, "test", InParams(ValType.ExternRef), I32, Test);
+            Bind(runtime, "cast", InParams(ValType.ExternRef), NonNullExtern, Cast);
+            Bind(runtime, "length", InParams(ValType.ExternRef), I32, Length);
+            Bind(runtime, "concat", InParams(ValType.ExternRef, ValType.ExternRef), NonNullExtern, Concat);
+            Bind(runtime, "substring", InParams(ValType.ExternRef, ValType.I32, ValType.I32), NonNullExtern, Substring);
+            Bind(runtime, "equals", InParams(ValType.ExternRef, ValType.ExternRef), I32, Equals);
+            Bind(runtime, "compare", InParams(ValType.ExternRef, ValType.ExternRef), I32, Compare);
+            Bind(runtime, "charCodeAt", InParams(ValType.ExternRef, ValType.I32), I32, CharCodeAt);
+            Bind(runtime, "codePointAt", InParams(ValType.ExternRef, ValType.I32), I32, CodePointAt);
+            Bind(runtime, "fromCharCode", InParams(ValType.I32), NonNullExtern, FromCharCode);
+            Bind(runtime, "fromCodePoint", InParams(ValType.I32), NonNullExtern, FromCodePoint);
+
+            // 2 GC-array-typed functions. We accept the generic arrayref
+            // supertype; contravariant import matching lets modules that
+            // declare (ref null (array (mut i16))) pass their specific type
+            // in. Validated structurally at runtime (element must unpack to
+            // a 16-bit code unit).
+            Bind(runtime, "fromCharCodeArray",
+                InParams(ValType.Array, ValType.I32, ValType.I32), NonNullExtern, FromCharCodeArray);
+            Bind(runtime, "intoCharCodeArray",
+                InParams(ValType.ExternRef, ValType.Array, ValType.I32), I32, IntoCharCodeArray);
+        }
+
+        // ---- Convenience type constructors ---------------------------------
+
+        private static readonly ResultType I32 = new(ValType.I32);
+        private static readonly ResultType NonNullExtern = new(ValType.Extern);
+
+        private static ResultType InParams(params ValType[] types) => new(types);
+
+        private static void Bind(WasmRuntime runtime, string name,
+            ResultType inTypes, ResultType outTypes, Action<ExecContext> impl)
+        {
+            var type = new FunctionType(inTypes, outTypes);
+            runtime.BindHostFunction((ModuleName, name),
+                new JsStringBuiltinFunc(name, type, impl));
+        }
+
+        // ---- Builtin implementations --------------------------------------
+
+        // Pop the top-of-stack externref and return the underlying string.
+        // Traps on null / non-string, matching spec §4.2: only `test` is
+        // null-tolerant.
+        private static string PopString(ExecContext ctx, string op)
+        {
+            var v = ctx.OpStack.PopRefType();
+            if (v.IsNullRef)
+                throw new TrapException($"js-string.{op}: null reference");
+            if (v.GcRef is not JsStringRef jsRef)
+                throw new TrapException($"js-string.{op}: operand is not a js string");
+            return jsRef.Value;
+        }
+
+        private static void PushString(ExecContext ctx, string s)
+        {
+            ctx.OpStack.PushValue(new Value(ValType.Extern, 0L, new JsStringRef(s)));
+        }
+
+        // test(externref) → i32 — 1 if the ref is a js-string, 0 otherwise
+        // (including null). The only builtin that does not trap on wrong type.
+        private static void Test(ExecContext ctx)
+        {
+            var v = ctx.OpStack.PopRefType();
+            int result = (!v.IsNullRef && v.GcRef is JsStringRef) ? 1 : 0;
+            ctx.OpStack.PushValue(new Value(result));
+        }
+
+        // cast(externref) → (ref extern) — assert-and-return. Traps on null
+        // or non-string; pushes the same ref typed as non-null.
+        private static void Cast(ExecContext ctx)
+        {
+            var s = PopString(ctx, "cast");
+            PushString(ctx, s);
+        }
+
+        // length(externref) → i32 — UTF-16 code-unit count.
+        private static void Length(ExecContext ctx)
+        {
+            var s = PopString(ctx, "length");
+            ctx.OpStack.PushValue(new Value(s.Length));
+        }
+
+        // concat(externref, externref) → (ref extern)
+        private static void Concat(ExecContext ctx)
+        {
+            var b = PopString(ctx, "concat");
+            var a = PopString(ctx, "concat");
+            PushString(ctx, string.Concat(a, b));
+        }
+
+        // substring(externref, i32 start, i32 end) → (ref extern)
+        // Per spec §4.2: start/end clamped to [0, length]; returns empty if
+        // end <= start after clamping.
+        private static void Substring(ExecContext ctx)
+        {
+            int end = ctx.OpStack.PopI32();
+            int start = ctx.OpStack.PopI32();
+            var s = PopString(ctx, "substring");
+
+            int len = s.Length;
+            int clampedStart = Math.Max(0, Math.Min(start, len));
+            int clampedEnd = Math.Max(0, Math.Min(end, len));
+            if (clampedEnd <= clampedStart)
+            {
+                PushString(ctx, string.Empty);
+                return;
+            }
+            PushString(ctx, s.Substring(clampedStart, clampedEnd - clampedStart));
+        }
+
+        // equals(externref, externref) → i32 — ordinal value comparison.
+        // Per spec: null-null → 1, null-any → 0. Type-traps if a non-null
+        // operand isn't a string.
+        private static void Equals(ExecContext ctx)
+        {
+            var b = ctx.OpStack.PopRefType();
+            var a = ctx.OpStack.PopRefType();
+
+            if (a.IsNullRef && b.IsNullRef)
+            {
+                ctx.OpStack.PushValue(new Value(1));
+                return;
+            }
+            if (a.IsNullRef || b.IsNullRef)
+            {
+                ctx.OpStack.PushValue(new Value(0));
+                return;
+            }
+            if (a.GcRef is not JsStringRef ra || b.GcRef is not JsStringRef rb)
+                throw new TrapException("js-string.equals: operand is not a js string");
+
+            ctx.OpStack.PushValue(new Value(string.Equals(ra.Value, rb.Value, StringComparison.Ordinal) ? 1 : 0));
+        }
+
+        // compare(externref, externref) → i32 — ordinal, normalized to {-1,0,1}.
+        // Traps on null on either side (only equals allows null).
+        private static void Compare(ExecContext ctx)
+        {
+            var b = PopString(ctx, "compare");
+            var a = PopString(ctx, "compare");
+            int cmp = string.CompareOrdinal(a, b);
+            ctx.OpStack.PushValue(new Value(cmp < 0 ? -1 : cmp > 0 ? 1 : 0));
+        }
+
+        // charCodeAt(externref, i32) → i32 — UTF-16 code unit or -1 if OOB.
+        private static void CharCodeAt(ExecContext ctx)
+        {
+            int idx = ctx.OpStack.PopI32();
+            var s = PopString(ctx, "charCodeAt");
+            int result = (uint)idx < (uint)s.Length ? s[idx] : -1;
+            ctx.OpStack.PushValue(new Value(result));
+        }
+
+        // codePointAt(externref, i32) → i32 — full codepoint (handles surrogate
+        // pairs), or -1 if OOB. Lone surrogates return as-is per spec.
+        private static void CodePointAt(ExecContext ctx)
+        {
+            int idx = ctx.OpStack.PopI32();
+            var s = PopString(ctx, "codePointAt");
+
+            if ((uint)idx >= (uint)s.Length)
+            {
+                ctx.OpStack.PushValue(new Value(-1));
+                return;
+            }
+
+            char c = s[idx];
+            if (char.IsHighSurrogate(c) && idx + 1 < s.Length)
+            {
+                char low = s[idx + 1];
+                if (char.IsLowSurrogate(low))
+                {
+                    int cp = char.ConvertToUtf32(c, low);
+                    ctx.OpStack.PushValue(new Value(cp));
+                    return;
+                }
+            }
+            ctx.OpStack.PushValue(new Value((int)c));
+        }
+
+        // fromCharCode(i32) → (ref extern) — single UTF-16 code unit to string.
+        // Low 16 bits used; high bits ignored per spec.
+        private static void FromCharCode(ExecContext ctx)
+        {
+            int code = ctx.OpStack.PopI32();
+            PushString(ctx, new string((char)(ushort)code, 1));
+        }
+
+        // fromCodePoint(i32) → (ref extern) — single codepoint to string.
+        // Traps on code > 0x10FFFF or < 0 (matches JS RangeError).
+        private static void FromCodePoint(ExecContext ctx)
+        {
+            int cp = ctx.OpStack.PopI32();
+            if (cp < 0 || cp > 0x10FFFF)
+                throw new TrapException("js-string.fromCodePoint: code point out of range");
+            PushString(ctx, char.ConvertFromUtf32(cp));
+        }
+
+        // fromCharCodeArray(arrayref, i32 start, i32 end) → (ref extern)
+        // Reads elements [start, end) as UTF-16 code units and builds a string.
+        // Traps on null array or OOB indices.
+        private static void FromCharCodeArray(ExecContext ctx)
+        {
+            int end = ctx.OpStack.PopI32();
+            int start = ctx.OpStack.PopI32();
+            var arrVal = ctx.OpStack.PopRefType();
+
+            if (arrVal.IsNullRef)
+                throw new TrapException("js-string.fromCharCodeArray: null array");
+            if (arrVal.GcRef is not StoreArray arr)
+                throw new TrapException("js-string.fromCharCodeArray: operand is not an array");
+            if (start < 0 || end < start || end > arr.Length)
+                throw new TrapException("js-string.fromCharCodeArray: range out of bounds");
+
+            int len = end - start;
+            if (len == 0)
+            {
+                PushString(ctx, string.Empty);
+                return;
+            }
+            var sb = new StringBuilder(len);
+            for (int i = 0; i < len; i++)
+                sb.Append((char)(ushort)arr[start + i].Data.Int32);
+            PushString(ctx, sb.ToString());
+        }
+
+        // intoCharCodeArray(externref, arrayref, i32 start) → i32
+        // Copies the string's UTF-16 code units into arr[start..start+len].
+        // Returns count of code units written. Traps on null array or OOB.
+        private static void IntoCharCodeArray(ExecContext ctx)
+        {
+            int start = ctx.OpStack.PopI32();
+            var arrVal = ctx.OpStack.PopRefType();
+            var s = PopString(ctx, "intoCharCodeArray");
+
+            if (arrVal.IsNullRef)
+                throw new TrapException("js-string.intoCharCodeArray: null array");
+            if (arrVal.GcRef is not StoreArray arr)
+                throw new TrapException("js-string.intoCharCodeArray: operand is not an array");
+            if (start < 0 || start + s.Length > arr.Length)
+                throw new TrapException("js-string.intoCharCodeArray: range out of bounds");
+
+            for (int i = 0; i < s.Length; i++)
+                arr[start + i] = new Value(s[i]);
+            ctx.OpStack.PushValue(new Value(s.Length));
+        }
+    }
+
+    /// <summary>
+    /// Minimal IFunctionInstance wrapper for a JS-string builtin. Goes
+    /// straight to the OpStack rather than the delegate marshaler because
+    /// the marshaler doesn't yet route externref / arrayref params.
+    /// </summary>
+    internal sealed class JsStringBuiltinFunc : IFunctionInstance
+    {
+        private readonly Action<ExecContext> _impl;
+
+        public JsStringBuiltinFunc(string name, FunctionType type, Action<ExecContext> impl)
+        {
+            Name = name;
+            Type = type;
+            _impl = impl;
+        }
+
+        public FunctionType Type { get; }
+        public string Name { get; }
+        public string Id => $"{JsStringBuiltins.ModuleName}.{Name}";
+        public bool IsAsync => false;
+
+        public bool IsExport
+        {
+            get => true;
+            set { /* builtins are inherently exported; setter is a no-op */ }
+        }
+
+        public void SetName(string name) { /* name is fixed at construction */ }
+
+        public void Invoke(ExecContext context) => _impl(context);
+    }
+}

--- a/Wacs.Core/Runtime/Builtins/JsStringRef.cs
+++ b/Wacs.Core/Runtime/Builtins/JsStringRef.cs
@@ -1,0 +1,37 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Wacs.Core.Types;
+
+namespace Wacs.Core.Runtime.Builtins
+{
+    /// <summary>
+    /// Externref-carrier for a .NET string, used by the JS String Builtins
+    /// (wasm:js-string) proposal. Lets wasm modules manipulate host-owned
+    /// UTF-16 strings without copying through linear memory. The spec is
+    /// observationally defined against UTF-16 code units, which matches
+    /// System.String exactly, so no transcoding is needed at the boundary.
+    /// </summary>
+    public sealed class JsStringRef : IGcRef
+    {
+        public string Value { get; }
+
+        public JsStringRef(string value)
+        {
+            Value = value;
+        }
+
+        public RefIdx StoreIndex => new PtrIdx(0);
+    }
+}

--- a/Wacs.Core/Runtime/WasmRuntimeBinding.cs
+++ b/Wacs.Core/Runtime/WasmRuntimeBinding.cs
@@ -407,6 +407,18 @@ namespace Wacs.Core.Runtime
             _entityBindings[id] = funcAddr;
         }
 
+        // Bind a pre-built IFunctionInstance at a given (module, entity) name.
+        // Used by recognized-import builtins (e.g. wasm:js-string) that need
+        // operand-stack access for ref-typed params the delegate marshaler
+        // doesn't cover.
+        public void BindHostFunction((string module, string entity) id, IFunctionInstance func)
+        {
+            Store.OpenTransaction();
+            var funcAddr = Store.AddFunction(func);
+            Store.CommitTransaction();
+            _entityBindings[id] = funcAddr;
+        }
+
         public string GetFunctionName(FuncAddr funcAddr)
         {
             if (!GetExecContext().Store.Contains(funcAddr))


### PR DESCRIPTION
## Summary

Implements the [JS String Builtins](https://github.com/WebAssembly/js-string-builtins) proposal (WebAssembly 3.0, Phase 5) against `System.String`. The spec is JS-named but defined observationally against UTF-16 code units — identical to `System.String` semantics — so an environment swap yields the same observable behavior without transcoding.

Modules compiled with `--enable-js-string-builtins` (Binaryen) now run unmodified on WACS after the host calls `JsStringBuiltins.BindTo(runtime)`.

## What's in it

- **All 13 functions** in the `wasm:js-string` namespace: `test`, `cast`, `length`, `concat`, `substring`, `equals`, `compare`, `charCodeAt`, `codePointAt`, `fromCharCode`, `fromCodePoint`, `fromCharCodeArray`, `intoCharCodeArray`.
- **`JsStringRef : IGcRef`** — externref carrier that holds a `System.String`.
- **`JsStringBuiltins.BindTo(runtime)`** — explicit host opt-in, same idiom as `Wasi.BindToRuntime`.
- **`BindHostFunction((module, entity), IFunctionInstance)`** overload for recognized-import builtins that need operand-stack access.
- **`InstCall.Link` generalized** to accept any `IFunctionInstance` (previously hardcoded `FunctionInstance` / `HostFunction`). Required by recognized-import builtins; async path casts to `HostFunction` when it needs `InvokeAsync`.
- **README** feature matrix: JS String Builtins flipped 🌐 → ✅.

## Design notes

The builtins are implemented as direct `IFunctionInstance` subclasses rather than delegate-marshaled `HostFunction`s because the marshaler's `PopScalars` path throws on `externref`. Going straight to the OpStack lets `System.String` flow through `externref` via `JsStringRef.GcRef` without needing externref marshaling in the general host-binding machinery.

## Transpiler impact

**Zero transpiler changes.** JS String Builtins are imports, not new opcodes — nothing for the transpiler to lower. Transpiled modules route through `HostedRunner.BuildImportsProxy` (`Wacs.Transpiler.Lib/Hosting/HostedRunner.cs:212-221`) which resolves imports via `runtime.CreateStackInvoker`, hitting `ExecContext.Invoke`'s `IFunctionInstance` default branch. Regression-checked against `Wacs.Transpiler.Test` (549/549 pass).

## AOT

Preserves `IsAotCompatible=true`. No `Reflection.Emit`, no `DynamicMethod`, no `Expression.Compile` — only in-box managed primitives (`Action<ExecContext>`, `System.String` methods, `IGcRef`).

## Test plan

- [x] `dotnet build WACS.sln -c Release` — 0 errors
- [x] `dotnet test Wacs.Core.Test` — 400/400 pass (includes 34 new `JsStringBuiltinsTests`)
- [x] `dotnet test Spec.Test --filter BindingTests` — 10/10 pass
- [x] `dotnet test Wacs.Transpiler.Test --filter FullyQualifiedName!~Equivalence` — 549/549 pass
- [x] All 13 builtins exercised: 28 end-to-end through WAT + `CreateStackInvoker` for the 11 simple externref/i32 functions; 6 direct-invoke for the GC-array-typed `fromCharCodeArray` / `intoCharCodeArray` (WAT parser doesn't support `array.new_fixed` yet — phase 1.4 scope — so these build `StoreArray` in C# and drive the bound `IFunctionInstance` directly)
- [x] Surrogate round-trip, OOB sentinels, ordinal compare, null-tolerance on `test`/`equals`, trap paths on `cast` / `fromCodePoint(0x110000)` / null array / OOB

🤖 Generated with [Claude Code](https://claude.com/claude-code)