### PR TITLE
nuget.yml: wire publish for v0.10.0 release surface

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -3,10 +3,18 @@ name: Publish Updated Packages to NuGet
 on:
   push:
     tags:
+      # Existing prefixes (pre-v0.10.0).
       - 'WACS-v*.*.*'
       - 'WASIp1-v*.*.*'
       - 'WACS-Transpiler-v*.*.*'
       - 'WACS-WASI-Threads-v*.*.*'
+      # New prefixes for the v0.10.0 release surface. Related
+      # packages share a prefix so a single tag publishes the
+      # group (e.g. WACS-ComponentModel-v0.1.0 publishes both
+      # the runtime + the bindgen lib).
+      - 'WACS-Cli-v*.*.*'
+      - 'WACS-ComponentModel-v*.*.*'
+      - 'WACS-WASI-Preview2-v*.*.*'
 
 jobs:
   build-and-publish:
@@ -18,6 +26,7 @@ jobs:
     strategy:
       matrix:
         include:
+          # Pre-v0.10.0 packages.
           - path: Wacs.Core
             package_name: WACS
             tag_prefix: WACS-v
@@ -33,6 +42,31 @@ jobs:
           - path: Wacs.WASI.Threads
             package_name: WACS.WASI.Threads
             tag_prefix: WACS-WASI-Threads-v
+
+          # v0.10.0 release surface.
+          # `WACS-Cli-v*` → wacs CLI apphost.
+          - path: Wacs.Console
+            package_name: WACS.Cli
+            tag_prefix: WACS-Cli-v
+
+          # `WACS-ComponentModel-v*` → component-model runtime +
+          # bindgen library (versioned together; both 0.1.0 today).
+          - path: Wacs.ComponentModel
+            package_name: WACS.ComponentModel
+            tag_prefix: WACS-ComponentModel-v
+          - path: Wacs.ComponentModel.Bindgen.Lib
+            package_name: WACS.ComponentModel.Bindgen.Lib
+            tag_prefix: WACS-ComponentModel-v
+
+          # `WACS-WASI-Preview2-v*` → typed WASI Preview 2 host
+          # interfaces + the Microsoft.Extensions.DependencyInjection
+          # extension (versioned together; both 0.1.0 today).
+          - path: Wacs.WASI.Preview2
+            package_name: WACS.WASI.Preview2
+            tag_prefix: WACS-WASI-Preview2-v
+          - path: Wacs.WASI.Preview2.DependencyInjection
+            package_name: WACS.WASI.Preview2.DependencyInjection
+            tag_prefix: WACS-WASI-Preview2-v
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

The Component Model PR (#89) added six new packages and the follow-up bindgen consolidation (#90) shifted the surface, but `.github/workflows/nuget.yml`'s matrix + tag-prefix triggers still only know about the **original five** pre-v0.10.0 packages. Pushing tags right now would silently no-op for everything new.

This PR adds **3 new tag prefixes** and **5 new matrix rows** so the next round of publishes covers the full v0.10.0 release surface.

## New tag prefixes

| Tag prefix | Publishes |
|---|---|
| `WACS-Cli-v*` | `WACS.Cli` (the unified `wacs` apphost) |
| `WACS-ComponentModel-v*` | `WACS.ComponentModel` + `WACS.ComponentModel.Bindgen.Lib` (two packages, same prefix because they version together) |
| `WACS-WASI-Preview2-v*` | `WACS.WASI.Preview2` + `WACS.WASI.Preview2.DependencyInjection` (same versioning rationale) |

Existing prefixes (`WACS-v*`, `WASIp1-v*`, `WACS-Transpiler-v*`, `WACS-WASI-Threads-v*`) and their matrix rows are **unchanged**.

## After merge — release tag push sequence

```bash
# Already-bumped packages from #89 (Component Model release)
git tag WACS-v0.10.0                  && git push origin WACS-v0.10.0
git tag WACS-Transpiler-v0.4.0        && git push origin WACS-Transpiler-v0.4.0   # publishes .Lib 0.4.0 + .Transpiler 0.3.1 deprecated
git tag WACS-ComponentModel-v0.1.0    && git push origin WACS-ComponentModel-v0.1.0
git tag WACS-WASI-Preview2-v0.1.0     && git push origin WACS-WASI-Preview2-v0.1.0

# Bumped from #90 (bindgen roll-in)
git tag WACS-Cli-v1.1.0               && git push origin WACS-Cli-v1.1.0
```

5 tags → 9 packages published. The pre-existing `WACS.WASIp1` (0.9.7) and `WACS.WASI.Threads` (0.1.0) don't need re-tagging — they're already on NuGet at the right version.

## Test plan

- [x] `dotnet pack Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj` — produces `WACS.WASI.Preview2.0.1.0.nupkg` cleanly.
- [x] `dotnet pack Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj` — produces `WACS.WASI.Preview2.DependencyInjection.0.1.0.nupkg` cleanly.
- [x] (Already verified earlier) `Wacs.ComponentModel`, `Wacs.ComponentModel.Bindgen.Lib`, `Wacs.Console` all pack cleanly with their bumped versions.
- [x] Workflow YAML is valid (nothing else changed besides additive matrix rows + tag triggers).
- [ ] Tag push verification: requires landing this PR + pushing a real tag — left for the release sequence above.

## Note

The CI workflow (`ci.yml`) already runs on every PR + push to main and is unaffected by this change. Only `nuget.yml` (tag-gated publish) is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)