### PR TITLE
Coldstart bench, AOT exploration, and docs/COLDSTART.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,31 @@ positioning, not apples-to-apples):
   logic that doesn't dominate a frame budget — but don't put it in
   a hot inner loop.
 
+### Cold-Start
+
+The runtime numbers above are *steady-state*. The first invocation
+also pays the .NET tier-1 JIT cost, and a transpiler embedding pays
+its `Reflection.Emit` warm-up — together that's ~30–55 ms of cold
+start out of the box on a tiny module. Two build-time switches knock
+that down dramatically; pick the row that matches what your embedding
+ships:
+
+| tier | build flag | cold to first call (fib(100), 242-byte module) | trade-off |
+|------|------------|---------------------------------:|-----------|
+| **default** | plain `dotnet publish -c Release` | 35–55 ms | Smallest deploy artifact, every runtime works. JIT warmup dominates. |
+| **better**  | `-p:PublishReadyToRun=true --self-contained` | 16–30 ms | Larger publish (~70 MB self-contained). All four runtimes still work. ~1.5–2.8× faster cold; the `--switch` interpreter sees the biggest win (45 → 16 ms) because R2R skips the giant prefix-split-switch tier-1 JIT. |
+| **best (interpreter-only)** | `<PublishAot>true</PublishAot>` in csproj | **0.3–1.0 ms** | Single ~10 MB native binary, no JIT in the process. Excludes `transpiler` and `Wacs.ComponentModel` (both need runtime IL emission). `--switch` interpreter hits 319 µs cold. |
+| **best (transpiler ok)** | `wacs build` then `TranspiledModuleLoader.Load` under R2R | **~1 ms** | Run the transpile once at build time and ship the `.dll`. Same R2R caveats, plus a one-time ~100 ms transpile cost off the runtime path. Steady-state matches the in-process transpiler. |
+
+For the absolute cold-start floor — both startup *and* steady-state on
+a single machine — there's a fifth path worth knowing about: link the
+transpiled `.dll` statically into a NativeAOT-published consumer (501 µs
+cold and ~100 ns per fib(100) call, in a 4.3 MB native binary). Today
+this requires hand-wired csproj plumbing; a future `wacs aot` workflow
+will automate it. Full breakdown, methodology, and the four-runtime ×
+three-build-flag matrix in
+[`docs/COLDSTART.md`](docs/COLDSTART.md).
+
 ### Running `wacs`
 
 `wacs` is the reference CLI — verb-based subcommand layout (`run`

--- a/WACS.sln
+++ b/WACS.sln
@@ -43,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wacs.WASI.Preview2.Dependen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wacs.WASIp1.Test", "Wacs.WASIp1.Test\Wacs.WASIp1.Test.csproj", "{BA061514-ADB0-44B7-ADFF-D2D637F14151}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wacs.Bench.Aot", "Wacs.Bench.Aot\Wacs.Bench.Aot.csproj", "{6F7F8FF4-AA7F-41CA-8AFB-65C9A512D5E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -133,5 +135,9 @@ Global
 		{BA061514-ADB0-44B7-ADFF-D2D637F14151}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA061514-ADB0-44B7-ADFF-D2D637F14151}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA061514-ADB0-44B7-ADFF-D2D637F14151}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F7F8FF4-AA7F-41CA-8AFB-65C9A512D5E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F7F8FF4-AA7F-41CA-8AFB-65C9A512D5E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F7F8FF4-AA7F-41CA-8AFB-65C9A512D5E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F7F8FF4-AA7F-41CA-8AFB-65C9A512D5E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Wacs.Bench.Aot/Program.cs
+++ b/Wacs.Bench.Aot/Program.cs
@@ -1,0 +1,155 @@
+// AOT-only cold-start bench. References only Wacs.Core (no transpiler,
+// no component-model). Goal: prove an embedder can ship an
+// interpreter-only WACS as a NativeAOT binary, and measure what that
+// buys for cold start.
+//
+// Same workload as Wacs.Bench's Coldstart.cs interpreter rows so the
+// numbers line up. Run with:
+//
+//   dotnet publish Wacs.Bench.Aot -c Release -r osx-arm64 \
+//       -p:PublishAot=true -o /tmp/wacs-bench-aot
+//   /tmp/wacs-bench-aot/Wacs.Bench.Aot
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Wacs.Core;
+using Wacs.Core.Runtime;
+
+return args.Length >= 2 && args[0] == "run"
+    ? RunChild(args[1])
+    : RunFreshProcesses();
+
+static int RunFreshProcesses()
+{
+    Console.WriteLine("Coldstart benchmark — fib.wasm — fresh process per runtime (AOT build)");
+    Console.WriteLine("  trials per cell: 7 (trial 0 = 'first', subsequent 6 reported as median)");
+    Console.WriteLine("  units: microseconds (us)");
+    Console.WriteLine();
+
+    var dotnet = Environment.ProcessPath ?? "dotnet";
+    foreach (var runtime in new[] { "interp-poly", "interp-switch" })
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = dotnet,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("run");
+        psi.ArgumentList.Add(runtime);
+        using var p = Process.Start(psi)!;
+        Console.Write(p.StandardOutput.ReadToEnd());
+        p.WaitForExit();
+    }
+    return 0;
+}
+
+static int RunChild(string runtime)
+{
+    var bytes = File.ReadAllBytes(LocateFib());
+    foreach (var arg in new[] { 100, 5_000_000 })
+    {
+        Console.WriteLine($"=== {runtime} fib({arg:N0}) ({bytes.Length}-byte module) ===");
+        Header();
+        switch (runtime)
+        {
+            case "interp-poly":   Measure(runtime, bytes, arg, useSwitch: false); break;
+            case "interp-switch": Measure(runtime, bytes, arg, useSwitch: true);  break;
+            default: Console.Error.WriteLine($"unknown runtime: {runtime}"); return 2;
+        }
+        Console.WriteLine();
+    }
+    return 0;
+}
+
+static string LocateFib()
+{
+    var here = AppContext.BaseDirectory;
+    var sideBySide = Path.Combine(here, "fib.wasm");
+    if (File.Exists(sideBySide)) return sideBySide;
+    var devTree = Path.GetFullPath(Path.Combine(here, "..", "..", "..", "..", "Wacs.Bench", "fib.wasm"));
+    if (File.Exists(devTree)) return devTree;
+    throw new FileNotFoundException(
+        $"fib.wasm not found next to the binary or in the dev tree (looked at {sideBySide} and {devTree})");
+}
+
+static void Header()
+{
+    Console.WriteLine($"  {"runtime",-15}  {"phase",-10}  {"first(us)",10}  {"subseq-med(us)",16}");
+    Console.WriteLine($"  ----------------------------------------------------------------");
+}
+
+const int Trials = 7;
+
+static void Measure(string name, byte[] bytes, int arg, bool useSwitch)
+{
+    var trials = new (double parse, double inst, double first, double warm)[Trials];
+    for (int i = 0; i < Trials; i++)
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        trials[i] = RunOne(bytes, arg, useSwitch);
+    }
+    var subseq = trials.Skip(1).ToArray();
+    Print(name, "parse", trials[0].parse, Median(subseq.Select(t => t.parse).ToArray()));
+    Print(name, "inst",  trials[0].inst,  Median(subseq.Select(t => t.inst).ToArray()));
+    Print(name, "first", trials[0].first, Median(subseq.Select(t => t.first).ToArray()));
+    Print(name, "warm",  trials[0].warm,  Median(subseq.Select(t => t.warm).ToArray()));
+    double total0 = trials[0].parse + trials[0].inst + trials[0].first;
+    double totalMed = Median(subseq.Select(t => t.parse + t.inst + t.first).ToArray());
+    Print(name, "TOTAL", total0, totalMed);
+}
+
+static void Print(string name, string phase, double first, double subseq)
+    => Console.WriteLine($"  {name,-15}  {phase,-10}  {first,10:F1}  {subseq,16:F1}");
+
+static double Median(double[] xs)
+{
+    Array.Sort(xs);
+    int n = xs.Length;
+    return n % 2 == 1 ? xs[n / 2] : (xs[n / 2 - 1] + xs[n / 2]) / 2.0;
+}
+
+static (double parse, double inst, double first, double warm) RunOne(byte[] bytes, int arg, bool useSwitch)
+{
+    var sw = new Stopwatch();
+    sw.Restart();
+    Wacs.Core.Module module;
+    using (var ms = new MemoryStream(bytes))
+        module = BinaryModuleParser.ParseWasm(ms);
+    sw.Stop();
+    var parse = ToUs(sw);
+
+    sw.Restart();
+    var runtime = new WasmRuntime();
+    runtime.UseSwitchRuntime = useSwitch;
+    var modInst = runtime.InstantiateModule(module,
+        new RuntimeOptions { SkipModuleValidation = true });
+    runtime.RegisterModule("bench", modInst);
+    sw.Stop();
+    var inst = ToUs(sw);
+
+    if (!runtime.TryGetExportedFunction(("bench", "fib"), out var addr))
+        throw new Exception("fib not exported");
+    var invoker = runtime.CreateStackInvoker(addr,
+        new InvokerOptions { SynchronousExecution = true });
+    var argArr = new[] { new Value(arg) };
+
+    sw.Restart();
+    invoker(argArr);
+    sw.Stop();
+    var first = ToUs(sw);
+
+    sw.Restart();
+    invoker(argArr);
+    sw.Stop();
+    var warm = ToUs(sw);
+
+    return (parse, inst, first, warm);
+}
+
+static double ToUs(Stopwatch sw)
+    => sw.ElapsedTicks * 1_000_000.0 / Stopwatch.Frequency;

--- a/Wacs.Bench.Aot/Wacs.Bench.Aot.csproj
+++ b/Wacs.Bench.Aot/Wacs.Bench.Aot.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <LangVersion>9</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <RootNamespace>Wacs.Bench.Aot</RootNamespace>
+    <!-- Opt the consuming entry point into AOT analyzer warnings. -->
+    <IsAotCompatible>true</IsAotCompatible>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- UndefineProperties stops PublishAot from propagating into Wacs.Core's
+         netstandard2.1 leg or the Wacs.Compilation source generator's
+         netstandard2.0 build, both of which trip NETSDK1207 even though
+         neither ships at runtime in this configuration. -->
+    <ProjectReference Include="..\Wacs.Core\Wacs.Core.csproj"
+                      UndefineProperties="PublishAot;PublishTrimmed;PublishReadyToRun;SelfContained;RuntimeIdentifier" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\Wacs.Bench\fib.wasm" Link="fib.wasm" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/Wacs.Bench/Coldstart.cs
+++ b/Wacs.Bench/Coldstart.cs
@@ -76,9 +76,7 @@ internal static class Coldstart
 
     private static int RunChild(string runtime)
     {
-        var here = AppContext.BaseDirectory;
-        var fibWasm = Path.GetFullPath(Path.Combine(here, "..", "..", "..", "fib.wasm"));
-        var bytes = File.ReadAllBytes(fibWasm);
+        var bytes = File.ReadAllBytes(LocateFib());
 
         // For the saved-DLL runtime, transpile + persist to a temp .dll once
         // before the trial loop. This is the build-time cost — paid once per
@@ -119,9 +117,7 @@ internal static class Coldstart
 
     private static int RunInProcess()
     {
-        var here = AppContext.BaseDirectory;
-        var fibWasm = Path.GetFullPath(Path.Combine(here, "..", "..", "..", "fib.wasm"));
-        var bytes = File.ReadAllBytes(fibWasm);
+        var bytes = File.ReadAllBytes(LocateFib());
 
         Console.WriteLine($"Coldstart benchmark — fib.wasm ({bytes.Length} bytes) — IN-PROCESS");
         Console.WriteLine($"  warning: only the first runtime listed gets true cold .NET JIT;");
@@ -314,6 +310,20 @@ internal static class Coldstart
 
     private static double ToUs(Stopwatch sw)
         => sw.ElapsedTicks * 1_000_000.0 / Stopwatch.Frequency;
+
+    // Resolve fib.wasm in either the development tree (run from
+    // bin/Release/net8.0/) or a published self-contained directory (where
+    // CopyToOutputDirectory drops it alongside the binary).
+    private static string LocateFib()
+    {
+        var here = AppContext.BaseDirectory;
+        var sideBySide = Path.Combine(here, "fib.wasm");
+        if (File.Exists(sideBySide)) return sideBySide;
+        var devTree = Path.GetFullPath(Path.Combine(here, "..", "..", "..", "fib.wasm"));
+        if (File.Exists(devTree)) return devTree;
+        throw new FileNotFoundException(
+            $"fib.wasm not found next to the binary or in the dev tree (looked at {sideBySide} and {devTree})");
+    }
 
     // ---------- transpiler-saved (.dll) driver ----------
 

--- a/Wacs.Bench/Coldstart.cs
+++ b/Wacs.Bench/Coldstart.cs
@@ -1,0 +1,423 @@
+// Coldstart micro-benchmark. Measures how long each runtime takes to go
+// from a wasm byte buffer to a returned value on the first invocation.
+//
+// Phases measured per trial:
+//   parse    BinaryModuleParser.ParseWasm
+//   inst     WasmRuntime ctor + InstantiateModule
+//   xpile    (transpiler only) ModuleTranspiler.Transpile
+//   activate (transpiler only) Activator.CreateInstance(ModuleClass)
+//   first    first invoke (cold JIT for generated/dispatched code)
+//   warm     second invoke (hot JIT)
+//
+// Trial 0 is reported separately ("first") as the closest in-process proxy
+// for true cold start; trials 1..N median is reported as "subsequent" since
+// in-process JIT for runtime code itself warms up after the first trial.
+//
+// Workload is fib.wasm exporting fib(n). We run two variants:
+//   fib(100)         — trivial body, exposes startup overhead
+//   fib(5_000_000)   — long body, exposes per-op dispatch cost on first call
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Transpiler.AOT;
+
+internal static class Coldstart
+{
+    // Top-level entry. Dispatches based on optional second arg:
+    //   coldstart                  -> spawns one child per runtime (true cold per runtime)
+    //   coldstart in-process       -> measures all three in this process (shared JIT warmup)
+    //   coldstart run <runtime>    -> child-process mode; emits one runtime's numbers
+    public static int Run(string[] args)
+    {
+        if (args.Length >= 3 && args[1] == "run")
+            return RunChild(args[2]);
+
+        bool inProcess = args.Length >= 2 && args[1] == "in-process";
+        return inProcess ? RunInProcess() : RunFreshProcesses();
+    }
+
+    private static int RunFreshProcesses()
+    {
+        Console.WriteLine($"Coldstart benchmark — fib.wasm — fresh process per runtime");
+        Console.WriteLine($"  trials per cell: 7 (trial 0 = 'first', subsequent 6 reported as median)");
+        Console.WriteLine($"  units: microseconds (us)");
+        Console.WriteLine();
+
+        var dll = typeof(Coldstart).Assembly.Location;
+        var dotnet = Environment.ProcessPath ?? "dotnet";
+        bool selfHosted = !string.Equals(Path.GetFileName(dotnet), "dotnet", StringComparison.OrdinalIgnoreCase);
+
+        foreach (var runtime in new[] { "interp-poly", "interp-switch", "transpiler", "transpiler-saved" })
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = selfHosted ? dotnet : "dotnet",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            if (!selfHosted) psi.ArgumentList.Add(dll);
+            psi.ArgumentList.Add("coldstart");
+            psi.ArgumentList.Add("run");
+            psi.ArgumentList.Add(runtime);
+
+            using var p = Process.Start(psi)!;
+            Console.Write(p.StandardOutput.ReadToEnd());
+            p.WaitForExit();
+        }
+        return 0;
+    }
+
+    private static int RunChild(string runtime)
+    {
+        var here = AppContext.BaseDirectory;
+        var fibWasm = Path.GetFullPath(Path.Combine(here, "..", "..", "..", "fib.wasm"));
+        var bytes = File.ReadAllBytes(fibWasm);
+
+        // For the saved-DLL runtime, transpile + persist to a temp .dll once
+        // before the trial loop. This is the build-time cost — paid once per
+        // module ever, not at startup. Print it as a separate one-time line
+        // so it's not folded into the per-trial coldstart numbers.
+        string? savedDllPath = null;
+        if (runtime == "transpiler-saved")
+        {
+            var sw = Stopwatch.StartNew();
+            savedDllPath = TranspileAndSave(bytes);
+            sw.Stop();
+            Console.WriteLine($"  one-time build-time cost: transpile + Lokad.ILPack save = {ToUs(sw):F1} us");
+            Console.WriteLine($"  saved .dll: {savedDllPath} ({new FileInfo(savedDllPath).Length} bytes)");
+            Console.WriteLine();
+        }
+
+        foreach (var arg in new[] { 100, 5_000_000 })
+        {
+            Console.WriteLine($"=== {runtime} fib({arg:N0}) ({bytes.Length}-byte module) ===");
+            Header();
+            switch (runtime)
+            {
+                case "interp-poly":      Measure(runtime, bytes, arg, RunInterpreter,  useSwitch: false); break;
+                case "interp-switch":    Measure(runtime, bytes, arg, RunInterpreter,  useSwitch: true);  break;
+                case "transpiler":       Measure(runtime, bytes, arg, RunTranspiler,   useSwitch: false); break;
+                case "transpiler-saved": MeasureSaved(runtime, savedDllPath!, arg); break;
+                default: Console.Error.WriteLine($"unknown runtime: {runtime}"); return 2;
+            }
+            Console.WriteLine();
+        }
+
+        if (savedDllPath != null && File.Exists(savedDllPath))
+        {
+            try { File.Delete(savedDllPath); } catch { /* best-effort cleanup */ }
+        }
+        return 0;
+    }
+
+    private static int RunInProcess()
+    {
+        var here = AppContext.BaseDirectory;
+        var fibWasm = Path.GetFullPath(Path.Combine(here, "..", "..", "..", "fib.wasm"));
+        var bytes = File.ReadAllBytes(fibWasm);
+
+        Console.WriteLine($"Coldstart benchmark — fib.wasm ({bytes.Length} bytes) — IN-PROCESS");
+        Console.WriteLine($"  warning: only the first runtime listed gets true cold .NET JIT;");
+        Console.WriteLine($"  later runtimes share warmed parser/runtime code. Use the default");
+        Console.WriteLine($"  fresh-process mode for fair cross-runtime comparison.");
+        Console.WriteLine($"  trials per cell: 7 (1 first + 6 subsequent; subsequent reported as median)");
+        Console.WriteLine();
+
+        var savedSw = Stopwatch.StartNew();
+        var savedDll = TranspileAndSave(bytes);
+        savedSw.Stop();
+        Console.WriteLine($"  one-time build cost (transpile + Lokad.ILPack save): {ToUs(savedSw):F1} us");
+        Console.WriteLine();
+
+        foreach (var arg in new[] { 100, 5_000_000 })
+        {
+            Console.WriteLine($"=== fib({arg:N0}) ===");
+            Header();
+            Measure("interp-poly",      bytes, arg, RunInterpreter, useSwitch: false);
+            Measure("interp-switch",    bytes, arg, RunInterpreter, useSwitch: true);
+            Measure("transpiler",       bytes, arg, RunTranspiler,  useSwitch: false);
+            MeasureSaved("transpiler-saved", savedDll, arg);
+            Console.WriteLine();
+        }
+
+        try { File.Delete(savedDll); } catch { }
+        return 0;
+    }
+
+    private const int Trials = 7;
+
+    private static void Header()
+    {
+        Console.WriteLine($"  {"runtime",-15}  {"phase",-10}  {"first(us)",10}  {"subseq-med(us)",16}");
+        Console.WriteLine($"  ----------------------------------------------------------------");
+    }
+
+    // run-fn signature: takes (bytes, arg, useSwitch, out PhaseTimings) and produces no return value.
+    // PhaseTimings has parse/inst/xpile/activate/first/warm in microseconds.
+    private delegate PhaseTimings RunFn(byte[] bytes, int arg, bool useSwitch);
+
+    private struct PhaseTimings
+    {
+        public double Parse;     // us
+        public double Inst;      // us
+        public double Xpile;     // us, 0 for interpreter
+        public double Activate;  // us, 0 for interpreter
+        public double First;     // us, first invoke
+        public double Warm;      // us, second invoke
+    }
+
+    private static void Measure(string name, byte[] bytes, int arg, RunFn fn, bool useSwitch)
+    {
+        var trials = new PhaseTimings[Trials];
+        for (int i = 0; i < Trials; i++)
+        {
+            // Force GC before each trial so allocations during the measured region
+            // aren't followed by a collection that gets billed to the next phase.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            trials[i] = fn(bytes, arg, useSwitch);
+        }
+
+        // Trial 0 = "first"; remaining 6 = "subsequent".
+        var subseq = trials.Skip(1).ToArray();
+
+        Print(name, "parse",    trials[0].Parse,    Median(subseq, t => t.Parse));
+        Print(name, "inst",     trials[0].Inst,     Median(subseq, t => t.Inst));
+        if (trials[0].Xpile > 0 || trials.Any(t => t.Xpile > 0))
+            Print(name, "xpile",    trials[0].Xpile,    Median(subseq, t => t.Xpile));
+        if (trials[0].Activate > 0 || trials.Any(t => t.Activate > 0))
+            Print(name, "activate", trials[0].Activate, Median(subseq, t => t.Activate));
+        Print(name, "first",    trials[0].First,    Median(subseq, t => t.First));
+        Print(name, "warm",     trials[0].Warm,     Median(subseq, t => t.Warm));
+
+        // Total cold = parse + inst + xpile + activate + first.
+        double Total(PhaseTimings t) => t.Parse + t.Inst + t.Xpile + t.Activate + t.First;
+        Print(name, "TOTAL",    Total(trials[0]),   Median(subseq, Total));
+    }
+
+    private static void Print(string name, string phase, double first, double subseq)
+        => Console.WriteLine($"  {name,-15}  {phase,-10}  {first,10:F1}  {subseq,16:F1}");
+
+    private static double Median(PhaseTimings[] xs, Func<PhaseTimings, double> sel)
+    {
+        var arr = xs.Select(sel).OrderBy(v => v).ToArray();
+        int n = arr.Length;
+        return n % 2 == 1 ? arr[n / 2] : (arr[n / 2 - 1] + arr[n / 2]) / 2.0;
+    }
+
+    // ---------- runtime drivers ----------
+
+    private static PhaseTimings RunInterpreter(byte[] bytes, int arg, bool useSwitch)
+    {
+        var t = new PhaseTimings();
+        var sw = new Stopwatch();
+
+        sw.Restart();
+        Wacs.Core.Module module;
+        using (var ms = new MemoryStream(bytes))
+            module = BinaryModuleParser.ParseWasm(ms);
+        sw.Stop();
+        t.Parse = ToUs(sw);
+
+        sw.Restart();
+        var runtime = new WasmRuntime();
+        runtime.UseSwitchRuntime = useSwitch;
+        var modInst = runtime.InstantiateModule(module,
+            new RuntimeOptions { SkipModuleValidation = true });
+        runtime.RegisterModule("bench", modInst);
+        sw.Stop();
+        t.Inst = ToUs(sw);
+
+        if (!runtime.TryGetExportedFunction(("bench", "fib"), out var addr))
+            throw new Exception("fib not exported");
+        var invoker = runtime.CreateStackInvoker(addr,
+            new InvokerOptions { SynchronousExecution = true });
+        var argArr = new[] { new Value(arg) };
+
+        sw.Restart();
+        invoker(argArr);
+        sw.Stop();
+        t.First = ToUs(sw);
+
+        sw.Restart();
+        invoker(argArr);
+        sw.Stop();
+        t.Warm = ToUs(sw);
+
+        return t;
+    }
+
+    private static PhaseTimings RunTranspiler(byte[] bytes, int arg, bool useSwitch)
+    {
+        var t = new PhaseTimings();
+        var sw = new Stopwatch();
+
+        sw.Restart();
+        Wacs.Core.Module module;
+        using (var ms = new MemoryStream(bytes))
+            module = BinaryModuleParser.ParseWasm(ms);
+        sw.Stop();
+        t.Parse = ToUs(sw);
+
+        sw.Restart();
+        var runtime = new WasmRuntime();
+        var modInst = runtime.InstantiateModule(module,
+            new RuntimeOptions { SkipModuleValidation = true });
+        sw.Stop();
+        t.Inst = ToUs(sw);
+
+        sw.Restart();
+        var transpiler = new ModuleTranspiler();
+        var result = transpiler.Transpile(modInst, runtime, "Bench");
+        sw.Stop();
+        t.Xpile = ToUs(sw);
+
+        if (result.ModuleClass == null)
+            throw new Exception("transpiler produced no Module class");
+
+        sw.Restart();
+        var instance = Activator.CreateInstance(result.ModuleClass);
+        sw.Stop();
+        t.Activate = ToUs(sw);
+
+        // fib export — find the generated method by WASM name.
+        var exportMeta = result.ExportMethods.FirstOrDefault(m => m.WasmName == "fib")
+            ?? throw new Exception("fib not exported in transpiled module");
+        var method = result.ModuleClass.GetMethod(exportMeta.Name,
+            BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new Exception($"method {exportMeta.Name} not found");
+
+        var clrArgs = new object[] { arg };
+
+        sw.Restart();
+        try { method.Invoke(instance, clrArgs); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null) { throw tie.InnerException; }
+        sw.Stop();
+        t.First = ToUs(sw);
+
+        sw.Restart();
+        try { method.Invoke(instance, clrArgs); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null) { throw tie.InnerException; }
+        sw.Stop();
+        t.Warm = ToUs(sw);
+
+        return t;
+    }
+
+    private static double ToUs(Stopwatch sw)
+        => sw.ElapsedTicks * 1_000_000.0 / Stopwatch.Frequency;
+
+    // ---------- transpiler-saved (.dll) driver ----------
+
+    private static string TranspileAndSave(byte[] bytes)
+    {
+        Wacs.Core.Module module;
+        using (var ms = new MemoryStream(bytes))
+            module = BinaryModuleParser.ParseWasm(ms);
+        var runtime = new WasmRuntime();
+        var modInst = runtime.InstantiateModule(module,
+            new RuntimeOptions { SkipModuleValidation = true });
+        var transpiler = new ModuleTranspiler();
+        var result = transpiler.Transpile(modInst, runtime, "Bench");
+        var path = Path.Combine(Path.GetTempPath(),
+            $"wacs-bench-{Guid.NewGuid():N}.dll");
+        result.SaveAssembly(path);
+        return path;
+    }
+
+    private static void MeasureSaved(string name, string dllPath, int arg)
+    {
+        // Pre-read DLL bytes once, outside the trial loop. The trials measure
+        // the cost of taking those bytes through Assembly load → instantiate →
+        // first JITted call, not the disk I/O (which a real deployment would
+        // have already streamed via OS page cache anyway).
+        var dllBytes = File.ReadAllBytes(dllPath);
+
+        var trials = new PhaseTimings[Trials];
+        for (int i = 0; i < Trials; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            trials[i] = RunSavedOnce(dllBytes, arg);
+        }
+
+        var subseq = trials.Skip(1).ToArray();
+
+        // Repurpose phase columns: parse=load (Assembly.LoadFromStream),
+        // inst=resolve (find Module type), xpile=0, activate=ctor, first/warm=invoke.
+        Print(name, "load",     trials[0].Parse,    Median(subseq, t => t.Parse));
+        Print(name, "resolve",  trials[0].Inst,     Median(subseq, t => t.Inst));
+        Print(name, "activate", trials[0].Activate, Median(subseq, t => t.Activate));
+        Print(name, "first",    trials[0].First,    Median(subseq, t => t.First));
+        Print(name, "warm",     trials[0].Warm,     Median(subseq, t => t.Warm));
+
+        double Total(PhaseTimings t) => t.Parse + t.Inst + t.Activate + t.First;
+        Print(name, "TOTAL",    Total(trials[0]),   Median(subseq, Total));
+    }
+
+    private static PhaseTimings RunSavedOnce(byte[] dllBytes, int arg)
+    {
+        var t = new PhaseTimings();
+        var sw = new Stopwatch();
+
+        // Fresh AssemblyLoadContext per trial — Assembly.LoadFile would cache
+        // and trials 1..N would hit the cache, hiding the real load cost.
+        var alc = new AssemblyLoadContext(
+            "wacs-bench-" + Guid.NewGuid().ToString("N").Substring(0, 6),
+            isCollectible: true);
+
+        sw.Restart();
+        Assembly asm;
+        using (var ms = new MemoryStream(dllBytes))
+            asm = alc.LoadFromStream(ms);
+        sw.Stop();
+        t.Parse = ToUs(sw);
+
+        sw.Restart();
+        Type? moduleType = null;
+        foreach (var ty in asm.GetExportedTypes())
+        {
+            if (ty.Name != "Module") continue;
+            var ctxField = ty.GetField("_ctx", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (ctxField != null) { moduleType = ty; break; }
+        }
+        if (moduleType == null) throw new Exception("Module type not found in saved .dll");
+        // Find fib export by CLR name (sanitized "fib" stays "fib").
+        var method = moduleType.GetMethod("fib",
+            BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new Exception("fib export not found in saved .dll");
+        sw.Stop();
+        t.Inst = ToUs(sw);
+
+        sw.Restart();
+        var instance = Activator.CreateInstance(moduleType);
+        sw.Stop();
+        t.Activate = ToUs(sw);
+
+        var clrArgs = new object[] { arg };
+
+        sw.Restart();
+        try { method.Invoke(instance, clrArgs); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null) { throw tie.InnerException; }
+        sw.Stop();
+        t.First = ToUs(sw);
+
+        sw.Restart();
+        try { method.Invoke(instance, clrArgs); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null) { throw tie.InnerException; }
+        sw.Stop();
+        t.Warm = ToUs(sw);
+
+        alc.Unload();
+        return t;
+    }
+}

--- a/Wacs.Bench/Program.cs
+++ b/Wacs.Bench/Program.cs
@@ -10,6 +10,9 @@ using System.IO;
 using Wacs.Core;
 using Wacs.Core.Runtime;
 
+if (args.Length > 0 && args[0] == "coldstart")
+    return Coldstart.Run(args);
+
 static long RunOne(string wasmPath, bool useSwitch, bool superInst, bool useMinimal, bool switchSuper, Bench b)
 {
     var bytes = File.ReadAllBytes(wasmPath);

--- a/Wacs.Bench/Wacs.Bench.csproj
+++ b/Wacs.Bench/Wacs.Bench.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wacs.Core\Wacs.Core.csproj" />
+    <ProjectReference Include="..\Wacs.Transpiler.Lib\Wacs.Transpiler.Lib.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="fib.wasm" CopyToOutputDirectory="PreserveNewest" />

--- a/docs/COLDSTART.md
+++ b/docs/COLDSTART.md
@@ -7,36 +7,20 @@ it's distinct from steady-state throughput.
 
 WACS ships four execution paths. They all parse the same wasm and
 implement the same semantics, but they make very different cold-start
-trade-offs. This doc walks through where the time goes in each, and
-how to pick one for a given embedding.
+trade-offs. A fifth path — statically linking a transpiled module's
+.dll into a NativeAOT-published consumer — is achievable today with
+hand-wired csproj plumbing and is the likely target of a future single-
+shot `wacs aot` workflow.
 
-The numbers below come from `Wacs.Bench/Coldstart.cs` running on
-macOS / arm64 / net8.0 Release, 2026-05-01. Reproduce with:
-
-```bash
-# JIT-only baseline
-dotnet run -c Release --project Wacs.Bench -- coldstart
-
-# R2R (works for all four runtimes)
-dotnet publish Wacs.Bench -c Release -r osx-arm64 \
-    --self-contained -p:PublishReadyToRun=true -o /tmp/wacs-r2r
-/tmp/wacs-r2r/Wacs.Bench coldstart
-
-# NativeAOT (interpreter-only — see Wacs.Bench.Aot)
-dotnet publish Wacs.Bench.Aot -c Release -r osx-arm64 -o /tmp/wacs-aot
-/tmp/wacs-aot/Wacs.Bench.Aot
-```
-
-The bench spawns one fresh child process per runtime (so the .NET CLR +
-shared parser/runtime JIT cost is paid honestly by each), then runs 7
-trials of each: trial 0 is reported as "first," the median of trials 1–6
-as "subsequent." Workload is `fib.wasm` (242 bytes, no imports), called
-with `fib(100)` (startup-dominated) and `fib(5_000_000)` (execution-
-dominated).
+The numbers below come from `Wacs.Bench/Coldstart.cs` (and a since-
+removed `Wacs.Bench.Aot.Saved` experiment for the AOT-linked row),
+running on macOS / arm64 / net8.0 Release, 2026-05-01. The
+[Methodology](#methodology) section shows exactly how to reproduce each
+column.
 
 ---
 
-## The four runtimes
+## The execution paths
 
 ### `interp-poly` — the default polymorphic interpreter
 
@@ -81,43 +65,71 @@ instantiate, no IL emission.
 Cold-start path: `LoadFromStream` → resolve types → `Activator
 .CreateInstance` → invoke.
 
+### `transpiler-aot-linked` — statically link the transpiled .dll into a NativeAOT host
+
+The pre-built .dll is referenced as a regular assembly from a NativeAOT-
+publishing consumer csproj. NativeAOT's ILC pulls the transpiled wasm's
+IL into the same single native binary as the host, so the wasm methods
+become direct typed CLR calls in the final native code. No JIT, no
+Reflection.Emit, no Assembly.Load, no `MethodInfo.Invoke`.
+
+Cold-start path: `new Module()` (ctor — direct C# `new`) → typed
+virtual call into the wasm function.
+
 ---
 
 ## Cold-start numbers
 
 `fib(100)` — trivial body, exposes the per-runtime startup floor.
 
-| runtime            | JIT-only cold (µs) | R2R cold (µs) | NativeAOT cold (µs) |
-|--------------------|-------------------:|--------------:|--------------------:|
-| interp-poly        |             35,676 |        24,336 |                 988 |
-| interp-switch      |             45,230 |        16,396 |             **319** |
-| transpiler         |             54,737 |        29,983 |   not supported     |
-| transpiler-saved   |              1,715 |           998 |   not supported     |
+| runtime                  | JIT-only cold (µs) | R2R cold (µs) | NativeAOT cold (µs) |
+|--------------------------|-------------------:|--------------:|--------------------:|
+| interp-poly              |             35,676 |        24,336 |                 988 |
+| interp-switch            |             45,230 |        16,396 |             **319** |
+| transpiler               |             54,737 |        29,983 |       not supported |
+| transpiler-saved         |              1,715 |           998 |       not supported |
+| **transpiler-aot-linked** |              n/a |           n/a |             **501** |
 
-NativeAOT only applies to the interpreter rows — see "Build-time
-configuration" below for why both transpiler paths require a JIT.
+NativeAOT only applies to runtimes without runtime IL emission/loading
+— see [Build-time configuration](#build-time-configuration-what-users-can-opt-into)
+below for why.
 
 `fib(5,000,000)` — long inner loop, exposes per-op execution cost on
 first call. Build configuration barely matters here because the inner
 loop runs in already-tier-1 code regardless: R2R precompiles, JIT tiers
 up almost immediately, AOT compiles ahead of time.
 
-| runtime            | JIT-only cold (µs) | R2R cold (µs) | NativeAOT cold (µs) |
-|--------------------|-------------------:|--------------:|--------------------:|
-| interp-poly        |            453,920 |       492,535 |             459,964 |
-| interp-switch      |            262,543 |       257,656 |             260,830 |
-| transpiler         |              3,274 |         3,348 |       not supported |
-| **transpiler-saved** |          **2,922** |     **3,202** |       not supported |
+| runtime                  | JIT-only cold (µs) | R2R cold (µs) | NativeAOT cold (µs) |
+|--------------------------|-------------------:|--------------:|--------------------:|
+| interp-poly              |            453,920 |       492,535 |             459,964 |
+| interp-switch            |            262,543 |       257,656 |             260,830 |
+| transpiler               |              3,274 |         3,348 |       not supported |
+| transpiler-saved         |              2,922 |         3,202 |       not supported |
+| **transpiler-aot-linked** |              n/a |           n/a |           **2,628** |
 
 Build-time cost for the saved-DLL path (paid once per module ever, not
 at startup): transpile + Lokad.ILPack save = ~100 ms. The saved .dll is
 4,608 bytes for a 242-byte wasm input — typical PE-format overhead.
 
+Native binary sizes (single self-contained executable, macOS arm64):
+
+| binary                   | size  |
+|--------------------------|------:|
+| `Wacs.Bench.Aot` (interpreter-only)              | 9.8 MB |
+| `Wacs.Bench.Aot.Saved` (transpiler-aot-linked)   | 4.3 MB |
+| `Wacs.Bench` self-contained R2R                  |  ~70 MB |
+| Default JIT publish (managed assemblies + apphost) |  ~30 MB |
+
+Smaller for the AOT-linked variant because trimming proves the
+interpreter, parser, and transpiler emitter are all dead code — only
+the specific transpiled functions plus the runtime support types
+(`ThinContext`, `InitializationHelper`) survive.
+
 ---
 
 ## Where the time goes
 
-Per-phase breakdown of trial-0 cold start, fib(100):
+Per-phase breakdown of trial-0 cold start, fib(100), JIT-only:
 
 | runtime          | parse | inst  | xpile  | activate | first invoke | total  |
 |------------------|------:|------:|-------:|---------:|-------------:|-------:|
@@ -131,31 +143,45 @@ Per-phase breakdown of trial-0 cold start, fib(100):
 ctor + `InitializationHelper`. There is no parse or xpile because the
 build did them already.)
 
+For `transpiler-aot-linked`, fib(100) cold trial 0 is just:
+
+| activate (Module ctor) | first invoke | total |
+|-----------------------:|-------------:|------:|
+|                    501 |          0.1 |   501 |
+
+The first-invoke time is genuinely sub-microsecond — no JIT, no
+indirection, just the AOT-compiled fib loop running on bare arm64.
+Verified with a result sink in the bench so the optimizer can't
+elide the call.
+
 What stands out:
 
-- **The interpreters' "parse" and "inst" first-call numbers are 14–17 ms,
+- **The interpreters' "parse" and "inst" first-call numbers are 14–17 ms**
   not because parsing 242 bytes intrinsically takes that long, but because
   the parser + instantiator code is paying its own .NET tier-1 JIT cost
-  the first time it runs in the process.** Subsequent trials in the same
+  the first time it runs in the process. Subsequent trials in the same
   process do parse + inst in 30–100 µs.
 
-- **The switch interpreter's first invoke is ~14 ms** — that's RyuJIT
-  promoting the prefix-split `TryDispatch_XX` methods to tier 1. After
-  that, they execute at ~6 µs per fib(100) call, beating polymorphic's
-  50 µs by 8×. This is the trade: cheap steady state, expensive first
-  call.
+- **The switch interpreter's first invoke is ~14 ms** under JIT — that's
+  RyuJIT promoting the prefix-split `TryDispatch_XX` methods to tier 1.
+  After that, they execute at ~6 µs per fib(100) call, beating
+  polymorphic's 50 µs by 8×. Under R2R or NativeAOT the tier-1 cost
+  vanishes (R2R: 977 µs first invoke; AOT: 26 µs).
 
 - **The in-process transpiler pays an extra ~25 ms for `xpile`** —
   Reflection.Emit warming up plus IL emission for fib's small functions.
-  Once that's done, every invoke is sub-millisecond. The trade-off only
-  pays back if you're doing real work (fib(5M) goes from 454 ms cold on
-  poly to 3.3 ms cold on the transpiler — **138× faster**).
+  Once that's done, every invoke is sub-millisecond.
 
 - **`transpiler-saved` skips parse, inst, and xpile entirely.** What
   remains is `AssemblyLoadContext.LoadFromStream` (41 µs), type
   resolution (44 µs), the module's init ctor (1.5 ms), and the first
-  JITted invoke (136 µs). Total cold: 1.7 ms — **20× faster than the
-  fastest interpreter**, **32× faster than in-process transpile**.
+  JITted invoke (136 µs).
+
+- **`transpiler-aot-linked` is `transpiler-saved` minus the JIT and the
+  load.** All the fib code is in the host process's native image at
+  build time. Cold start is just the Module ctor's first-time class
+  initialization (~500 µs trial 0, ~50 µs subsequent) plus an actual
+  function call (~100 ns).
 
 ---
 
@@ -199,16 +225,21 @@ The blast radius of dynamic codegen is genuinely contained:
   `Runtime/Types/HostFunction.cs`, for binding host-function adapter
   classes — easy to make AOT-safe with a
   `[DynamicallyAccessedMembers]` annotation if needed).
-- `Wacs.Transpiler.Lib` uses Reflection.Emit. AOT-incompatible.
+- `Wacs.Transpiler.Lib` uses Reflection.Emit at *transpile* time, but
+  its *runtime* support types (`ThinContext`,
+  `InitializationHelper`) are AOT-compatible — that's why
+  `transpiler-aot-linked` works.
 - `Wacs.ComponentModel` uses `MakeGenericMethod` + `DispatchProxy`.
   AOT-incompatible.
-- The saved-DLL path uses `AssemblyLoadContext.LoadFromStream` to
-  load IL that needs a JIT — also AOT-incompatible (NativeAOT
-  processes have no JIT).
+- The `transpiler-saved` runtime path uses `AssemblyLoadContext
+  .LoadFromStream` to load IL that needs a JIT — also AOT-
+  incompatible (NativeAOT processes have no JIT). The `transpiler-
+  aot-linked` path avoids this by linking the .dll at build time.
 
 So an AOT WACS embedding includes the parser + both interpreters +
-WASIp1 + host-binding APIs, but excludes the transpiler and
-component-model. That's a real but bounded trade-off.
+WASIp1 + host-binding APIs, plus optionally a build-time-transpiled
+wasm linked statically. It excludes the in-process transpiler,
+component-model, and runtime saved-DLL loading.
 
 The MSBuild trick to make AOT publish work: put `<PublishAot>true
 </PublishAot>` **inside the consumer's csproj**, not on the CLI
@@ -229,7 +260,10 @@ For "what users can ship today":
 
 - **R2R** for any embedding (works with all four runtimes).
 - **NativeAOT** for interpreter-only embeddings (component-model and
-  transpiler users stay on R2R or JIT).
+  in-process-transpiler users stay on R2R or JIT).
+- **NativeAOT + linked transpiled .dll** for the absolute floor on
+  cold-start *and* steady-state, when the wasm is known at build
+  time. Manual plumbing today; tracked for `wacs aot` automation.
 
 ---
 
@@ -245,15 +279,7 @@ For "what users can ship today":
 | Serverless / edge / cold-boot-sensitive (transpiler ok) | **`transpiler-saved`** | R2R |
 | Game engine, plug-ins shipped pre-transpiled        | **`transpiler-saved`** | R2R       |
 | Game engine, IL2CPP-style AOT (iOS/console)         | `interp-switch`       | NativeAOT  |
-
-The two interpreters have a similar cold-start floor under JIT (~35–45
-ms, mostly .NET JIT warmup); pick between them based on steady-state
-hotness, not cold start. Under R2R the picture sharpens: `interp-switch`
-becomes the cold-start winner among interpreters (16 ms vs 24 ms for
-poly) because R2R kills its expensive first-invoke tier-1 JIT cost.
-Once you decide you can absorb ~14–25 ms of in-process xpile or move it
-to build time, the transpiler is the right answer for anything that
-runs more than trivial work.
+| Embedded wasm known at host build time, every µs counts | **`transpiler-aot-linked`** | **NativeAOT** |
 
 For the "I can transpile at build time" path, the workflow is:
 
@@ -271,6 +297,107 @@ module.InvokeExport("_start", Array.Empty<Value>());
 `TranspiledModuleLoader` (in `Wacs.Transpiler.Lib/Hosting/`) handles
 finding the `Module` type, wiring imports, and turning exports into
 typed delegates.
+
+---
+
+## Methodology
+
+Each cell in the tables above was measured with a separate command.
+Reproduce in this order on macOS arm64 / .NET 8 (Linux x64 and Windows
+x64 differ in absolute terms but the per-runtime ratios hold).
+
+### JIT-only baseline (all four runtimes)
+
+```bash
+dotnet run -c Release --project Wacs.Bench -- coldstart
+```
+
+Spawns one fresh child process per runtime via
+`Process.Start(Environment.ProcessPath)`. Each child runs 7 trials of
+its assigned runtime: trial 0 is reported as "first," the median of
+trials 1–6 as "subsequent." Workload is `Wacs.Bench/fib.wasm` (242
+bytes), called with `fib(100)` (startup-dominated) and
+`fib(5_000_000)` (execution-dominated).
+
+A `coldstart in-process` mode runs everything in one CLR (cheaper but
+shared-JIT-warmup makes only the first runtime's "first" column honest).
+
+### R2R (all four runtimes)
+
+```bash
+dotnet publish Wacs.Bench -c Release -r osx-arm64 \
+    --self-contained -p:PublishReadyToRun=true -o /tmp/wacs-r2r
+/tmp/wacs-r2r/Wacs.Bench coldstart
+```
+
+`-r osx-arm64` is platform-specific — substitute `linux-x64` or
+`win-x64` as needed. `--self-contained` is required so the published
+output ships its own R2R-precompiled framework runtime; without it,
+only the WACS code is R2R-precompiled while the BCL falls back to its
+upstream R2R image (which is the JIT-only baseline already).
+
+### NativeAOT (interpreter-only)
+
+```bash
+dotnet publish Wacs.Bench.Aot -c Release -r osx-arm64 -o /tmp/wacs-aot
+/tmp/wacs-aot/Wacs.Bench.Aot
+```
+
+`Wacs.Bench.Aot/` is a separate consumer that references only
+`Wacs.Core` (no transpiler, no component-model) and sets
+`<PublishAot>true</PublishAot>` inside its csproj. Output is a
+self-contained ~10 MB native binary. Measures the same fib(100) +
+fib(5M) workload across `interp-poly` and `interp-switch`.
+
+### NativeAOT + linked transpiled .dll (`transpiler-aot-linked`)
+
+This isn't yet a one-shot user workflow. The numbers in the tables come
+from a manually-wired experiment that has since been removed from the
+repo. To replicate:
+
+```bash
+# 1) Produce the saved .dll. The transpiler currently appends a
+#    _<uniqueId> suffix to the assembly name, which makes static
+#    references brittle. Capture the actual name from the output.
+dotnet run -c Release --project Wacs.Console -- build app.wasm --out app.dll
+
+# 2) Inspect the assembly's logical name (e.g. "Wacs.Transpiled.App_1")
+#    and rename the file on disk to match — ILC's resolver requires
+#    file name == assembly name.
+mv app.dll Wacs.Transpiled.App_1.dll
+
+# 3) Create a tiny consumer csproj like Wacs.Bench.Aot's, with these
+#    additions:
+#
+#      <ProjectReference Include="..\Wacs.Transpiler.Lib\..."
+#                        UndefineProperties="PublishAot;PublishTrimmed;..." />
+#      <Reference Include="Wacs.Transpiled.App_1">
+#        <HintPath>$(MSBuildThisFileDirectory)Wacs.Transpiled.App_1.dll</HintPath>
+#        <Private>true</Private>
+#      </Reference>
+#
+# 4) In Program.cs:
+#      using Wacs.Transpiled.App;
+#      var m = new Module();
+#      m.SomeExport(arg);
+#
+# 5) Publish.
+dotnet publish MyHost -c Release -r osx-arm64 -o /tmp/myhost
+```
+
+The plumbing pain (steps 1–3) is exactly what a future `wacs aot`
+subcommand should automate — see the followup tracked in this
+project's notes for the three concrete blockers
+(`ModuleTranspiler` stable assembly naming, filename = assembly name
+emit convention, MSBuild target).
+
+### Bench code locations
+
+- Top-level dispatcher: `Wacs.Bench/Program.cs`
+- Coldstart logic and per-runtime drivers: `Wacs.Bench/Coldstart.cs`
+- AOT bench (interpreter-only): `Wacs.Bench.Aot/`
+- Steady-state dispatch microbench (orthogonal to coldstart):
+  `Wacs.Bench/BASELINE.md`
 
 ---
 
@@ -297,3 +424,8 @@ typed delegates.
   `AssemblyLoadContext` per trial so the load isn't cached, but they
   still benefit from in-process JIT warmup of the loader code itself.
   True per-process cold start in the bench is the trial-0 column.
+- `transpiler-aot-linked` numbers were measured with a result sink
+  (`Sink.V += instance.fib(arg);`) so NativeAOT's optimizer couldn't
+  elide the call as dead code. The sink showed real fib values
+  (e.g. -13,721,502,550 summed across trials of fib(100), which
+  overflows i32 as wasm fib does after ~46 iterations).

--- a/docs/COLDSTART.md
+++ b/docs/COLDSTART.md
@@ -14,10 +14,17 @@ The numbers below come from `Wacs.Bench/Coldstart.cs` running on
 macOS / arm64 / net8.0 Release, 2026-05-01. Reproduce with:
 
 ```bash
-dotnet run -c Release --project Wacs.Bench -- coldstart            # JIT-only baseline
+# JIT-only baseline
+dotnet run -c Release --project Wacs.Bench -- coldstart
+
+# R2R (works for all four runtimes)
 dotnet publish Wacs.Bench -c Release -r osx-arm64 \
     --self-contained -p:PublishReadyToRun=true -o /tmp/wacs-r2r
-/tmp/wacs-r2r/Wacs.Bench coldstart                                 # R2R numbers
+/tmp/wacs-r2r/Wacs.Bench coldstart
+
+# NativeAOT (interpreter-only — see Wacs.Bench.Aot)
+dotnet publish Wacs.Bench.Aot -c Release -r osx-arm64 -o /tmp/wacs-aot
+/tmp/wacs-aot/Wacs.Bench.Aot
 ```
 
 The bench spawns one fresh child process per runtime (so the .NET CLR +
@@ -80,28 +87,31 @@ Cold-start path: `LoadFromStream` → resolve types → `Activator
 
 `fib(100)` — trivial body, exposes the per-runtime startup floor.
 
-| runtime            | JIT-only cold (µs) | R2R cold (µs) | R2R speedup |
-|--------------------|-------------------:|--------------:|------------:|
-| interp-poly        |             35,676 |        24,336 |       1.47× |
-| interp-switch      |             45,230 |        16,396 |       2.76× |
-| transpiler         |             54,737 |        29,983 |       1.83× |
-| **transpiler-saved** |          **1,715** |       **998** |   **1.72×** |
+| runtime            | JIT-only cold (µs) | R2R cold (µs) | NativeAOT cold (µs) |
+|--------------------|-------------------:|--------------:|--------------------:|
+| interp-poly        |             35,676 |        24,336 |                 988 |
+| interp-switch      |             45,230 |        16,396 |             **319** |
+| transpiler         |             54,737 |        29,983 |   not supported     |
+| transpiler-saved   |              1,715 |           998 |   not supported     |
+
+NativeAOT only applies to the interpreter rows — see "Build-time
+configuration" below for why both transpiler paths require a JIT.
 
 `fib(5,000,000)` — long inner loop, exposes per-op execution cost on
-first call. R2R doesn't help here because the inner loop runs in tier-1
-JIT (interpreter) or transpiled IL (transpiler) regardless of host
-configuration, and is too long to be cold-dominated.
+first call. Build configuration barely matters here because the inner
+loop runs in already-tier-1 code regardless: R2R precompiles, JIT tiers
+up almost immediately, AOT compiles ahead of time.
 
-| runtime            | JIT-only cold (µs) | R2R cold (µs) |
-|--------------------|-------------------:|--------------:|
-| interp-poly        |            453,920 |       492,535 |
-| interp-switch      |            262,543 |       257,656 |
-| transpiler         |              3,274 |         3,348 |
-| **transpiler-saved** |          **2,922** |     **3,202** |
+| runtime            | JIT-only cold (µs) | R2R cold (µs) | NativeAOT cold (µs) |
+|--------------------|-------------------:|--------------:|--------------------:|
+| interp-poly        |            453,920 |       492,535 |             459,964 |
+| interp-switch      |            262,543 |       257,656 |             260,830 |
+| transpiler         |              3,274 |         3,348 |       not supported |
+| **transpiler-saved** |          **2,922** |     **3,202** |       not supported |
 
-Build-time cost (paid once per module ever, not at startup): transpile +
-Lokad.ILPack save = ~100 ms. The saved .dll is 4,608 bytes for a
-242-byte wasm input — typical PE-format overhead.
+Build-time cost for the saved-DLL path (paid once per module ever, not
+at startup): transpile + Lokad.ILPack save = ~100 ms. The saved .dll is
+4,608 bytes for a 242-byte wasm input — typical PE-format overhead.
 
 ---
 
@@ -170,41 +180,71 @@ Per-phase, R2R changes:
 | `transpiler-saved` cold total        | ~1.7× faster  | loader code precompiled; the loaded .dll is still pure IL though |
 | any `subsequent` median              | unchanged     | already tier-1 in steady state |
 
-Two further dials exist but are **not currently usable** for WACS:
+**NativeAOT** (`Wacs.Bench.Aot/`, demonstrating the path) works today
+for interpreter-only embedders and delivers the largest cold-start
+improvement of all: no JIT in the process, no .NET runtime startup, a
+single self-contained native binary (~10 MB on macOS arm64 vs ~30 MB
+of managed assemblies + framework for a JIT publish).
 
-- **NativeAOT** (`-p:PublishAot=true`) would deliver the largest
-  cold-start improvement of all (no JIT in the process, no .NET runtime
-  startup, single-file native binary). It's blocked today by two
-  things: (1) `Wacs.Compilation` targets netstandard2.0 only, and AOT
-  requires net8.0 across the dep graph; (2) AOT is incompatible with
-  both the in-process transpiler (Reflection.Emit emits IL that needs
-  a JIT) and the saved-DLL path (the loaded .dll is plain IL, also
-  JIT-required). An AOT-flavored WACS embedding would be **interpreter-
-  only**, which gives up the transpiler's 100×+ steady-state advantage.
-  Not obviously a win.
+The blast radius of dynamic codegen is genuinely contained:
 
-- **IL trimming** (`-p:PublishTrimmed=true`) would shrink the published
-  binary but the WACS code base uses reflection in places that aren't
-  trim-annotated (component-model bridge, transpiler interface
-  generation), so trimming today produces a binary that may fail at
-  runtime when those paths are exercised. Tracking work would be
-  per-call-site `[DynamicallyAccessedMembers]` annotations.
+- `Wacs.Compilation` is a Roslyn source generator
+  (`OutputItemType="Analyzer"`, `ReferenceOutputAssembly="false"`).
+  It runs at compile time inside csc.exe and is **not in the runtime
+  output** — confirm with `ls Wacs.Bench/bin/Release/net8.0/ | grep
+  Wacs.Compilation` (empty). Its netstandard2.0 target framework
+  doesn't matter for runtime AOT.
+- `Wacs.Core` itself is `IsAotCompatible=true` and uses dynamic APIs
+  in exactly one place (`Activator.CreateInstance(hostType)` in
+  `Runtime/Types/HostFunction.cs`, for binding host-function adapter
+  classes — easy to make AOT-safe with a
+  `[DynamicallyAccessedMembers]` annotation if needed).
+- `Wacs.Transpiler.Lib` uses Reflection.Emit. AOT-incompatible.
+- `Wacs.ComponentModel` uses `MakeGenericMethod` + `DispatchProxy`.
+  AOT-incompatible.
+- The saved-DLL path uses `AssemblyLoadContext.LoadFromStream` to
+  load IL that needs a JIT — also AOT-incompatible (NativeAOT
+  processes have no JIT).
 
-For "what users can ship today," **R2R is the realistic upgrade**.
-NativeAOT and trimming are both 2026-or-later refactors.
+So an AOT WACS embedding includes the parser + both interpreters +
+WASIp1 + host-binding APIs, but excludes the transpiler and
+component-model. That's a real but bounded trade-off.
+
+The MSBuild trick to make AOT publish work: put `<PublishAot>true
+</PublishAot>` **inside the consumer's csproj**, not on the CLI
+(`-p:PublishAot=true`). As a CLI global property, AOT propagates into
+every referenced project's MSBuild evaluation, which trips
+`NETSDK1207` on the source generator's netstandard2.0 leg. As a
+csproj-local property, MSBuild scopes it correctly. See
+`Wacs.Bench.Aot/Wacs.Bench.Aot.csproj` for the working incantation.
+
+**IL trimming** (`-p:PublishTrimmed=true`) is automatically enabled by
+NativeAOT — the published interpreter-only binary above is also
+trimmed. Standalone trimming without AOT works for the same
+interpreter-only subset; the transpiler and component-model paths
+need per-call-site `[DynamicallyAccessedMembers]` annotations to be
+trim-safe (tracked as future work).
+
+For "what users can ship today":
+
+- **R2R** for any embedding (works with all four runtimes).
+- **NativeAOT** for interpreter-only embeddings (component-model and
+  transpiler users stay on R2R or JIT).
 
 ---
 
 ## Picking a runtime
 
-| Embedding                                           | Recommendation        |
-|-----------------------------------------------------|-----------------------|
-| Short-lived CLI invocation, ad-hoc wasm             | `interp-poly`         |
-| Long-running host, hot loops in wasm                | `interp-switch`       |
-| Build pipeline can run wacs-transpile               | **`transpiler-saved`** |
-| Test/dev loop, no .dll in source control            | `transpiler` (in-process) |
-| Serverless / edge / cold-boot-sensitive             | **`transpiler-saved`** |
-| Game engine, plug-ins shipped pre-transpiled        | **`transpiler-saved`** |
+| Embedding                                           | Recommendation        | Build flag |
+|-----------------------------------------------------|-----------------------|------------|
+| Short-lived CLI invocation, ad-hoc wasm             | `interp-poly`         | NativeAOT  |
+| Long-running host, hot loops in wasm                | `interp-switch`       | NativeAOT  |
+| Build pipeline can run wacs-transpile               | **`transpiler-saved`** | R2R       |
+| Test/dev loop, no .dll in source control            | `transpiler` (in-process) | R2R    |
+| Serverless / edge / cold-boot-sensitive (no transpiler) | `interp-switch`   | **NativeAOT** |
+| Serverless / edge / cold-boot-sensitive (transpiler ok) | **`transpiler-saved`** | R2R |
+| Game engine, plug-ins shipped pre-transpiled        | **`transpiler-saved`** | R2R       |
+| Game engine, IL2CPP-style AOT (iOS/console)         | `interp-switch`       | NativeAOT  |
 
 The two interpreters have a similar cold-start floor under JIT (~35–45
 ms, mostly .NET JIT warmup); pick between them based on steady-state

--- a/docs/COLDSTART.md
+++ b/docs/COLDSTART.md
@@ -14,7 +14,10 @@ The numbers below come from `Wacs.Bench/Coldstart.cs` running on
 macOS / arm64 / net8.0 Release, 2026-05-01. Reproduce with:
 
 ```bash
-dotnet run -c Release --project Wacs.Bench -- coldstart
+dotnet run -c Release --project Wacs.Bench -- coldstart            # JIT-only baseline
+dotnet publish Wacs.Bench -c Release -r osx-arm64 \
+    --self-contained -p:PublishReadyToRun=true -o /tmp/wacs-r2r
+/tmp/wacs-r2r/Wacs.Bench coldstart                                 # R2R numbers
 ```
 
 The bench spawns one fresh child process per runtime (so the .NET CLR +
@@ -77,22 +80,24 @@ Cold-start path: `LoadFromStream` → resolve types → `Activator
 
 `fib(100)` — trivial body, exposes the per-runtime startup floor.
 
-| runtime            | cold (µs) | subsequent median (µs) |
-|--------------------|----------:|----------------------:|
-| interp-poly        |    35,676 |                   155 |
-| interp-switch      |    45,230 |                   129 |
-| transpiler         |    54,737 |                   572 |
-| **transpiler-saved** |  **1,715** |                  **458** |
+| runtime            | JIT-only cold (µs) | R2R cold (µs) | R2R speedup |
+|--------------------|-------------------:|--------------:|------------:|
+| interp-poly        |             35,676 |        24,336 |       1.47× |
+| interp-switch      |             45,230 |        16,396 |       2.76× |
+| transpiler         |             54,737 |        29,983 |       1.83× |
+| **transpiler-saved** |          **1,715** |       **998** |   **1.72×** |
 
 `fib(5,000,000)` — long inner loop, exposes per-op execution cost on
-first call.
+first call. R2R doesn't help here because the inner loop runs in tier-1
+JIT (interpreter) or transpiled IL (transpiler) regardless of host
+configuration, and is too long to be cold-dominated.
 
-| runtime            | cold (µs) | subsequent median (µs) |
-|--------------------|----------:|----------------------:|
-| interp-poly        |   453,920 |               356,601 |
-| interp-switch      |   262,543 |               261,326 |
-| transpiler         |     3,274 |                 3,254 |
-| **transpiler-saved** |  **2,922** |                **3,006** |
+| runtime            | JIT-only cold (µs) | R2R cold (µs) |
+|--------------------|-------------------:|--------------:|
+| interp-poly        |            453,920 |       492,535 |
+| interp-switch      |            262,543 |       257,656 |
+| transpiler         |              3,274 |         3,348 |
+| **transpiler-saved** |          **2,922** |     **3,202** |
 
 Build-time cost (paid once per module ever, not at startup): transpile +
 Lokad.ILPack save = ~100 ms. The saved .dll is 4,608 bytes for a
@@ -144,6 +149,52 @@ What stands out:
 
 ---
 
+## Build-time configuration: what users can opt into
+
+The "JIT-only" column above is what you get from a default
+`dotnet publish -c Release` (or `dotnet run`). Every row improves under
+**ReadyToRun (R2R)**, which precompiles the WACS managed code to native
+during publish. The cost is binary size (`Wacs.Core.dll` grows from
+1.5 MB to 2.9 MB) and platform-specific publish artifacts. For a
+serverless or game-engine embedder where startup matters, the trade is
+near-always worth it.
+
+Per-phase, R2R changes:
+
+| phase                                | improvement   | why |
+|--------------------------------------|---------------|-----|
+| interpreter `parse` first call       | ~2× faster    | no tier-1 JIT for the parser |
+| interpreter `inst` first call        | ~2× faster    | same — instantiator is precompiled |
+| `interp-switch` first invoke         | **~14× faster** | the giant `TryDispatch_XX` methods stop paying tier-1 JIT (this is the headline win) |
+| `transpiler` `xpile` first call      | ~1.8× faster  | Reflection.Emit warmup |
+| `transpiler-saved` cold total        | ~1.7× faster  | loader code precompiled; the loaded .dll is still pure IL though |
+| any `subsequent` median              | unchanged     | already tier-1 in steady state |
+
+Two further dials exist but are **not currently usable** for WACS:
+
+- **NativeAOT** (`-p:PublishAot=true`) would deliver the largest
+  cold-start improvement of all (no JIT in the process, no .NET runtime
+  startup, single-file native binary). It's blocked today by two
+  things: (1) `Wacs.Compilation` targets netstandard2.0 only, and AOT
+  requires net8.0 across the dep graph; (2) AOT is incompatible with
+  both the in-process transpiler (Reflection.Emit emits IL that needs
+  a JIT) and the saved-DLL path (the loaded .dll is plain IL, also
+  JIT-required). An AOT-flavored WACS embedding would be **interpreter-
+  only**, which gives up the transpiler's 100×+ steady-state advantage.
+  Not obviously a win.
+
+- **IL trimming** (`-p:PublishTrimmed=true`) would shrink the published
+  binary but the WACS code base uses reflection in places that aren't
+  trim-annotated (component-model bridge, transpiler interface
+  generation), so trimming today produces a binary that may fail at
+  runtime when those paths are exercised. Tracking work would be
+  per-call-site `[DynamicallyAccessedMembers]` annotations.
+
+For "what users can ship today," **R2R is the realistic upgrade**.
+NativeAOT and trimming are both 2026-or-later refactors.
+
+---
+
 ## Picking a runtime
 
 | Embedding                                           | Recommendation        |
@@ -155,11 +206,14 @@ What stands out:
 | Serverless / edge / cold-boot-sensitive             | **`transpiler-saved`** |
 | Game engine, plug-ins shipped pre-transpiled        | **`transpiler-saved`** |
 
-The two interpreters have effectively the same cold-start floor (~35–45
-ms on a tiny module, mostly .NET JIT warmup); pick between them based
-on steady-state hotness, not cold start. Once you decide you can absorb
-~25 ms of in-process xpile or move it to build time, the transpiler is
-the right answer for anything that runs more than trivial work.
+The two interpreters have a similar cold-start floor under JIT (~35–45
+ms, mostly .NET JIT warmup); pick between them based on steady-state
+hotness, not cold start. Under R2R the picture sharpens: `interp-switch`
+becomes the cold-start winner among interpreters (16 ms vs 24 ms for
+poly) because R2R kills its expensive first-invoke tier-1 JIT cost.
+Once you decide you can absorb ~14–25 ms of in-process xpile or move it
+to build time, the transpiler is the right answer for anything that
+runs more than trivial work.
 
 For the "I can transpile at build time" path, the workflow is:
 
@@ -185,6 +239,12 @@ typed delegates.
 - These are wall-clock numbers from a single machine on a single day.
   Treat the *ratios* as durable; treat the absolute microseconds as
   approximate.
+- The bench's R2R numbers come from `dotnet publish -r osx-arm64
+  --self-contained -p:PublishReadyToRun=true`. R2R is platform-
+  specific — Linux x64 and Windows x64 numbers will differ in absolute
+  terms but the per-runtime story should hold. The framework BCL
+  always ships R2R'd, so even the "JIT-only" rows already benefit
+  from precompiled `System.*`.
 - "Cold" here means a fresh OS process, but a warm OS file cache. If
   your wasm or .dll isn't already in cache, add disk read time.
 - The bench uses fib's 242-byte module. Larger modules shift the

--- a/docs/COLDSTART.md
+++ b/docs/COLDSTART.md
@@ -386,10 +386,38 @@ dotnet publish MyHost -c Release -r osx-arm64 -o /tmp/myhost
 ```
 
 The plumbing pain (steps 1–3) is exactly what a future `wacs aot`
-subcommand should automate — see the followup tracked in this
-project's notes for the three concrete blockers
-(`ModuleTranspiler` stable assembly naming, filename = assembly name
-emit convention, MSBuild target).
+subcommand should automate. The known follow-up work to make
+`wacs aot app.wasm -o app` a single-shot user workflow:
+
+- **Stable assembly naming.** `ModuleTranspiler.cs:154` appends a
+  `_<uniqueId>` suffix to avoid in-process collisions; saved-to-static-
+  reference usage needs a predictable name. Add an explicit
+  `assemblyName` parameter to `Transpile` / `SaveAssembly`.
+- **Filename = assembly name on emit.** ILC's resolver requires the
+  on-disk file to be named after the assembly's logical name, so
+  `wacs build` should emit `<assemblyname>.dll` by default rather
+  than letting the consumer pick.
+- **AOT-linked emission mode.** Today every saved .dll's Module ctor
+  routes through a base64 → `Convert.FromBase64String` →
+  `InitDataCodec.Decode` → `InitializeFromEmbedded` wrapper that
+  exists to bridge cross-process state transfer (in-process registry
+  was empty when the .dll loaded). For AOT-linked, transpile and
+  consume are different processes by definition AND the toolchain
+  knows it at emission time. A
+  `TranspilerOptions.EmissionTarget = AotLinked` flag would let the
+  generator emit a Module ctor that directly constructs the
+  `ThinContext` from inlined IL constants and static `byte[]` fields
+  (generalizing the existing `DataSegmentStorage.StaticArrays` mode),
+  dead-stripping the codec / embedded-bytes machinery from the AOT
+  binary entirely. Negligible win on tiny modules, significant for
+  multi-MB-data-segment ones (replaces base64 + binary-decode + heap
+  alloc + memcpy with straight `Buffer.MemoryCopy` from PE-resident
+  bytes).
+- **MSBuild integration.** A `<WasmModule Include="app.wasm" />`
+  item that an SDK target turns into build-time `wacs transpile` +
+  auto-`<Reference>`, OR a `wacs aot` CLI subcommand that scaffolds a
+  throwaway csproj and runs `dotnet publish -p:PublishAot=true`. The
+  CLI form is easier to prototype without a custom SDK.
 
 ### Bench code locations
 

--- a/docs/COLDSTART.md
+++ b/docs/COLDSTART.md
@@ -1,0 +1,199 @@
+# Cold-start latency across WACS runtimes
+
+"Cold start" is the wall time from a process launching to the first wasm
+function returning a value. It's the latency a CLI tool, a serverless
+worker, or a game-engine plug-in pays before doing useful work — and
+it's distinct from steady-state throughput.
+
+WACS ships four execution paths. They all parse the same wasm and
+implement the same semantics, but they make very different cold-start
+trade-offs. This doc walks through where the time goes in each, and
+how to pick one for a given embedding.
+
+The numbers below come from `Wacs.Bench/Coldstart.cs` running on
+macOS / arm64 / net8.0 Release, 2026-05-01. Reproduce with:
+
+```bash
+dotnet run -c Release --project Wacs.Bench -- coldstart
+```
+
+The bench spawns one fresh child process per runtime (so the .NET CLR +
+shared parser/runtime JIT cost is paid honestly by each), then runs 7
+trials of each: trial 0 is reported as "first," the median of trials 1–6
+as "subsequent." Workload is `fib.wasm` (242 bytes, no imports), called
+with `fib(100)` (startup-dominated) and `fib(5_000_000)` (execution-
+dominated).
+
+---
+
+## The four runtimes
+
+### `interp-poly` — the default polymorphic interpreter
+
+`WasmRuntime.InstantiateModule` walks the parsed module, allocates
+memories/tables/globals, and produces an executable `ModuleInstance`.
+Each opcode dispatches through a virtual call into a small per-op
+`InstructionBase.Execute` method. The CLR JIT inlines these
+aggressively after a few invocations.
+
+Cold-start path: `ParseWasm` → `InstantiateModule` →
+`CreateStackInvoker` → invoke.
+
+### `interp-switch` — the monolithic switch interpreter
+
+Same parse + instantiate, but execution dispatches through a single
+`TryDispatch` switch over the opcode space, prefix-split into per-prefix
+methods (`TryDispatch_00`, `TryDispatch_FB`, `TryDispatch_FC`,
+`TryDispatch_FD`). Hot loops run faster steady-state because all
+operands live in a single register-bank frame, but each per-prefix
+method is huge — first invocation pays a noticeable JIT-tier-1 cost.
+
+### `transpiler` — in-process AOT to a dynamic .NET assembly
+
+`Wacs.Transpiler.Lib`'s `ModuleTranspiler.Transpile` walks each function
+and emits CIL via `System.Reflection.Emit` into an
+`AssemblyBuilder(Run)`. The result is a real .NET type with one method
+per wasm function. From there it's a regular CLR object — `Activator
+.CreateInstance(ModuleClass)` runs the module's init, and `MethodInfo
+.Invoke` calls into JITted IL.
+
+Cold-start path: `ParseWasm` → `InstantiateModule` → `Transpile` →
+`Activator.CreateInstance` → invoke.
+
+### `transpiler-saved` — load a pre-built .dll
+
+The transpiler can persist its dynamic assembly to a portable PE file
+via `result.SaveAssembly(path)` (Lokad.ILPack under the hood). At run
+time, the embedder loads that .dll into an `AssemblyLoadContext`, finds
+the `Module` class, instantiates it, and invokes — no parse, no
+instantiate, no IL emission.
+
+Cold-start path: `LoadFromStream` → resolve types → `Activator
+.CreateInstance` → invoke.
+
+---
+
+## Cold-start numbers
+
+`fib(100)` — trivial body, exposes the per-runtime startup floor.
+
+| runtime            | cold (µs) | subsequent median (µs) |
+|--------------------|----------:|----------------------:|
+| interp-poly        |    35,676 |                   155 |
+| interp-switch      |    45,230 |                   129 |
+| transpiler         |    54,737 |                   572 |
+| **transpiler-saved** |  **1,715** |                  **458** |
+
+`fib(5,000,000)` — long inner loop, exposes per-op execution cost on
+first call.
+
+| runtime            | cold (µs) | subsequent median (µs) |
+|--------------------|----------:|----------------------:|
+| interp-poly        |   453,920 |               356,601 |
+| interp-switch      |   262,543 |               261,326 |
+| transpiler         |     3,274 |                 3,254 |
+| **transpiler-saved** |  **2,922** |                **3,006** |
+
+Build-time cost (paid once per module ever, not at startup): transpile +
+Lokad.ILPack save = ~100 ms. The saved .dll is 4,608 bytes for a
+242-byte wasm input — typical PE-format overhead.
+
+---
+
+## Where the time goes
+
+Per-phase breakdown of trial-0 cold start, fib(100):
+
+| runtime          | parse | inst  | xpile  | activate | first invoke | total  |
+|------------------|------:|------:|-------:|---------:|-------------:|-------:|
+| interp-poly      | 16,269 | 17,114 |     — |       — |        2,293 | 35,676 |
+| interp-switch    | 14,383 | 16,922 |     — |       — |       13,926 | 45,230 |
+| transpiler       | 14,062 | 14,541 | 24,766 |    1,275 |           93 | 54,737 |
+| transpiler-saved |     41 |     44 |     — |    1,494 |          136 |  1,715 |
+
+(For `transpiler-saved` the columns map to: load = `Assembly
+.LoadFromStream`, resolve = type/method lookup, activate = `Module`
+ctor + `InitializationHelper`. There is no parse or xpile because the
+build did them already.)
+
+What stands out:
+
+- **The interpreters' "parse" and "inst" first-call numbers are 14–17 ms,
+  not because parsing 242 bytes intrinsically takes that long, but because
+  the parser + instantiator code is paying its own .NET tier-1 JIT cost
+  the first time it runs in the process.** Subsequent trials in the same
+  process do parse + inst in 30–100 µs.
+
+- **The switch interpreter's first invoke is ~14 ms** — that's RyuJIT
+  promoting the prefix-split `TryDispatch_XX` methods to tier 1. After
+  that, they execute at ~6 µs per fib(100) call, beating polymorphic's
+  50 µs by 8×. This is the trade: cheap steady state, expensive first
+  call.
+
+- **The in-process transpiler pays an extra ~25 ms for `xpile`** —
+  Reflection.Emit warming up plus IL emission for fib's small functions.
+  Once that's done, every invoke is sub-millisecond. The trade-off only
+  pays back if you're doing real work (fib(5M) goes from 454 ms cold on
+  poly to 3.3 ms cold on the transpiler — **138× faster**).
+
+- **`transpiler-saved` skips parse, inst, and xpile entirely.** What
+  remains is `AssemblyLoadContext.LoadFromStream` (41 µs), type
+  resolution (44 µs), the module's init ctor (1.5 ms), and the first
+  JITted invoke (136 µs). Total cold: 1.7 ms — **20× faster than the
+  fastest interpreter**, **32× faster than in-process transpile**.
+
+---
+
+## Picking a runtime
+
+| Embedding                                           | Recommendation        |
+|-----------------------------------------------------|-----------------------|
+| Short-lived CLI invocation, ad-hoc wasm             | `interp-poly`         |
+| Long-running host, hot loops in wasm                | `interp-switch`       |
+| Build pipeline can run wacs-transpile               | **`transpiler-saved`** |
+| Test/dev loop, no .dll in source control            | `transpiler` (in-process) |
+| Serverless / edge / cold-boot-sensitive             | **`transpiler-saved`** |
+| Game engine, plug-ins shipped pre-transpiled        | **`transpiler-saved`** |
+
+The two interpreters have effectively the same cold-start floor (~35–45
+ms on a tiny module, mostly .NET JIT warmup); pick between them based
+on steady-state hotness, not cold start. Once you decide you can absorb
+~25 ms of in-process xpile or move it to build time, the transpiler is
+the right answer for anything that runs more than trivial work.
+
+For the "I can transpile at build time" path, the workflow is:
+
+```bash
+# Build-time: produce the .dll once.
+wacs transpile --input app.wasm --output app.dll
+
+# Runtime: load + invoke. ~1.7 ms cold to first call.
+var alc = new AssemblyLoadContext("app", isCollectible: true);
+var asm = alc.LoadFromAssemblyPath("app.dll");
+var module = TranspiledModuleLoader.Load(asm);
+module.InvokeExport("_start", Array.Empty<Value>());
+```
+
+`TranspiledModuleLoader` (in `Wacs.Transpiler.Lib/Hosting/`) handles
+finding the `Module` type, wiring imports, and turning exports into
+typed delegates.
+
+---
+
+## Caveats
+
+- These are wall-clock numbers from a single machine on a single day.
+  Treat the *ratios* as durable; treat the absolute microseconds as
+  approximate.
+- "Cold" here means a fresh OS process, but a warm OS file cache. If
+  your wasm or .dll isn't already in cache, add disk read time.
+- The bench uses fib's 242-byte module. Larger modules shift the
+  balance: parse and instantiate scale with module size, while the
+  one-time JIT-warmup floor stays fixed. For big real-world modules
+  (multi-MB), parse + inst can run into hundreds of milliseconds on
+  the interpreters, making the transpile-once-load-many path even
+  more attractive.
+- `transpiler-saved`'s "subsequent" numbers in the bench use a fresh
+  `AssemblyLoadContext` per trial so the load isn't cached, but they
+  still benefit from in-process JIT warmup of the loader code itself.
+  True per-process cold start in the bench is the trial-0 column.


### PR DESCRIPTION
## Summary

- New cold-start benchmark (`Wacs.Bench/Coldstart.cs`) measuring parse + instantiate + first-call latency for all four WACS execution paths in fresh child processes per runtime
- New `Wacs.Bench.Aot/` interpreter-only consumer that publishes as a 9.8 MB self-contained NativeAOT binary — proves the dynamic-codegen blast radius is genuinely contained to `Wacs.Transpiler.Lib` + `Wacs.ComponentModel`
- New `docs/COLDSTART.md` explainer covering the four shipping runtimes, a fifth (transpiler-AOT-linked) future path, per-phase breakdowns, build-flag matrix (JIT / R2R / NativeAOT), embedding recommendations, and full reproduction methodology
- README "Cold-Start" subsection under Performance with the default/better/best tier table and a pointer to the doc

## Headline numbers (fib.wasm 242-byte module, fib(100) cold start)

| runtime              | JIT      | R2R      | NativeAOT |
|----------------------|---------:|---------:|----------:|
| interp-poly          | 35.7 ms  | 24.3 ms  | **988 µs** |
| interp-switch        | 45.2 ms  | 16.4 ms  | **319 µs** |
| transpiler           | 54.7 ms  | 30.0 ms  | n/a       |
| transpiler-saved     | 1.7 ms   | 998 µs   | n/a       |
| transpiler-aot-linked | n/a     | n/a      | **501 µs** (manual plumbing today) |

R2R helps every runtime; NativeAOT helps the interpreters dramatically (interp-switch's expensive tier-1 JIT cost on the prefix-split `TryDispatch_XX` methods vanishes).

## Follow-up tracked in the doc

The single-shot `wacs aot app.wasm -o app` workflow has four concrete blockers identified during the experiment, enumerated in `docs/COLDSTART.md` (Methodology section): stable assembly naming, filename = assembly name on emit, an AOT-linked emission mode that skips the base64 + `InitDataCodec.Decode` wrapper, and an MSBuild integration.

## Test plan

- [x] `dotnet build` clean across `Wacs.Bench`, `Wacs.Bench.Aot`
- [x] `dotnet run -c Release --project Wacs.Bench -- coldstart` produces the JIT-only table
- [x] `dotnet publish Wacs.Bench -c Release -r osx-arm64 --self-contained -p:PublishReadyToRun=true` produces the R2R table
- [x] `dotnet publish Wacs.Bench.Aot -c Release -r osx-arm64` produces a 9.8 MB native binary that runs the AOT table
- [x] No regressions in existing test suites (no production code changed; only new bench projects + doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)