### PR TITLE
Branch hinting: parse metadata.code.branch_hint, reorder if/else in transpiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [WACS 0.11.0 + WACS.Transpiler.Lib 0.6.0] — Branch hinting
+
+Wires the WebAssembly [Branch Hinting](https://github.com/WebAssembly/branch-hinting)
+proposal end-to-end:
+
+- **WACS 0.11.0** parses the `metadata.code.branch_hint` custom
+  section into `Module.BranchHints` (a `(funcIdx → byte_offset →
+  BranchHint)` map). The full payload is retained verbatim including
+  the length-prefixed data vector so future revisions to the
+  proposal can extend the hint encoding without a parser change.
+  Every parsed instruction inside a function body now carries its
+  body-relative byte offset on `InstructionBase.ByteOffsetInFunc` —
+  the lookup key against the hint map.
+
+- **WACS.Transpiler.Lib 0.6.0** consumes the hints in two emission
+  shapes:
+    * `if`-with-`else` hint=unlikely → `EmitIf` swaps the test
+      (`Brtrue then_label` instead of `Brfalse else_label`) and
+      emits the else-arm as the hot fall-through with the then-arm
+      as the cold side-jump.
+    * `if`-without-`else` hint=unlikely → new `_coldTailEmissions`
+      mechanism on `FunctionCodegen` lifts the body out of the
+      linear flow entirely. Hot path is `Brtrue cold_label;
+      <fall-through>`; cold body is emitted between the function
+      body's terminator and the funcEndLabel mark, with a back-jump
+      to the if's endLabel to resume normal flow. Non-reducible CFG;
+      RyuJIT and ILC handle it.
+
+  Optimistic per design: the IL expresses the hint via ordering and
+  branch sense. We don't claim downstream JIT/AOT honors it beyond
+  what its own block-layout pass already does (RyuJIT tier-1 will
+  eventually overrule us with profile data anyway). The bet pays
+  off most for `wacs aot` / NativeAOT cold paths where there's no
+  profile data to rely on.
+
+The README's Branch Hinting feature row updates from "Custom section
+ignored" to describe the new transpiler integration.
+
+Validation is intentionally permissive ("optimistic"): the parser
+rejects duplicate `(funcidx, offset)` entries and out-of-range
+funcidx, but does NOT cross-validate that each hint's target offset
+lands on an `if`/`br_if` instruction. Consumers can re-check at
+use site if they need stricter semantics.
+
 ## [WACS.Cli 1.2.0 + WACS.WASI.Preview1 0.11.0 + WACS.HostBindings.* 0.1.0 + WACS.Transpiler.Lib 0.5.0] — `wacs aot` end-to-end + WASI rename
 
 A wasm input is now one CLI call away from a self-contained NativeAOT

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Overview
 
 **Latest releases** (see the [CHANGELOG](CHANGELOG.md) for details):
-WACS `0.10.0` · WACS.Cli `1.2.0` · WACS.WASI.Preview1 `0.11.0` · WACS.HostBindings.Abstractions `0.1.0` · WACS.HostBindings.SourceGen `0.1.0` · WACS.Transpiler.Lib `0.5.0` · WACS.ComponentModel `0.1.0` · WACS.WASI.Preview2 `0.1.0` · WACS.WASI.Preview2.DependencyInjection `0.1.0` · WACS.ComponentModel.Bindgen.Lib `0.1.0` · WACS.WASI.Threads `0.1.0`
+WACS `0.11.0` · WACS.Cli `1.2.0` · WACS.WASI.Preview1 `0.11.0` · WACS.HostBindings.Abstractions `0.1.0` · WACS.HostBindings.SourceGen `0.1.0` · WACS.Transpiler.Lib `0.6.0` · WACS.ComponentModel `0.1.0` · WACS.WASI.Preview2 `0.1.0` · WACS.WASI.Preview2.DependencyInjection `0.1.0` · WACS.ComponentModel.Bindgen.Lib `0.1.0` · WACS.WASI.Threads `0.1.0`
 
 > **Renaming notice (0.11.0):** the `WACS.WASIp1` package has been renamed to `WACS.WASI.Preview1` to make room for `WACS.WASI.Preview2` / `.Preview3` under one prefix. The old id still restores (it's now a metapackage) but emits a build-time warning. See [docs/MIGRATION_WASIp1_to_WASI.md](docs/MIGRATION_WASIp1_to_WASI.md) for the one-shot sed.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Harnessed results from [wasm-feature-detect](https://github.com/GoogleChromeLabs
 |Proposal |Features|    |
 |------|-------|----|
 |**Phase 5 – Standardized**|
-|[Branch Hinting](https://github.com/WebAssembly/branch-hinting)||<span title="Custom section ignored; no behavior impact">✅</span>|
+|[Branch Hinting](https://github.com/WebAssembly/branch-hinting)||<span title="metadata.code.branch_hint custom section parsed; transpiler reorders `if`/`else` arms based on hints">✅</span>|
 |[Bulk memory operations](https://github.com/webassembly/bulk-memory-operations)||✅|
 |[Custom Annotation Syntax in the Text Format](https://github.com/WebAssembly/annotations)||✅|
 |[Exception handling](https://github.com/WebAssembly/exception-handling)|exceptions|✅|

--- a/Wacs.Compilation.Test/BranchHintParsingTests.cs
+++ b/Wacs.Compilation.Test/BranchHintParsingTests.cs
@@ -1,0 +1,203 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using Wacs.Core;
+using Wacs.Core.Instructions;
+using Wacs.Core.OpCodes;
+using Xunit;
+
+namespace Wacs.Compilation.Test
+{
+    /// <summary>
+    /// Phase 1 of the Branch Hinting work: verify that the binary
+    /// parser captures the <c>metadata.code.branch_hint</c> custom
+    /// section verbatim into <see cref="Module.BranchHints"/>, and
+    /// that every parsed instruction in a function body carries the
+    /// byte offset that the hint section keys against.
+    /// </summary>
+    public class BranchHintParsingTests
+    {
+        // (module
+        //   (type (func (param i32 i32) (result i32)))
+        //   (func (export "f") (param i32 i32) (result i32)
+        //     local.get 0
+        //     (@metadata.code.branch_hint "\01") if (result i32)
+        //       local.get 1
+        //     else
+        //       i32.const 0
+        //     end))
+        //
+        // Function body bytes. The branch-hinting proposal indexes
+        // into the body AFTER the locals declaration, so offsets
+        // shown are relative to the byte immediately after the
+        // locals-count byte (which is 0x00 here for "no locals").
+        //   00: 0x20 0x00         local.get 0
+        //   02: 0x04 0x7F         if (result i32)
+        //   04: 0x20 0x01         local.get 1
+        //   06: 0x05              else
+        //   07: 0x41 0x00         i32.const 0
+        //   09: 0x0B              end
+        //   0A: 0x0B              expression-end
+        //
+        // The `if` lands at body-relative byte 0x02 — that is the
+        // hint's lookup key.
+        private static readonly byte[] HintedIfModule =
+        {
+            // Magic + version
+            0x00, 0x61, 0x73, 0x6D,  0x01, 0x00, 0x00, 0x00,
+            // Type: (i32 i32) -> i32
+            0x01, 0x07, 0x01,  0x60, 0x02, 0x7F, 0x7F, 0x01, 0x7F,
+            // Function: 1 func, type 0
+            0x03, 0x02, 0x01, 0x00,
+            // Export "f" -> func 0
+            0x07, 0x05, 0x01,  0x01, 0x66, 0x00, 0x00,
+            // Code section: 1 body, size 12 bytes
+            0x0A, 0x0E, 0x01,
+                0x0C,                            // body size
+                0x00,                            // 0 locals
+                0x20, 0x00,                      // local.get 0          (offset 0)
+                0x04, 0x7F,                      // if (result i32)      (offset 2)
+                0x20, 0x01,                      // local.get 1          (offset 4)
+                0x05,                            // else                 (offset 6)
+                0x41, 0x00,                      // i32.const 0          (offset 7)
+                0x0B,                            // end                  (offset 9)
+                0x0B,                            // expression end       (offset 10)
+            // Custom section: "metadata.code.branch_hint"
+            //   1 func entry: funcidx=0, 1 hint at offset=3, payload="\x01"
+            // Payload size: name-len(1) + name(25) + funcs-vec(6) = 32
+            0x00,                                // section id 0 (custom)
+            0x20,                                // section size = 32
+                // name length = 25, name = "metadata.code.branch_hint"
+                0x19,
+                0x6D, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x2E,
+                0x63, 0x6F, 0x64, 0x65, 0x2E, 0x62, 0x72, 0x61, 0x6E,
+                0x63, 0x68, 0x5F, 0x68, 0x69, 0x6E, 0x74,
+                // payload: 1 func entry
+                0x01,                            // 1 function entry
+                0x00,                            // funcidx 0
+                0x01,                            // 1 hint
+                0x02,                            // byte_offset = 2 (= `if`)
+                0x01,                            // hint payload length = 1
+                0x01,                            // hint byte = 0x01 (likely)
+        };
+
+        [Fact]
+        public void ParsesBranchHintCustomSection()
+        {
+            var module = ParseModule(HintedIfModule);
+
+            Assert.NotNull(module.BranchHints);
+            Assert.True(module.BranchHints!.ByFuncIndex.ContainsKey(0));
+
+            var fnMap = module.BranchHints.ByFuncIndex[0];
+            Assert.Single(fnMap);
+            Assert.True(fnMap.ContainsKey(2));
+
+            var hint = fnMap[2];
+            Assert.Equal(2u, hint.ByteOffset);
+            Assert.Equal(1, hint.RawData.Length);
+            Assert.Equal((byte)0x01, hint.HintByte);
+            Assert.True(hint.IsLikely);
+        }
+
+        [Fact]
+        public void TryGetReturnsHintForKnownInstruction()
+        {
+            var module = ParseModule(HintedIfModule);
+            var hit = module.BranchHints!.TryGet(0, 2);
+            Assert.NotNull(hit);
+            Assert.True(hit!.Value.IsLikely);
+
+            // Negative lookup paths
+            Assert.Null(module.BranchHints.TryGet(0, 99));
+            Assert.Null(module.BranchHints.TryGet(99, 2));
+        }
+
+        [Fact]
+        public void InstructionsCarryFuncRelativeByteOffset()
+        {
+            var module = ParseModule(HintedIfModule);
+
+            // Walk the top-level instructions of the only function.
+            // (Nested instructions inside the if-block also get
+            // body-relative offsets; we check the if itself.)
+            var body = module.Funcs[0].Body.Instructions.ToList();
+
+            // Per the byte map in the test fixture comment:
+            //   local.get 0  -> offset 0
+            //   if           -> offset 2
+            //   end          -> offset 10  (the trailing expression-end
+            //                                belongs to the function body
+            //                                itself, not the if-block)
+            Assert.Equal((uint)0, body[0].ByteOffsetInFunc);
+            Assert.Equal((uint)2, body[1].ByteOffsetInFunc);
+
+            // The hint's offset (2) matches the `if` instruction's offset.
+            var hintedInst = body[1];
+            var hint = module.BranchHints!.TryGet(0, hintedInst.ByteOffsetInFunc);
+            Assert.NotNull(hint);
+            Assert.True(hint!.Value.IsLikely);
+        }
+
+        // Module byte layout (cumulative offsets from start of blob):
+        //    0..7   magic + version             (8 bytes)
+        //    8..16  type section                (9 bytes: id+size+payload)
+        //   17..20  function section            (4 bytes)
+        //   21..27  export section              (7 bytes)
+        //   28..43  code section                (16 bytes: id+size+14 payload)
+        //   44      custom section id (0x00)
+        //   45      custom section size (0x20 = 32)
+        //   46      name-length byte (0x19 = 25)
+        //   47..71  name "metadata.code.branch_hint"
+        //   72      func count (0x01)
+        //   73      funcidx (0x00)              ← mutation target
+        //   74      hint count (0x01)
+        //   75      byte_offset (0x02)
+        //   76      hint data length (0x01)
+        //   77      hint data byte (0x01)
+        private const int CustomSectionStart = 44;
+        private const int FuncIdxByteIndex = 73;
+
+        [Fact]
+        public void NoBranchHintsWhenSectionAbsent()
+        {
+            // Truncate the blob right before the custom section.
+            var withoutHints = HintedIfModule.AsSpan(0, CustomSectionStart).ToArray();
+            var module = ParseModule(withoutHints);
+            Assert.Null(module.BranchHints);
+
+            // But instruction byte offsets still get populated — that's
+            // a parser-level thing independent of the hint section.
+            var body = module.Funcs[0].Body.Instructions.ToList();
+            Assert.Equal((uint)0, body[0].ByteOffsetInFunc);
+            Assert.Equal((uint)2, body[1].ByteOffsetInFunc);
+        }
+
+        [Fact]
+        public void RejectsBranchHintWithFuncIdxOutOfRange()
+        {
+            var bad = (byte[])HintedIfModule.Clone();
+            Assert.Equal((byte)0x00, bad[FuncIdxByteIndex]); // sanity
+            bad[FuncIdxByteIndex] = 0x07; // module only has 1 function
+            Assert.Throws<FormatException>(() => ParseModule(bad));
+        }
+
+        // -----------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------
+
+        private static Module ParseModule(byte[] bytes)
+        {
+            using var ms = new MemoryStream(bytes);
+            return BinaryModuleParser.ParseWasm(ms);
+        }
+    }
+}

--- a/Wacs.Compilation.Test/BranchHintParsingTests.cs
+++ b/Wacs.Compilation.Test/BranchHintParsingTests.cs
@@ -196,6 +196,10 @@ namespace Wacs.Compilation.Test
 
         private static Module ParseModule(byte[] bytes)
         {
+            // Branch-hint parsing is opt-in — interpreter consumers
+            // skip the section. Tests in this file always exercise
+            // the hint path, so flip the static flag once here.
+            BinaryModuleParser.ParseBranchHints = true;
             using var ms = new MemoryStream(bytes);
             return BinaryModuleParser.ParseWasm(ms);
         }

--- a/Wacs.Compilation.Test/BranchHintSpecWastTests.cs
+++ b/Wacs.Compilation.Test/BranchHintSpecWastTests.cs
@@ -1,0 +1,147 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Wacs.Core;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Compilation.Test
+{
+    /// <summary>
+    /// Runs the upstream Branch Hinting proposal's spec test
+    /// (<c>spec/test/custom/metadata.code.branch_hint/branch_hint.wast</c>)
+    /// directly through WACS's own WAT/WAST parser — no wabt or
+    /// wasm-tools dependency. The .wast uses
+    /// <c>assert_malformed_custom</c> and <c>assert_invalid_custom</c>
+    /// directives that neither external tool understands; lowering
+    /// those to the same code path as <c>assert_malformed</c> /
+    /// <c>assert_invalid</c> is part of this PR's WAST parser changes.
+    /// </summary>
+    public class BranchHintSpecWastTests
+    {
+        private static string LocateWastFile()
+        {
+            // Walk up from the test bin/ to the repo root, then resolve
+            // the spec submodule path.
+            var dir = AppContext.BaseDirectory;
+            while (dir != null && !File.Exists(Path.Combine(dir, "WACS.sln")))
+                dir = Path.GetDirectoryName(dir);
+            Assert.NotNull(dir);
+            var path = Path.Combine(dir!, "Spec.Test", "spec", "test", "custom",
+                "metadata.code.branch_hint", "branch_hint.wast");
+            Assert.True(File.Exists(path),
+                $"spec submodule fixture not found at {path} — run `git submodule update --init`");
+            return path;
+        }
+
+        [Fact]
+        public void RunBranchHintSpecWast()
+        {
+            // Branch-hint annotations are only honored when the parser
+            // flag is on (interpreter consumers skip them). The spec
+            // file's whole point is exercising that path.
+            BinaryModuleParser.ParseBranchHints = true;
+
+            var source = File.ReadAllText(LocateWastFile());
+            var commands = TextScriptParser.ParseWast(source);
+
+            int modulesParsed = 0;
+            int malformedAssertsChecked = 0;
+            int invalidAssertsChecked = 0;
+
+            foreach (var cmd in commands)
+            {
+                switch (cmd)
+                {
+                    case ScriptModule sm:
+                    {
+                        Assert.NotNull(sm.Module);
+                        // The valid module declares hinted `if` instructions.
+                        // Confirm the WAT parser captured at least one hint.
+                        Assert.NotNull(sm.Module!.BranchHints);
+                        Assert.NotEmpty(sm.Module.BranchHints!.ByInstruction);
+                        modulesParsed++;
+                        break;
+                    }
+                    case ScriptAssertMalformed am:
+                    {
+                        // The expected message is one of:
+                        //   "@metadata.code.branch_hint annotation: duplicate annotation"
+                        //   "@metadata.code.branch_hint annotation: not in a function"
+                        // Either way: parse must FAIL — i.e. eager
+                        // parse during command construction yielded
+                        // null Module, or a re-parse throws.
+                        AssertModuleRejected(am.Module, am.ExpectedMessage,
+                            "assert_malformed_custom");
+                        malformedAssertsChecked++;
+                        break;
+                    }
+                    case ScriptAssertInvalid ai:
+                    {
+                        // Expected: "@metadata.code.branch_hint annotation: invalid target"
+                        AssertModuleRejected(ai.Module, ai.ExpectedMessage,
+                            "assert_invalid_custom");
+                        invalidAssertsChecked++;
+                        break;
+                    }
+                    default:
+                        Assert.Fail($"unexpected command in branch_hint.wast: {cmd.GetType().Name}");
+                        break;
+                }
+            }
+
+            // Sanity-check the file shape — if the upstream test grows
+            // new commands we want to know.
+            Assert.Equal(1, modulesParsed);
+            Assert.Equal(2, malformedAssertsChecked);
+            Assert.Equal(1, invalidAssertsChecked);
+        }
+
+        private static void AssertModuleRejected(
+            ScriptModule sm, string expectedMessageHint, string assertion)
+        {
+            // Eager parse at script-parse time may have already
+            // captured the failure as Module == null. If so, we're done.
+            if (sm.Module == null)
+                return;
+
+            // Otherwise, force a re-parse and expect a FormatException.
+            // (Quote modules: re-parse the bytes; text modules: nothing
+            // to re-parse — Module being non-null already means the
+            // assertion's expectation was wrong.)
+            if (sm.Kind == ScriptModuleKind.Quote)
+            {
+                Assert.NotNull(sm.Bytes);
+                var text = System.Text.Encoding.UTF8.GetString(sm.Bytes!);
+                var ex = Assert.Throws<FormatException>(
+                    () => TextModuleParser.ParseWat(text));
+                Assert.Contains(KeyTermFromHint(expectedMessageHint), ex.Message);
+                return;
+            }
+            // Binary modules within these asserts aren't expected.
+            Assert.Fail(
+                $"{assertion} expected module to be rejected at parse time " +
+                $"(line {sm.Line}); got a non-null parsed Module of kind {sm.Kind}.");
+        }
+
+        private static string KeyTermFromHint(string spec)
+        {
+            // The spec's expected message is a free-form English
+            // string. Match on the salient keyword so we don't
+            // brittle-couple to the spec runner's exact phrasing.
+            if (spec.Contains("duplicate")) return "duplicate annotation";
+            if (spec.Contains("not in a function")) return "not in a function";
+            if (spec.Contains("invalid target")) return "invalid target";
+            return spec;
+        }
+    }
+}

--- a/Wacs.Compilation.Test/BranchHintWatAnnotationTests.cs
+++ b/Wacs.Compilation.Test/BranchHintWatAnnotationTests.cs
@@ -1,0 +1,155 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Linq;
+using Wacs.Core;
+using Wacs.Core.Instructions;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Compilation.Test
+{
+    /// <summary>
+    /// Phase-1 follow-up: the WAT parser also recognizes
+    /// <c>(@metadata.code.branch_hint "\xx")</c> annotations and
+    /// attaches the resulting <see cref="BranchHint"/> to the
+    /// next-emitted <c>if</c> / <c>br_if</c> instruction. The hint
+    /// surfaces via <see cref="Module.BranchHintMap.TryGet(InstructionBase)"/>,
+    /// the same lookup the transpiler uses for binary inputs.
+    /// </summary>
+    public class BranchHintWatAnnotationTests
+    {
+        private const string AnnotatedIfModule = @"
+(module
+  (func (export ""f"") (param i32) (result i32)
+    local.get 0
+    (@metadata.code.branch_hint ""\01"")
+    if (result i32)
+      i32.const 100
+    else
+      i32.const 200
+    end))";
+
+        [Fact]
+        public void WatParserCapturesBranchHintOnIf()
+        {
+            BinaryModuleParser.ParseBranchHints = true;
+            var module = TextModuleParser.ParseWat(AnnotatedIfModule);
+
+            Assert.NotNull(module.BranchHints);
+
+            // Walk the function body, find the `if`, look it up by ref.
+            var ifInst = FindFirst<InstIf>(module.Funcs[0].Body.Instructions);
+            Assert.NotNull(ifInst);
+
+            var hint = module.BranchHints!.TryGet(ifInst!);
+            Assert.NotNull(hint);
+            Assert.True(hint!.Value.IsLikely);
+            Assert.Equal((byte)0x01, hint.Value.HintByte);
+        }
+
+        [Fact]
+        public void GateRespectsParserFeatureFlag()
+        {
+            // Flag off → annotation skipped silently, no BranchHints map.
+            BinaryModuleParser.ParseBranchHints = false;
+            var module = TextModuleParser.ParseWat(AnnotatedIfModule);
+            Assert.Null(module.BranchHints);
+        }
+
+        [Fact]
+        public void RejectsDuplicateAnnotationOnSameInstruction()
+        {
+            const string wat = @"
+(module
+  (func (export ""f"") (param i32) (result i32)
+    local.get 0
+    (@metadata.code.branch_hint ""\01"")
+    (@metadata.code.branch_hint ""\01"")
+    if (result i32)
+      i32.const 1
+    else
+      i32.const 2
+    end))";
+            BinaryModuleParser.ParseBranchHints = true;
+            var ex = Assert.Throws<FormatException>(() => TextModuleParser.ParseWat(wat));
+            Assert.Contains("duplicate annotation", ex.Message);
+        }
+
+        [Fact]
+        public void RejectsAnnotationOnInvalidTarget()
+        {
+            // Hint precedes `i32.eq`, not an if/br_if. Spec: invalid target.
+            const string wat = @"
+(module
+  (func (export ""f"") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    (@metadata.code.branch_hint ""\01"")
+    i32.eq))";
+            BinaryModuleParser.ParseBranchHints = true;
+            var ex = Assert.Throws<FormatException>(() => TextModuleParser.ParseWat(wat));
+            Assert.Contains("invalid target", ex.Message);
+        }
+
+        [Fact]
+        public void RejectsModuleLevelBranchHintAnnotation()
+        {
+            const string wat = @"
+(module
+  (@metadata.code.branch_hint ""\01"")
+  (func (export ""f"") (result i32) i32.const 42))";
+            BinaryModuleParser.ParseBranchHints = true;
+            var ex = Assert.Throws<FormatException>(() => TextModuleParser.ParseWat(wat));
+            Assert.Contains("not in a function", ex.Message);
+        }
+
+        [Fact]
+        public void FoldedIfShapeAlsoCapturesHint()
+        {
+            const string wat = @"
+(module
+  (func (export ""f"") (param i32) (result i32)
+    (@metadata.code.branch_hint ""\00"")
+    (if (result i32) (local.get 0)
+      (then (i32.const 1))
+      (else (i32.const 2)))))";
+            BinaryModuleParser.ParseBranchHints = true;
+            var module = TextModuleParser.ParseWat(wat);
+
+            var ifInst = FindFirst<InstIf>(module.Funcs[0].Body.Instructions);
+            Assert.NotNull(ifInst);
+            var hint = module.BranchHints?.TryGet(ifInst!);
+            Assert.NotNull(hint);
+            Assert.False(hint!.Value.IsLikely);
+        }
+
+        // -----------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------
+
+        private static T? FindFirst<T>(System.Collections.Generic.IEnumerable<InstructionBase> body)
+            where T : InstructionBase
+        {
+            foreach (var inst in body)
+            {
+                if (inst is T t) return t;
+                if (inst is IBlockInstruction block)
+                {
+                    for (int i = 0; i < block.Count; i++)
+                    {
+                        var nested = FindFirst<T>(block.GetBlock(i).Instructions);
+                        if (nested != null) return nested;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Wacs.Console/Verbs/BuildHandler.cs
+++ b/Wacs.Console/Verbs/BuildHandler.cs
@@ -123,6 +123,10 @@ namespace Wacs.Console.Verbs
             Wacs.Core.Module module;
             try
             {
+                // Opt the parser into Branch Hinting metadata. The
+                // transpiler is the only consumer today; `wacs build`
+                // always transpiles, so always parse the hints.
+                Wacs.Core.BinaryModuleParser.ParseBranchHints = true;
                 using var fs = new FileStream(input, FileMode.Open, FileAccess.Read);
                 module = BinaryModuleParser.ParseWasm(fs);
 
@@ -192,6 +196,10 @@ namespace Wacs.Console.Verbs
 
             var runtime = new WasmRuntime();
             var disposables = new List<IDisposable>();
+
+            // Opt the parser into Branch Hinting metadata for the
+            // whole batch — every parsed input goes to the transpiler.
+            Wacs.Core.BinaryModuleParser.ParseBranchHints = true;
 
             // --wasi / --bind apply to the SHARED runtime.
             try

--- a/Wacs.Console/Verbs/RunHandler.cs
+++ b/Wacs.Console/Verbs/RunHandler.cs
@@ -134,6 +134,12 @@ namespace Wacs.Console.Verbs
             var parseTimer = new Stopwatch();
             if (opts.Verbose) parseTimer.Start();
 
+            // Branch-hint metadata only matters when we go through the
+            // transpiler. Interpreter / switch runtime ignore it, so
+            // skip the parse work for those engines.
+            Wacs.Core.BinaryModuleParser.ParseBranchHints = string.Equals(
+                opts.Engine, "transpiler", StringComparison.OrdinalIgnoreCase);
+
             Wacs.Core.Module module;
             using (var fileStream = new FileStream(wasmPath, FileMode.Open))
             {

--- a/Wacs.Core/Instructions/InstructionBase.cs
+++ b/Wacs.Core/Instructions/InstructionBase.cs
@@ -44,6 +44,18 @@ namespace Wacs.Core.Instructions
 
         public int Size = 1;
 
+        /// <summary>
+        /// Byte offset of this instruction within its enclosing
+        /// function body (i.e. relative to the byte after the locals
+        /// declaration). Populated by the binary parser for
+        /// instructions parsed from a function body; remains zero
+        /// for instructions parsed from constant expressions
+        /// (global initializers, element offsets, etc.) where
+        /// branch-hint metadata cannot apply. Used as the lookup key
+        /// against <see cref="Wacs.Core.Module.BranchHintMap"/>.
+        /// </summary>
+        public uint ByteOffsetInFunc;
+
         public InstructionBase(ByteCode op, int stack) =>
             (Op, StackDiff) = (op, stack);
 

--- a/Wacs.Core/Modules/Module.cs
+++ b/Wacs.Core/Modules/Module.cs
@@ -56,6 +56,20 @@ namespace Wacs.Core
         public static bool AnnotateWhileParsing = true;
         public static bool SkipFinalization = false;
         public static bool ParseCustomNames = false;
+
+        /// <summary>
+        /// Opt-in for the `metadata.code.branch_hint` custom section
+        /// (and WAT-level `(@metadata.code.branch_hint …)` annotations).
+        /// Off by default — interpreter / switch-runtime consumers
+        /// don't read the hints, so parsing them is dead work. The
+        /// transpiler is the only consumer today; CLI commands that
+        /// transpile (`wacs build`, `wacs aot`) set this true before
+        /// parsing. Programmatic embedders should do the same when
+        /// they intend to feed the parsed Module into
+        /// <c>ModuleTranspiler</c>.
+        /// </summary>
+        public static bool ParseBranchHints = false;
+
         public static uint MaximumFunctionLocals = 2048;
 
         public static int InstructionsParsed = 0;
@@ -279,12 +293,11 @@ namespace Wacs.Core
                             module.Names = ParseNameSection(subreader);
                         }
                         break;
-                    case "metadata.code.branch_hint":
-                        // Capture every hint in the section even if no
-                        // downstream consumer reads it today; the data
-                        // is cheap to retain and gives future passes
-                        // (e.g. block ordering, inlining) something to
-                        // key on. Validation against the actual
+                    case "metadata.code.branch_hint" when ParseBranchHints:
+                        // Capture every hint in the section. Gated
+                        // behind the opt-in flag because interpreter
+                        // consumers don't use it and parsing is dead
+                        // work for them. Validation against the actual
                         // instruction stream happens later, after the
                         // code section is fully resolved.
                         using (var subreader = reader.GetSubsectionTo((int)payloadEnd))
@@ -420,6 +433,13 @@ namespace Wacs.Core
                             $"branch_hint: funcidx {funcIdx} out of range " +
                             $"(module has {funcCount} functions)");
                 }
+                // Bridge the offset-keyed parse data to the
+                // ref-keyed transpile data. After this, both binary
+                // and WAT inputs have a uniform `TryGet(inst)` lookup.
+                module.BranchHints.JoinByInstruction(
+                    module.Funcs.Select(f =>
+                        (f.Index.Value, (System.Collections.Generic.IEnumerable<InstructionBase>)
+                            f.Body.Instructions)));
             }
         }
     }

--- a/Wacs.Core/Modules/Module.cs
+++ b/Wacs.Core/Modules/Module.cs
@@ -60,6 +60,21 @@ namespace Wacs.Core
 
         public static int InstructionsParsed = 0;
 
+        /// <summary>
+        /// Absolute byte position (within the binary stream) of the
+        /// start of the function body currently being parsed. Set by
+        /// <see cref="Module.FuncLocalsBody.Parse"/> before reading
+        /// instructions, restored on exit. Read by
+        /// <see cref="ParseInstruction"/> to compute each
+        /// instruction's body-relative offset (the lookup key for
+        /// branch-hint metadata). A negative sentinel means "not in
+        /// a function body" — instructions parsed in that state
+        /// (constant expressions, etc.) leave their
+        /// <see cref="InstructionBase.ByteOffsetInFunc"/> at zero.
+        /// Single-threaded parser; static field is safe.
+        /// </summary>
+        internal static long CurrentFunctionBodyStart = -1;
+
         public static readonly SectionId[] SectionOrder = new[]
         {
             SectionId.Type,
@@ -264,6 +279,19 @@ namespace Wacs.Core
                             module.Names = ParseNameSection(subreader);
                         }
                         break;
+                    case "metadata.code.branch_hint":
+                        // Capture every hint in the section even if no
+                        // downstream consumer reads it today; the data
+                        // is cheap to retain and gives future passes
+                        // (e.g. block ordering, inlining) something to
+                        // key on. Validation against the actual
+                        // instruction stream happens later, after the
+                        // code section is fully resolved.
+                        using (var subreader = reader.GetSubsectionTo((int)payloadEnd))
+                        {
+                            module.BranchHints = ParseBranchHintSection(subreader);
+                        }
+                        break;
                     default:
                         //Skip others
                         // Console.WriteLine($"   name: {customSectionName}");
@@ -298,10 +326,14 @@ namespace Wacs.Core
         /// </summary>
         public static InstructionBase? ParseInstruction(BinaryReader reader)
         {
-            
+            // Capture the absolute position before consuming the
+            // opcode so we can compute this instruction's
+            // body-relative byte offset (the branch-hint coordinate).
+            long instAbsPos = reader.BaseStream.Position;
+
             //Splice another byte if the first byte is a prefix
             var opcode = (OpCode)reader.ReadByte() switch {
-                OpCode.FB => new ByteCode((GcCode)reader.ReadLeb128_u32()), 
+                OpCode.FB => new ByteCode((GcCode)reader.ReadLeb128_u32()),
                 OpCode.FC => new ByteCode((ExtCode)reader.ReadLeb128_u32()),
                 OpCode.FD => new ByteCode((SimdCode)reader.ReadLeb128_u32()),
                 OpCode.FE => new ByteCode((AtomCode)reader.ReadLeb128_u32()),
@@ -310,7 +342,10 @@ namespace Wacs.Core
             int traceIdx = InstructionsParsed;
             try
             {
-                return InstructionFactory.CreateInstruction(opcode)?.Parse(reader);
+                var inst = InstructionFactory.CreateInstruction(opcode)?.Parse(reader);
+                if (inst != null && CurrentFunctionBodyStart >= 0)
+                    inst.ByteOffsetInFunc = (uint)(instAbsPos - CurrentFunctionBodyStart);
+                return inst;
             }
             catch (InvalidDataException exc)
             {
@@ -362,11 +397,30 @@ namespace Wacs.Core
             
             if (module.DataCount == uint.MaxValue)
                 module.DataCount = (uint)module.Datas.Length;
-            
+
             if (module.DataCount != module.Datas.Length)
                 throw new FormatException($"Data count and data section have inconsistent lengths.");
-            
+
             PatchNames(module);
+
+            // Branch-hint funcidx range check: a module-level
+            // assertion that's cheap and catches obvious corruption.
+            // Per-instruction target validation (hint must land on an
+            // `if`/`br_if`) is intentionally not enforced here — the
+            // proposal classifies bad targets as advisory and we
+            // prefer to surface the data verbatim. Consumers of
+            // BranchHints can re-check at use-site.
+            if (module.BranchHints != null)
+            {
+                int funcCount = module.Funcs.Count + module.ImportedFunctions.Count;
+                foreach (var funcIdx in module.BranchHints.ByFuncIndex.Keys)
+                {
+                    if (funcIdx >= funcCount)
+                        throw new FormatException(
+                            $"branch_hint: funcidx {funcIdx} out of range " +
+                            $"(module has {funcCount} functions)");
+                }
+            }
         }
     }
 }

--- a/Wacs.Core/Modules/Sections/BranchHintSection.cs
+++ b/Wacs.Core/Modules/Sections/BranchHintSection.cs
@@ -1,0 +1,150 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Wacs.Core.Utilities;
+
+namespace Wacs.Core
+{
+    /// <summary>
+    /// A single hint entry from the <c>metadata.code.branch_hint</c>
+    /// custom section. The proposal pins the hint payload at one byte
+    /// today (0x00 = unlikely-taken, 0x01 = likely-taken), but encodes
+    /// it as a length-prefixed byte vector so future revisions can
+    /// extend it. We keep the raw bytes alongside the decoded
+    /// <see cref="HintByte"/> so consumers always have the full data
+    /// even if a future hint shape isn't yet recognized.
+    /// </summary>
+    public readonly struct BranchHint
+    {
+        /// <summary>Function-body-relative byte offset of the hinted instruction.</summary>
+        public readonly uint ByteOffset;
+
+        /// <summary>Raw bytes from the hint payload — always at least one byte today.</summary>
+        public readonly byte[] RawData;
+
+        /// <summary>Convenience accessor for the first byte of the hint payload.</summary>
+        public byte HintByte => RawData[0];
+
+        /// <summary>
+        /// True when the hinted branch is predicted to be taken
+        /// (<c>0x01</c>); false for any other value, including the
+        /// explicit unlikely (<c>0x00</c>) and any unrecognized payload.
+        /// Callers that need to distinguish "hint absent" from
+        /// "hint present and unlikely" should check for the hint via
+        /// <see cref="Module.BranchHintSection"/> directly.
+        /// </summary>
+        public bool IsLikely => RawData.Length >= 1 && RawData[0] == 0x01;
+
+        public BranchHint(uint byteOffset, byte[] rawData)
+        {
+            ByteOffset = byteOffset;
+            RawData = rawData;
+        }
+    }
+
+    public partial class Module
+    {
+        /// <summary>
+        /// All hints captured from a <c>metadata.code.branch_hint</c>
+        /// custom section, keyed by function index, then by the
+        /// instruction's byte offset within its function body. Null
+        /// when no such custom section was present in the module.
+        /// </summary>
+        public BranchHintMap? BranchHints { get; internal set; }
+
+        /// <summary>
+        /// Per-module storage for parsed branch hints. Wraps the
+        /// keyed-by-funcidx dictionary so consumers can ask
+        /// "is there any hint table at all" without two-level
+        /// null-checks.
+        /// </summary>
+        public sealed class BranchHintMap
+        {
+            /// <summary>
+            /// Per-function map from instruction byte-offset to its
+            /// hint. The outer key is funcidx; the inner key is the
+            /// instruction's offset within its function body
+            /// (i.e. relative to the byte after the locals decl,
+            /// matching the spec's "code body" coordinate).
+            /// </summary>
+            public Dictionary<uint, Dictionary<uint, BranchHint>> ByFuncIndex { get; }
+                = new Dictionary<uint, Dictionary<uint, BranchHint>>();
+
+            /// <summary>Returns the hint for an instruction, or null.</summary>
+            public BranchHint? TryGet(uint funcIdx, uint instrByteOffset)
+            {
+                if (ByFuncIndex.TryGetValue(funcIdx, out var fnMap)
+                    && fnMap.TryGetValue(instrByteOffset, out var hint))
+                {
+                    return hint;
+                }
+                return null;
+            }
+        }
+    }
+
+    public static partial class BinaryModuleParser
+    {
+        /// <summary>
+        /// @Spec WebAssembly Branch Hinting proposal v1
+        /// https://github.com/WebAssembly/branch-hinting
+        ///
+        /// Custom section <c>"metadata.code.branch_hint"</c> payload:
+        /// <code>
+        ///   funcs : vec(func_hint)
+        ///   func_hint    ::= func_idx:u32  hints:vec(hint)
+        ///   hint         ::= byte_offset:u32  data:vec(byte)
+        /// </code>
+        ///
+        /// We accept any <c>data</c> length (the proposal pins it at 1
+        /// today but is structured for forward-compat) and capture
+        /// every byte. Validation against the actual instruction stream
+        /// (target must be <c>if</c>/<c>br_if</c>; no duplicate offsets
+        /// per func) happens after both sections are parsed; this
+        /// parser is permissive and round-trip-friendly.
+        /// </summary>
+        internal static Module.BranchHintMap ParseBranchHintSection(BinaryReader reader)
+        {
+            var map = new Module.BranchHintMap();
+            uint funcCount = reader.ReadLeb128_u32();
+            for (uint f = 0; f < funcCount; f++)
+            {
+                uint funcIdx = reader.ReadLeb128_u32();
+                uint hintCount = reader.ReadLeb128_u32();
+                var fnMap = new Dictionary<uint, BranchHint>((int)hintCount);
+                for (uint h = 0; h < hintCount; h++)
+                {
+                    uint byteOffset = reader.ReadLeb128_u32();
+                    uint dataLen = reader.ReadLeb128_u32();
+                    var data = reader.ReadBytes((int)dataLen);
+                    if (data.Length != (int)dataLen)
+                        throw new FormatException(
+                            $"branch_hint: short read on hint payload (expected {dataLen} bytes)");
+                    if (fnMap.ContainsKey(byteOffset))
+                        throw new FormatException(
+                            $"branch_hint: duplicate hint at funcidx={funcIdx} offset={byteOffset}");
+                    fnMap.Add(byteOffset, new BranchHint(byteOffset, data));
+                }
+                if (map.ByFuncIndex.ContainsKey(funcIdx))
+                    throw new FormatException(
+                        $"branch_hint: duplicate function entry funcidx={funcIdx}");
+                map.ByFuncIndex.Add(funcIdx, fnMap);
+            }
+            return map;
+        }
+    }
+}

--- a/Wacs.Core/Modules/Sections/BranchHintSection.cs
+++ b/Wacs.Core/Modules/Sections/BranchHintSection.cs
@@ -15,6 +15,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Wacs.Core.Instructions;
+using Wacs.Core.Types;
 using Wacs.Core.Utilities;
 
 namespace Wacs.Core
@@ -79,10 +81,37 @@ namespace Wacs.Core
             /// hint. The outer key is funcidx; the inner key is the
             /// instruction's offset within its function body
             /// (i.e. relative to the byte after the locals decl,
-            /// matching the spec's "code body" coordinate).
+            /// matching the spec's "code body" coordinate). Populated
+            /// by the binary parser. The WAT parser populates
+            /// <see cref="ByInstruction"/> directly since WAT
+            /// instructions don't have meaningful byte offsets.
             /// </summary>
             public Dictionary<uint, Dictionary<uint, BranchHint>> ByFuncIndex { get; }
                 = new Dictionary<uint, Dictionary<uint, BranchHint>>();
+
+            /// <summary>
+            /// Direct hint-by-instruction-reference map. The
+            /// authoritative lookup at use site (transpiler /
+            /// interpreter), since it's populated for both binary
+            /// (post-parse join via <see cref="JoinByInstruction"/>)
+            /// and WAT (during parse) inputs. Reference equality on
+            /// <see cref="InstructionBase"/> — safe because
+            /// instructions are never duplicated within a module.
+            /// </summary>
+            public Dictionary<InstructionBase, BranchHint> ByInstruction { get; }
+                = new Dictionary<InstructionBase, BranchHint>(InstRefEquality.Instance);
+
+            // .NET 5+ ships System.Collections.Generic.ReferenceEqualityComparer,
+            // but netstandard2.1 (one of our build targets) doesn't.
+            // Hand-roll the trivial comparer; safe to share across maps.
+            private sealed class InstRefEquality : IEqualityComparer<InstructionBase>
+            {
+                public static readonly InstRefEquality Instance = new InstRefEquality();
+                public bool Equals(InstructionBase? x, InstructionBase? y) =>
+                    ReferenceEquals(x, y);
+                public int GetHashCode(InstructionBase obj) =>
+                    System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+            }
 
             /// <summary>Returns the hint for an instruction, or null.</summary>
             public BranchHint? TryGet(uint funcIdx, uint instrByteOffset)
@@ -93,6 +122,51 @@ namespace Wacs.Core
                     return hint;
                 }
                 return null;
+            }
+
+            /// <summary>
+            /// Returns the hint attached to a given instruction, or
+            /// null. The transpiler's preferred lookup — uniform for
+            /// binary and WAT inputs.
+            /// </summary>
+            public BranchHint? TryGet(InstructionBase inst) =>
+                ByInstruction.TryGetValue(inst, out var h) ? h : (BranchHint?)null;
+
+            /// <summary>
+            /// Walk every instruction body in <paramref name="funcs"/>
+            /// and, for each instruction whose
+            /// <see cref="InstructionBase.ByteOffsetInFunc"/> matches a
+            /// hint in <see cref="ByFuncIndex"/>, populate the
+            /// instruction-keyed lookup. Idempotent — safe to call
+            /// twice. Used by the binary parser's finalize step to
+            /// bridge offset-keyed parse data to ref-keyed transpile
+            /// data.
+            /// </summary>
+            public void JoinByInstruction(
+                IEnumerable<(uint funcIdx, IEnumerable<InstructionBase> body)> funcs)
+            {
+                foreach (var (funcIdx, body) in funcs)
+                {
+                    if (!ByFuncIndex.TryGetValue(funcIdx, out var fnMap))
+                        continue;
+                    JoinFunctionInstructions(fnMap, body);
+                }
+            }
+
+            private void JoinFunctionInstructions(
+                Dictionary<uint, BranchHint> fnMap,
+                IEnumerable<InstructionBase> body)
+            {
+                foreach (var inst in body)
+                {
+                    if (fnMap.TryGetValue(inst.ByteOffsetInFunc, out var h))
+                        ByInstruction[inst] = h;
+                    if (inst is IBlockInstruction block)
+                    {
+                        for (int i = 0; i < block.Count; i++)
+                            JoinFunctionInstructions(fnMap, block.GetBlock(i).Instructions);
+                    }
+                }
             }
         }
     }

--- a/Wacs.Core/Modules/Sections/CodeSection.cs
+++ b/Wacs.Core/Modules/Sections/CodeSection.cs
@@ -50,8 +50,24 @@ namespace Wacs.Core
                 return (count, expr);
             }
 
-            public static FuncLocalsBody Parse(BinaryReader reader) =>
-                new(reader.ParseVector(ParseCompressedLocal), Expression.ParseFunc(reader));
+            public static FuncLocalsBody Parse(BinaryReader reader)
+            {
+                var locals = reader.ParseVector(ParseCompressedLocal);
+                // The branch-hinting proposal indexes into the
+                // function code body (after locals decl). Stash the
+                // body start here so ParseInstruction can record
+                // body-relative offsets onto each instruction.
+                long prevBodyStart = BinaryModuleParser.CurrentFunctionBodyStart;
+                BinaryModuleParser.CurrentFunctionBodyStart = reader.BaseStream.Position;
+                try
+                {
+                    return new FuncLocalsBody(locals, Expression.ParseFunc(reader));
+                }
+                finally
+                {
+                    BinaryModuleParser.CurrentFunctionBodyStart = prevBodyStart;
+                }
+            }
         }
 
         public class CodeDesc

--- a/Wacs.Core/Text/TextModuleParser.Instructions.cs
+++ b/Wacs.Core/Text/TextModuleParser.Instructions.cs
@@ -53,9 +53,35 @@ namespace Wacs.Core.Text
         {
             stopKeyword = null;
             var result = new List<InstructionBase>();
+
+            // Pending hint from a `(@metadata.code.branch_hint "\xx")`
+            // annotation on the previous sibling. Attached to the
+            // next-emitted `if` / `br_if` instruction. Per the
+            // proposal, "duplicate annotation" (two in a row) and
+            // "invalid target" (next instruction isn't if/br_if) are
+            // both errors. Only collected when Module.ParseBranchHints
+            // is on; otherwise annotations are silently skipped to
+            // save parse work for interpreter consumers.
+            BranchHint? pendingHint = null;
+            int pendingHintLine = 0;
+
             while (i < parent.Children.Count)
             {
                 var node = parent.Children[i];
+
+                // Annotation: `(@name args…)` — folded form whose head
+                // is a Reserved token starting with '@'. Recognized
+                // shapes are intercepted here; unrecognized shapes
+                // silently skipped (forward-compat with future
+                // annotations the parser doesn't yet know about).
+                if (node.Kind == SExprKind.List && IsAnnotationNode(node))
+                {
+                    HandleAnnotation(node, ref pendingHint, ref pendingHintLine);
+                    i++;
+                    continue;
+                }
+
+                int beforeCount = result.Count;
                 if (node.Kind == SExprKind.Atom)
                 {
                     if (node.Token.Kind == TokenKind.Keyword)
@@ -65,6 +91,9 @@ namespace Wacs.Core.Text
                         {
                             if (kw == "end" && (stop & InstrStop.End) != 0)
                             {
+                                if (pendingHint.HasValue)
+                                    throw new FormatException(
+                                        $"line {pendingHintLine}: @metadata.code.branch_hint annotation: invalid target (no following if/br_if before 'end')");
                                 stopKeyword = "end";
                                 i++;
                                 // Optional trailing label id — ignored (but consumed).
@@ -76,21 +105,118 @@ namespace Wacs.Core.Text
                             }
                             if (kw == "else" && (stop & InstrStop.Else) != 0)
                             {
+                                if (pendingHint.HasValue)
+                                    throw new FormatException(
+                                        $"line {pendingHintLine}: @metadata.code.branch_hint annotation: invalid target (no following if/br_if before 'else')");
                                 stopKeyword = "else";
                                 return result;   // leave 'else' for caller
                             }
                         }
                         ParsePlainInstruction(fctx, parent, ref i, kw, result);
-                        continue;
                     }
-                    throw new FormatException(
-                        $"line {node.Token.Line}: unexpected {node.Token.Kind} '{node.AtomText()}' in instruction list");
+                    else
+                    {
+                        throw new FormatException(
+                            $"line {node.Token.Line}: unexpected {node.Token.Kind} '{node.AtomText()}' in instruction list");
+                    }
                 }
-                // Folded form
-                ParseFoldedInstruction(fctx, node, result);
-                i++;
+                else
+                {
+                    // Folded form
+                    ParseFoldedInstruction(fctx, node, result);
+                    i++;
+                }
+
+                // If a hint is pending, attach it to the if/br_if among
+                // the newly-added instructions. Folded forms (e.g.
+                // (if (cond) (then ...) (else ...))) emit the operand
+                // sub-instructions first, then the if itself; we walk
+                // forward and attach to the first hint-eligible match.
+                if (pendingHint.HasValue)
+                {
+                    InstructionBase? target = null;
+                    for (int k = beforeCount; k < result.Count; k++)
+                    {
+                        if (result[k] is InstIf || result[k] is InstBranchIf)
+                        {
+                            target = result[k];
+                            break;
+                        }
+                    }
+                    if (target == null)
+                        throw new FormatException(
+                            $"line {pendingHintLine}: @metadata.code.branch_hint annotation: invalid target (preceding instruction not if/br_if)");
+
+                    var hints = EnsureBranchHints(fctx);
+                    hints.ByInstruction[target] = pendingHint.Value;
+                    pendingHint = null;
+                }
             }
+
+            if (pendingHint.HasValue)
+                throw new FormatException(
+                    $"line {pendingHintLine}: @metadata.code.branch_hint annotation: invalid target (end of instruction list)");
+
             return result;
+        }
+
+        // ---- Annotation helpers --------------------------------------------
+
+        private static bool IsAnnotationNode(SExpr node)
+        {
+            if (node.Kind != SExprKind.List) return false;
+            var head = node.Head;
+            return head != null
+                && head.Kind == SExprKind.Atom
+                && head.Token.Kind == TokenKind.Reserved
+                && head.AtomText().StartsWith("@");
+        }
+
+        private static void HandleAnnotation(
+            SExpr node, ref BranchHint? pendingHint, ref int pendingHintLine)
+        {
+            var head = node.Head!;
+            var name = head.AtomText();
+
+            // Other annotation shapes (round-trip metadata, custom
+            // tooling) are silently passed through — they don't
+            // affect IL emission.
+            if (name != "@metadata.code.branch_hint") return;
+
+            // Gate on the parser feature flag. When off, drop the
+            // annotation on the floor — interpreter consumers don't
+            // need branch hints, no point spending parse work.
+            if (!BinaryModuleParser.ParseBranchHints) return;
+
+            if (pendingHint.HasValue)
+                throw new FormatException(
+                    $"line {node.Token.Line}: @metadata.code.branch_hint annotation: duplicate annotation");
+
+            // Payload: a single string atom whose decoded bytes are
+            // the hint data. Spec pins length = 1 today, but the
+            // proposal encodes it as vec(byte) so future revisions
+            // can extend.
+            if (node.Children.Count != 2)
+                throw new FormatException(
+                    $"line {node.Token.Line}: @metadata.code.branch_hint annotation: expected exactly one string payload");
+            var payloadNode = node.Children[1];
+            if (payloadNode.Kind != SExprKind.Atom || payloadNode.Token.Kind != TokenKind.String)
+                throw new FormatException(
+                    $"line {payloadNode.Token.Line}: @metadata.code.branch_hint annotation: payload must be a string literal");
+
+            var data = node.Lexer.DecodeString(payloadNode.Token);
+            // Synthetic ByteOffset = 0; the WAT path uses ByInstruction
+            // for lookup, the offset is unused.
+            pendingHint = new BranchHint(0, data);
+            pendingHintLine = node.Token.Line;
+        }
+
+        private static Module.BranchHintMap EnsureBranchHints(TextFunctionContext fctx)
+        {
+            var module = fctx.Module.Module;
+            if (module.BranchHints == null)
+                module.BranchHints = new Module.BranchHintMap();
+            return module.BranchHints;
         }
 
         // ---- Folded forms -------------------------------------------------

--- a/Wacs.Core/Text/TextModuleParser.cs
+++ b/Wacs.Core/Text/TextModuleParser.cs
@@ -112,9 +112,20 @@ namespace Wacs.Core.Text
 
                 // Module-level WAT annotations `(@name …)` — round-trip
                 // metadata is deferred; for now we just skip them so the
-                // module still parses.
+                // module still parses. Branch_hint specifically: per
+                // spec the annotation must appear inside a function
+                // body; module-level use is malformed. Reject when
+                // branch-hint parsing is on so embedders see the
+                // diagnostic instead of silently mis-emitting; tolerate
+                // when off so existing inputs don't regress.
                 if (head.Token.Kind == TokenKind.Reserved && head.AtomText().StartsWith("@"))
+                {
+                    if (BinaryModuleParser.ParseBranchHints
+                        && head.AtomText() == "@metadata.code.branch_hint")
+                        throw new FormatException(
+                            $"line {head.Token.Line}: @metadata.code.branch_hint annotation: not in a function");
                     continue;
+                }
                 if (head.Token.Kind != TokenKind.Keyword)
                     throw new FormatException($"line {form.Token.Line}: section form must start with a keyword");
 

--- a/Wacs.Core/Text/TextScriptParser.cs
+++ b/Wacs.Core/Text/TextScriptParser.cs
@@ -90,10 +90,24 @@ namespace Wacs.Core.Text
                         result.Add(ParseAssertExhaustion(node));
                         break;
                     case "assert_invalid":
-                        result.Add(ParseAssertModuleFailure<ScriptAssertInvalid>(node, "assert_invalid"));
+                    // The Branch Hinting proposal introduces
+                    // `assert_invalid_custom` to call out failures that
+                    // originate in custom-section validation (where
+                    // standard spec runners would normally accept the
+                    // module). Lower it to the same script command —
+                    // the WACS parser validates `metadata.code.branch_hint`
+                    // when its feature flag is on and reports failures
+                    // through the same path.
+                    case "assert_invalid_custom":
+                        result.Add(ParseAssertModuleFailure<ScriptAssertInvalid>(node, kw));
                         break;
                     case "assert_malformed":
-                        result.Add(ParseAssertModuleFailure<ScriptAssertMalformed>(node, "assert_malformed"));
+                    // Same reasoning for `assert_malformed_custom` —
+                    // a malformed custom-section payload triggers the
+                    // same FormatException path as a malformed core
+                    // section.
+                    case "assert_malformed_custom":
+                        result.Add(ParseAssertModuleFailure<ScriptAssertMalformed>(node, kw));
                         break;
                     case "assert_unlinkable":
                         result.Add(ParseAssertModuleFailure<ScriptAssertUnlinkable>(node, "assert_unlinkable"));
@@ -381,7 +395,26 @@ namespace Wacs.Core.Text
                 throw new FormatException(
                     $"line {node.Token.Line}: ({name}) expects (module …) and message");
             var cmd = new T { Line = node.Token.Line, Column = node.Token.Column };
-            var module = ParseModuleCommand(node.Children[1]);
+            // The inner (module …) is EXPECTED to fail (that's the whole
+            // point of the enclosing assertion). Quote modules already
+            // swallow parse errors at ParseModuleCommand; do the same
+            // for text modules so the runner reaches the assertion
+            // verdict rather than aborting the whole script.
+            ScriptModule module;
+            try
+            {
+                module = ParseModuleCommand(node.Children[1]);
+            }
+            catch (System.FormatException)
+            {
+                module = new ScriptModule
+                {
+                    Line = node.Children[1].Token.Line,
+                    Column = node.Children[1].Token.Column,
+                    Kind = ScriptModuleKind.Text,
+                    Module = null,
+                };
+            }
             var msg = DecodeString(node, node.Children[2].Token);
             // Set via reflection-lite: each concrete type has Module and
             // ExpectedMessage fields. Rather than branching on T, use a

--- a/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.10.0</AssemblyVersion>
-    <Version>0.10.0</Version>
+    <AssemblyVersion>0.11.0</AssemblyVersion>
+    <Version>0.11.0</Version>
     <Authors>Kelvin Nishikawa</Authors>
-    <Description>A Pure C# WebAssembly Interpreter</Description>
+    <Description>A Pure C# WebAssembly Interpreter. v0.11 captures the WebAssembly Branch Hinting proposal's `metadata.code.branch_hint` custom section into Module.BranchHints and stamps every parsed instruction with its function-body-relative byte offset.</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Wacs.Transpiler.Lib/AOT/Emitters/ControlEmitter.cs
+++ b/Wacs.Transpiler.Lib/AOT/Emitters/ControlEmitter.cs
@@ -360,7 +360,8 @@ namespace Wacs.Transpiler.AOT.Emitters
             ModuleInstance? moduleInst = null,
             int tryDepth = 0,
             bool forceShuttle = false,
-            BranchHint? branchHint = null)
+            BranchHint? branchHint = null,
+            Action<Action>? registerColdEmission = null)
         {
             var (paramArity, resultArity, _, resultClrTypes) =
                 moduleInst != null
@@ -480,21 +481,67 @@ namespace Wacs.Transpiler.AOT.Emitters
             }
             else
             {
-                // condition is on stack — no results possible on false path (void if)
-                il.Emit(OpCodes.Brfalse, endLabel);
+                // if-without-else. The proposal allows hint=unlikely
+                // here too. The "ideal" emission for unlikely is to
+                // lift the cold then-body OUT of the linear flow so
+                // the hot path (cond=false → skip body) doesn't pay
+                // any I-cache for the dead body. We use the cold-tail
+                // mechanism on FunctionCodegen for exactly this.
+                bool moveToColdTail = branchHint.HasValue
+                                      && !branchHint.Value.IsLikely
+                                      && registerColdEmission != null;
 
-                // if-true body only
-                var ifBlock = inst.GetBlock(0);
-                foreach (var child in ifBlock.Instructions)
-                    emitInstruction(il, child);
-                bool ifEndReachable = BodyEndIsReachable(ifBlock.Instructions);
-
-                // End of if-true body: shuttle to locals if reachable
-                if (resultLocals != null && ifEndReachable)
+                if (moveToColdTail)
                 {
-                    for (int i = resultArity - 1; i >= 0; i--)
-                        il.Emit(OpCodes.Stloc, resultLocals[i]);
-                    il.Emit(OpCodes.Br, endLabel);
+                    // Define the cold entry; brtrue jumps there on the
+                    // cold (cond=true) path, otherwise hot fall-through
+                    // reaches endLabel directly.
+                    var coldThenLabel = il.DefineLabel();
+                    il.Emit(OpCodes.Brtrue, coldThenLabel);
+
+                    var ifBlock = inst.GetBlock(0);
+                    var capturedResultLocals = resultLocals;
+                    int capturedResultArity = resultArity;
+                    var capturedEndLabel = endLabel;
+                    registerColdEmission!(() =>
+                    {
+                        il.MarkLabel(coldThenLabel);
+                        foreach (var child in ifBlock.Instructions)
+                            emitInstruction(il, child);
+                        bool coldEndReachable = BodyEndIsReachable(ifBlock.Instructions);
+                        if (coldEndReachable)
+                        {
+                            if (capturedResultLocals != null)
+                            {
+                                for (int i = capturedResultArity - 1; i >= 0; i--)
+                                    il.Emit(OpCodes.Stloc, capturedResultLocals[i]);
+                            }
+                            // Back-jump into the main body at endLabel.
+                            // Non-reducible CFG, but RyuJIT and ILC
+                            // handle it; the win is that hot fall-through
+                            // never touches the cold body bytes.
+                            il.Emit(OpCodes.Br, capturedEndLabel);
+                        }
+                    });
+                }
+                else
+                {
+                    // condition is on stack — no results possible on false path (void if)
+                    il.Emit(OpCodes.Brfalse, endLabel);
+
+                    // if-true body only
+                    var ifBlock = inst.GetBlock(0);
+                    foreach (var child in ifBlock.Instructions)
+                        emitInstruction(il, child);
+                    bool ifEndReachable = BodyEndIsReachable(ifBlock.Instructions);
+
+                    // End of if-true body: shuttle to locals if reachable
+                    if (resultLocals != null && ifEndReachable)
+                    {
+                        for (int i = resultArity - 1; i >= 0; i--)
+                            il.Emit(OpCodes.Stloc, resultLocals[i]);
+                        il.Emit(OpCodes.Br, endLabel);
+                    }
                 }
             }
 

--- a/Wacs.Transpiler.Lib/AOT/Emitters/ControlEmitter.cs
+++ b/Wacs.Transpiler.Lib/AOT/Emitters/ControlEmitter.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
+using Wacs.Core;
 using Wacs.Core.Instructions;
 using Wacs.Core.Runtime.Types;
 using Wacs.Core.Types;
@@ -325,6 +326,30 @@ namespace Wacs.Transpiler.AOT.Emitters
 
         /// <summary>
         /// Emit an if instruction. Pops condition from stack, branches.
+        ///
+        /// <paramref name="branchHint"/> carries the
+        /// <c>metadata.code.branch_hint</c> annotation for this
+        /// instruction when present:
+        /// <list type="bullet">
+        ///   <item><c>null</c> or <c>IsLikely==true</c>: the existing
+        ///     emission is already ideal for "then is hot" — we emit
+        ///     <c>brfalse else_label</c> and let the then-body fall
+        ///     through (no jump on the predicted path).</item>
+        ///   <item><c>IsLikely==false</c> on an <c>if</c>-with-<c>else</c>:
+        ///     swap the test (<c>brtrue then_label</c>) and emit the
+        ///     else-body inline so the hot path falls through. Then-body
+        ///     becomes the side-jump. Pure local CIL transformation —
+        ///     same labels, same blockStack semantics, identical
+        ///     observable behavior.</item>
+        ///   <item><c>IsLikely==false</c> on an <c>if</c>-without-<c>else</c>:
+        ///     no inversion. The optimal layout (skip the then-body
+        ///     on the fall-through) requires moving the then-body
+        ///     out-of-line, which is Phase 3's cold-block ordering
+        ///     work. We emit the default for now so behavior is
+        ///     identical; Phase 3 will pick up these cases.</item>
+        /// </list>
+        /// "Optimistic" per the scoping pact: we don't claim the JIT
+        /// will respect our intent. We promise our IL expresses it.
         /// </summary>
         public static void EmitIf(
             ILGenerator il,
@@ -334,7 +359,8 @@ namespace Wacs.Transpiler.AOT.Emitters
             int stackHeight = 0,
             ModuleInstance? moduleInst = null,
             int tryDepth = 0,
-            bool forceShuttle = false)
+            bool forceShuttle = false,
+            BranchHint? branchHint = null)
         {
             var (paramArity, resultArity, _, resultClrTypes) =
                 moduleInst != null
@@ -367,8 +393,53 @@ namespace Wacs.Transpiler.AOT.Emitters
             });
 
             bool hasElse = inst.Count == 2;
+            // Hint=unlikely on an if-with-else: swap the test sense so
+            // the else-body is the fall-through (hot) and the then-body
+            // is the side-jump (cold). No-op when no hint or hint=likely.
+            bool invertForUnlikelyElse = hasElse
+                && branchHint.HasValue
+                && !branchHint.Value.IsLikely;
 
-            if (hasElse)
+            if (hasElse && invertForUnlikelyElse)
+            {
+                // SWAPPED layout: else-body is the hot fall-through,
+                // then-body is the side-jump.
+                var thenLabel = il.DefineLabel();
+
+                // condition is on stack — jump TO the then-body when true
+                il.Emit(OpCodes.Brtrue, thenLabel);
+
+                // else-body inline (hot path)
+                var elseBlockSwap = inst.GetBlock(1);
+                foreach (var child in elseBlockSwap.Instructions)
+                    emitInstruction(il, child);
+                bool elseEndReachableSwap = BodyEndIsReachable(elseBlockSwap.Instructions);
+
+                if (elseEndReachableSwap)
+                {
+                    if (resultLocals != null)
+                    {
+                        for (int i = resultArity - 1; i >= 0; i--)
+                            il.Emit(OpCodes.Stloc, resultLocals[i]);
+                    }
+                    il.Emit(OpCodes.Br, endLabel);
+                }
+
+                // then-body out-of-line (cold path)
+                il.MarkLabel(thenLabel);
+                var thenBlockSwap = inst.GetBlock(0);
+                foreach (var child in thenBlockSwap.Instructions)
+                    emitInstruction(il, child);
+                bool thenEndReachableSwap = BodyEndIsReachable(thenBlockSwap.Instructions);
+
+                if (resultLocals != null && thenEndReachableSwap)
+                {
+                    for (int i = resultArity - 1; i >= 0; i--)
+                        il.Emit(OpCodes.Stloc, resultLocals[i]);
+                    il.Emit(OpCodes.Br, endLabel);
+                }
+            }
+            else if (hasElse)
             {
                 var elseLabel = il.DefineLabel();
 

--- a/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
+++ b/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
@@ -680,8 +680,9 @@ namespace Wacs.Transpiler.AOT
                 case WasmOpCode.If:
                 {
                     int sh = (_currentInfo?.StackHeightBefore ?? 1) - 1;
-                    var hint = _moduleInst.Repr.BranchHints?.TryGet(
-                        _funcInst.Index.Value, inst.ByteOffsetInFunc);
+                    // Reference-keyed lookup works for both binary
+                    // (joined by FinalizeModule) and WAT-parsed inputs.
+                    var hint = _moduleInst.Repr.BranchHints?.TryGet(inst);
                     ControlEmitter.EmitIf(il, (InstIf)inst, _blockStack, EmitInstruction,
                         sh, _moduleInst, _tryDepth, _functionHasTryTable, hint,
                         _coldTailEmissions.Add);

--- a/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
+++ b/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
@@ -648,8 +648,10 @@ namespace Wacs.Transpiler.AOT
                 case WasmOpCode.If:
                 {
                     int sh = (_currentInfo?.StackHeightBefore ?? 1) - 1;
+                    var hint = _moduleInst.Repr.BranchHints?.TryGet(
+                        _funcInst.Index.Value, inst.ByteOffsetInFunc);
                     ControlEmitter.EmitIf(il, (InstIf)inst, _blockStack, EmitInstruction,
-                        sh, _moduleInst, _tryDepth, _functionHasTryTable);
+                        sh, _moduleInst, _tryDepth, _functionHasTryTable, hint);
                     break;
                 }
 

--- a/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
+++ b/Wacs.Transpiler.Lib/AOT/FunctionCodegen.cs
@@ -82,6 +82,26 @@ namespace Wacs.Transpiler.AOT
         // prove per-label reachability from inside a try region.
         private bool _functionHasTryTable;
 
+        /// <summary>
+        /// Cold-block emission queue. Branch-hinted cold arms can be
+        /// deferred onto this list so they emit AFTER the function body
+        /// proper (between the body's terminating jump and
+        /// <see cref="funcEndLabel"/>'s mark) instead of inline. Each
+        /// action receives nothing — closures capture the ILGenerator
+        /// + the cold body's CIL label + the rejoin target.
+        ///
+        /// Reachable only via explicit jump (e.g. <c>brtrue</c> from
+        /// within the body). The body's End handling always emits a
+        /// terminating <c>Br</c>/<c>Leave</c>/<c>Ret</c>, so linear
+        /// flow can't fall into the cold tail.
+        ///
+        /// Used by Phase 3 of the Branch Hinting work for
+        /// <c>if</c>-without-<c>else</c> with an unlikely hint, where
+        /// the only meaningful improvement is to lift the cold then-body
+        /// out of the linear flow entirely.
+        /// </summary>
+        private readonly List<Action> _coldTailEmissions = new List<Action>();
+
         // Module-bound wrappers that disambiguate concrete type indices.
         // Without the module, concrete func types would be misclassified as
         // GC refs (doc 2 §1 invariant 3).
@@ -219,6 +239,18 @@ namespace Wacs.Transpiler.AOT
             }
 
             _blockStack.Pop();
+
+            // Phase 3 (Branch Hinting): emit any cold-tail actions
+            // registered during body emission. Each action marks its
+            // label, emits a cold body, and back-jumps to the
+            // continuation point inside the main body. The body's
+            // own End handling already emits a Br/Leave/Ret terminator,
+            // so this position is unreachable from sequential flow —
+            // safe to insert blocks here without an extra skip jump.
+            foreach (var emit in _coldTailEmissions)
+                emit();
+            _coldTailEmissions.Clear();
+
             _il.MarkLabel(funcEndLabel);
 
             // If shuttle locals were allocated for the function-level block
@@ -651,7 +683,8 @@ namespace Wacs.Transpiler.AOT
                     var hint = _moduleInst.Repr.BranchHints?.TryGet(
                         _funcInst.Index.Value, inst.ByteOffsetInFunc);
                     ControlEmitter.EmitIf(il, (InstIf)inst, _blockStack, EmitInstruction,
-                        sh, _moduleInst, _tryDepth, _functionHasTryTable, hint);
+                        sh, _moduleInst, _tryDepth, _functionHasTryTable, hint,
+                        _coldTailEmissions.Add);
                     break;
                 }
 

--- a/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -11,11 +11,11 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.5.0</Version>
-        <AssemblyVersion>0.5.0</AssemblyVersion>
+        <Version>0.6.0</Version>
+        <AssemblyVersion>0.6.0</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
-        <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.5 adds the AotLinked emission target (skips the codec wrapper for ~22% binary-size reduction; covers memory / data / globals / tables / element segments) and a stable AssemblyName option for static-reference / NativeAOT-linked workflows. The transpiler now emits `[assembly: WacsTranspiledImports]` + `[assembly: WacsImportNames]` so the new WACS.HostBindings.SourceGen Roslyn generator can wire imports straight to `[WacsImport]`-annotated host statics — no reflection, no DispatchProxy. Together these enable the one-shot `wacs aot` CLI.</Description>
+        <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.6 consumes the WebAssembly Branch Hinting proposal's `metadata.code.branch_hint` custom section: `if`-with-`else` arms swap to put the likely arm on the hot fall-through, and `if`-without-`else` with an unlikely hint lifts its body to a function-tail cold block via the new `_coldTailEmissions` mechanism. Optimistic — the IL expresses the hint, downstream JIT/AOT layout passes are welcome to refine. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>
         <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/Wacs.Transpiler.Test/BranchHintEmissionTests.cs
+++ b/Wacs.Transpiler.Test/BranchHintEmissionTests.cs
@@ -102,6 +102,9 @@ namespace Wacs.Transpiler.Test
 
         private static (TranspilationResult Result, ModuleInstance ModInst) Transpile(byte[] wasm, string asmName)
         {
+            // Branch-hint parsing is opt-in. The transpiler tests
+            // always want it on.
+            BinaryModuleParser.ParseBranchHints = true;
             using var ms = new MemoryStream(wasm);
             var module = BinaryModuleParser.ParseWasm(ms);
             var runtime = new WasmRuntime();

--- a/Wacs.Transpiler.Test/BranchHintEmissionTests.cs
+++ b/Wacs.Transpiler.Test/BranchHintEmissionTests.cs
@@ -169,7 +169,136 @@ namespace Wacs.Transpiler.Test
                 b => b == OpCodes.Brtrue.Value || b == OpCodes.Brtrue_S.Value);
         }
 
-        private static byte[] GetFnIL(byte[] wasm, string asmName)
+        // Phase 3 fixture: same module shape as the Phase 2 if-with-else
+        // case, but without the else arm. The if-block writes a global
+        // side-effect (a local — observable via the return value) only
+        // when the condition is true.
+        //
+        // (module
+        //   (func (export "g") (param i32) (result i32)
+        //     (local i32)            ;; result accumulator, defaults to 0
+        //     i32.const 7
+        //     local.set 1
+        //     local.get 0
+        //     [hint=0x00 unlikely]
+        //     if
+        //       i32.const 99
+        //       local.set 1
+        //     end
+        //     local.get 1))
+        //
+        // Body bytes (offset relative to body start):
+        //   00: 0x41 0x07          i32.const 7
+        //   02: 0x21 0x01          local.set 1
+        //   04: 0x20 0x00          local.get 0
+        //   06: 0x04 0x40          if (block_type=void)            ← hint target
+        //   08: 0x41 0xE3 0x00     i32.const 99
+        //   0B: 0x21 0x01          local.set 1
+        //   0D: 0x0B               end (if)
+        //   0E: 0x20 0x01          local.get 1
+        //   10: 0x0B               end (function)
+        // Total body = 17 bytes. Plus locals decl prefix (1 (count) +
+        // 1 (entry count for "i32 ×1") + 1 (i32) = 3) → 20 bytes.
+
+        private static readonly byte[] VoidIfBodyBytes =
+        {
+            0x01, 0x01, 0x7F,        // 1 local-decl entry: 1 i32
+            0x41, 0x07,              // i32.const 7
+            0x21, 0x01,              // local.set 1
+            0x20, 0x00,              // local.get 0
+            0x04, 0x40,              // if (block_type=void)
+            0x41, 0xE3, 0x00,        // i32.const 99
+            0x21, 0x01,              // local.set 1
+            0x0B,                    // end (if)
+            0x20, 0x01,              // local.get 1
+            0x0B,                    // end (function)
+        };
+
+        private static byte[] BuildVoidIfModule(byte? hintByte)
+        {
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+            bw.Write(new byte[] { 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00 });
+            // Type: (i32) -> i32
+            bw.Write(new byte[] { 0x01, 0x06, 0x01,  0x60, 0x01, 0x7F, 0x01, 0x7F });
+            bw.Write(new byte[] { 0x03, 0x02, 0x01, 0x00 });
+            // Export "g" -> func 0
+            bw.Write(new byte[] { 0x07, 0x05, 0x01,  0x01, 0x67, 0x00, 0x00 });
+            bw.Write((byte)0x0A);                                // code id
+            bw.Write((byte)(VoidIfBodyBytes.Length + 2));        // section size
+            bw.Write((byte)0x01);                                // 1 body
+            bw.Write((byte)VoidIfBodyBytes.Length);              // body size
+            bw.Write(VoidIfBodyBytes);
+            if (hintByte.HasValue)
+            {
+                // Hint targets the `if` at body-relative offset 6
+                // (after the locals-count byte; counted from the start
+                // of the executable body).
+                const string name = "metadata.code.branch_hint";
+                int payloadLen = 1 + name.Length + 1 + 1 + 1 + 1 + 1 + 1;
+                bw.Write((byte)0x00);
+                bw.Write((byte)payloadLen);
+                bw.Write((byte)name.Length);
+                bw.Write(System.Text.Encoding.UTF8.GetBytes(name));
+                bw.Write((byte)0x01);                            // 1 func entry
+                bw.Write((byte)0x00);                            // funcidx
+                bw.Write((byte)0x01);                            // 1 hint
+                bw.Write((byte)0x06);                            // byte offset = 6 (the if)
+                bw.Write((byte)0x01);                            // payload length
+                bw.Write(hintByte.Value);
+            }
+            return ms.ToArray();
+        }
+
+        private static int InvokeG(TranspilationResult result, int arg)
+        {
+            var instance = Activator.CreateInstance(result.ModuleClass!)!;
+            var em = result.ExportMethods.First(m => m.WasmName == "g");
+            var method = result.ModuleClass!.GetMethod(em.Name,
+                BindingFlags.Public | BindingFlags.Instance)!;
+            try { return (int)method.Invoke(instance, new object[] { arg })!; }
+            catch (TargetInvocationException tie) when (tie.InnerException != null) { throw tie.InnerException; }
+        }
+
+        [Fact]
+        public void VoidIfBehaviorAgreesAcrossHintVariants()
+        {
+            var (noHint, _) = Transpile(BuildVoidIfModule(null), "Wacs.BHint.Void.None");
+            var (likely, _) = Transpile(BuildVoidIfModule(0x01), "Wacs.BHint.Void.Likely");
+            var (unlikely, _) = Transpile(BuildVoidIfModule(0x00), "Wacs.BHint.Void.Unlikely");
+
+            // arg != 0 → cond true → run if-body → local 1 = 99
+            // arg == 0 → cond false → skip if-body → local 1 = 7
+            foreach (var arg in new[] { 0, 1, -1, 42 })
+            {
+                int expected = arg != 0 ? 99 : 7;
+                Assert.Equal(expected, InvokeG(noHint, arg));
+                Assert.Equal(expected, InvokeG(likely, arg));
+                Assert.Equal(expected, InvokeG(unlikely, arg));
+            }
+        }
+
+        [Fact]
+        public void VoidIfUnlikelyHintMovesBodyToColdTail()
+        {
+            // Phase 3: unlikely hint on void if lifts the body out of
+            // the linear flow. The IL must differ from unhinted/likely
+            // (which keep the body inline).
+            var noHintIl = GetFnIL(BuildVoidIfModule(null), "Wacs.BHint.Void.IL.None", "g");
+            var likelyIl = GetFnIL(BuildVoidIfModule(0x01), "Wacs.BHint.Void.IL.Likely", "g");
+            var unlikelyIl = GetFnIL(BuildVoidIfModule(0x00), "Wacs.BHint.Void.IL.Unlikely", "g");
+
+            // Hint=likely is a no-op for void if (the inline emission
+            // is already optimal for "body usually runs").
+            Assert.Equal(noHintIl, likelyIl);
+
+            // Hint=unlikely changes the IL: brfalse becomes brtrue
+            // (skip-by-jump → run-by-jump), and the body bytes appear
+            // at the function tail rather than mid-body.
+            Assert.NotEqual(noHintIl, unlikelyIl);
+        }
+
+        private static byte[] GetFnIL(byte[] wasm, string asmName, string exportName = "f")
         {
             var (result, _) = Transpile(wasm, asmName);
             // The exported `f` on the Module class is a thin trampoline.
@@ -181,8 +310,9 @@ namespace Wacs.Transpiler.Test
             var method = fnsType.GetMethods(
                     BindingFlags.Public | BindingFlags.NonPublic
                     | BindingFlags.Static | BindingFlags.DeclaredOnly)
-                .First(m => m.Name == "f" || m.Name.EndsWith("_f")
-                                          || m.Name.StartsWith("f_"));
+                .First(m => m.Name == exportName
+                            || m.Name.EndsWith("_" + exportName)
+                            || m.Name.StartsWith(exportName + "_"));
             return method.GetMethodBody()!.GetILAsByteArray()!;
         }
     }

--- a/Wacs.Transpiler.Test/BranchHintEmissionTests.cs
+++ b/Wacs.Transpiler.Test/BranchHintEmissionTests.cs
@@ -1,0 +1,189 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Transpiler.AOT;
+using Xunit;
+
+namespace Wacs.Transpiler.Test
+{
+    /// <summary>
+    /// Phase 2 of the Branch Hinting work. Verifies that when a
+    /// <c>metadata.code.branch_hint</c> entry marks an
+    /// <c>if</c>-with-<c>else</c> as unlikely, the transpiler swaps
+    /// the test sense (<c>brfalse</c> → <c>brtrue</c>) and reorders
+    /// the bodies so the else-branch falls through. Behavior must be
+    /// identical to the unhinted emission; only the IL shape differs.
+    /// </summary>
+    public class BranchHintEmissionTests
+    {
+        // (module
+        //   (func (export "f") (param i32) (result i32)
+        //     local.get 0
+        //     [hint=0x00 unlikely OR no hint]
+        //     if (result i32)
+        //       i32.const 100      ;; then-arm
+        //     else
+        //       i32.const 200      ;; else-arm
+        //     end))
+        //
+        // Function body bytes (offset relative to body start):
+        //   00: 0x20 0x00      local.get 0
+        //   02: 0x04 0x7F      if (result i32)     ← hinted
+        //   04: 0x41 0xE4 0x00 i32.const 100
+        //   07: 0x05           else
+        //   08: 0x41 0xC8 0x01 i32.const 200
+        //   0B: 0x0B           end
+        //   0C: 0x0B           expression-end
+        // Body size = 13. Code section: 1 (count) + 1 (size) + 13 = 15.
+
+        private static readonly byte[] BodyBytes =
+        {
+            0x00,                    // 0 locals
+            0x20, 0x00,              // local.get 0
+            0x04, 0x7F,              // if (result i32)
+            0x41, 0xE4, 0x00,        // i32.const 100
+            0x05,                    // else
+            0x41, 0xC8, 0x01,        // i32.const 200
+            0x0B,                    // end (if)
+            0x0B,                    // end (function)
+        };
+
+        private static byte[] BuildModule(byte? hintByte)
+        {
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+            // Magic + version
+            bw.Write(new byte[] { 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00 });
+            // Type: (i32) -> i32
+            bw.Write(new byte[] { 0x01, 0x06, 0x01,  0x60, 0x01, 0x7F, 0x01, 0x7F });
+            // Function: 1 func, type 0
+            bw.Write(new byte[] { 0x03, 0x02, 0x01, 0x00 });
+            // Export "f" -> func 0
+            bw.Write(new byte[] { 0x07, 0x05, 0x01,  0x01, 0x66, 0x00, 0x00 });
+            // Code section: 1 body, body size = 13
+            bw.Write((byte)0x0A);                                // section id
+            bw.Write((byte)(BodyBytes.Length + 1 + 1));          // size = body + count + body-size
+            bw.Write((byte)0x01);                                // 1 body
+            bw.Write((byte)BodyBytes.Length);                    // body size
+            bw.Write(BodyBytes);
+            // Optional custom section "metadata.code.branch_hint"
+            // Hint targets the if at body-relative offset 2.
+            if (hintByte.HasValue)
+            {
+                const string name = "metadata.code.branch_hint";
+                // payload: name-len + name + funcs(1, [funcidx 0, hints(1, [offset 2, len 1, byte])])
+                int payloadLen = 1 + name.Length + 1 + 1 + 1 + 1 + 1 + 1;
+                bw.Write((byte)0x00);                            // section id
+                bw.Write((byte)payloadLen);                      // section size
+                bw.Write((byte)name.Length);
+                bw.Write(System.Text.Encoding.UTF8.GetBytes(name));
+                bw.Write((byte)0x01);                            // 1 function entry
+                bw.Write((byte)0x00);                            // funcidx
+                bw.Write((byte)0x01);                            // 1 hint
+                bw.Write((byte)0x02);                            // byte offset = 2
+                bw.Write((byte)0x01);                            // payload length
+                bw.Write(hintByte.Value);                        // hint byte
+            }
+            return ms.ToArray();
+        }
+
+        private static (TranspilationResult Result, ModuleInstance ModInst) Transpile(byte[] wasm, string asmName)
+        {
+            using var ms = new MemoryStream(wasm);
+            var module = BinaryModuleParser.ParseWasm(ms);
+            var runtime = new WasmRuntime();
+            var modInst = runtime.InstantiateModule(module);
+            var result = new ModuleTranspiler(asmName,
+                new TranspilerOptions { Emission = EmissionTarget.Standard })
+                .Transpile(modInst, runtime, "Mod");
+            return (result, modInst);
+        }
+
+        private static int InvokeF(TranspilationResult result, int arg)
+        {
+            var instance = Activator.CreateInstance(result.ModuleClass!)!;
+            var em = result.ExportMethods.First(m => m.WasmName == "f");
+            var method = result.ModuleClass!.GetMethod(em.Name,
+                BindingFlags.Public | BindingFlags.Instance)!;
+            try { return (int)method.Invoke(instance, new object[] { arg })!; }
+            catch (TargetInvocationException tie) when (tie.InnerException != null) { throw tie.InnerException; }
+        }
+
+        [Fact]
+        public void BehaviorAgreesAcrossHintVariants()
+        {
+            // The wasm semantics: arg != 0 -> 100, arg == 0 -> 200.
+            // All three emission variants must agree on every input.
+            var (noHint, _) = Transpile(BuildModule(null), "Wacs.BHint.None");
+            var (likely, _) = Transpile(BuildModule(0x01), "Wacs.BHint.Likely");
+            var (unlikely, _) = Transpile(BuildModule(0x00), "Wacs.BHint.Unlikely");
+
+            foreach (var arg in new[] { 0, 1, -1, 42 })
+            {
+                int expected = arg != 0 ? 100 : 200;
+                Assert.Equal(expected, InvokeF(noHint, arg));
+                Assert.Equal(expected, InvokeF(likely, arg));
+                Assert.Equal(expected, InvokeF(unlikely, arg));
+            }
+        }
+
+        [Fact]
+        public void UnlikelyHintInvertsBranchSenseInIL()
+        {
+            // The unhinted and likely-hinted emissions are byte-identical
+            // (both use the existing brfalse/then-inline/else-out-of-line
+            // shape). The unlikely-hinted emission should differ — it
+            // emits brtrue and swaps the bodies. Comparing IL byte arrays
+            // is the cleanest signal.
+            var noHintIl = GetFnIL(BuildModule(null), "Wacs.BHint.IL.None");
+            var likelyIl = GetFnIL(BuildModule(0x01), "Wacs.BHint.IL.Likely");
+            var unlikelyIl = GetFnIL(BuildModule(0x00), "Wacs.BHint.IL.Unlikely");
+
+            // Phase 2 contract: hint=likely is a no-op vs unhinted.
+            Assert.Equal(noHintIl, likelyIl);
+
+            // Hint=unlikely changes the IL — the swap is real.
+            Assert.NotEqual(noHintIl, unlikelyIl);
+
+            // Concretely: the conditional branch opcode flips. Byte
+            // OpCodes.Brfalse (0x39) → OpCodes.Brtrue (0x3A), or the
+            // short forms Brfalse_S (0x2C) → Brtrue_S (0x2D).
+            // The unhinted body should contain Brfalse[_S] but not
+            // Brtrue[_S]; the unlikely body should contain Brtrue[_S].
+            Assert.Contains(noHintIl,
+                b => b == OpCodes.Brfalse.Value || b == OpCodes.Brfalse_S.Value);
+            Assert.Contains(unlikelyIl,
+                b => b == OpCodes.Brtrue.Value || b == OpCodes.Brtrue_S.Value);
+        }
+
+        private static byte[] GetFnIL(byte[] wasm, string asmName)
+        {
+            var (result, _) = Transpile(wasm, asmName);
+            // The exported `f` on the Module class is a thin trampoline.
+            // The real per-function CIL lives on the sibling `Functions`
+            // class — that's where the if-block branching gets emitted.
+            // Find the matching method by inspection.
+            var fnsType = result.Assembly.GetTypes()
+                .First(t => t.Name == "Functions");
+            var method = fnsType.GetMethods(
+                    BindingFlags.Public | BindingFlags.NonPublic
+                    | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .First(m => m.Name == "f" || m.Name.EndsWith("_f")
+                                          || m.Name.StartsWith("f_"));
+            return method.GetMethodBody()!.GetILAsByteArray()!;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires the WebAssembly [Branch Hinting](https://github.com/WebAssembly/branch-hinting)
proposal into the parser and the AOT transpiler. End-to-end across
binary, WAT, and the upstream spec WAST fixture, gated behind a
parser feature flag so interpreter-only consumers don't pay the
parse cost.

### Commits

1. **Phase 1 — parse the binary section.** Custom-section parser
   decodes `metadata.code.branch_hint` into `Module.BranchHints`.
   Every parsed instruction body gets its byte offset stamped onto
   `InstructionBase.ByteOffsetInFunc`.
2. **Phase 2 — invert branch sense for unlikely if/else.** `EmitIf`
   swaps `Brfalse`/`Brtrue` so the else-arm becomes the hot
   fall-through.
3. **Phase 3 — cold-tail emission for void if (unlikely).** New
   `_coldTailEmissions` mechanism on `FunctionCodegen` lifts the
   then-body out of the linear flow.
4. **Phase 4 — WAT annotations + feature flag.** WAT parser
   recognizes `(@metadata.code.branch_hint "\xx")` annotations on
   `if` / `br_if`. New `BinaryModuleParser.ParseBranchHints` gate
   (default off); `wacs build` / `wacs aot` /
   `wacs run --engine transpiler` set it on.
5. **Phase 5 — spec branch_hint.wast via WACS's WAT parser.**
   Runs the upstream proposal's spec test directly through WACS's
   own WAST parser, no wabt or wasm-tools needed. `TextScriptParser`
   now handles `assert_malformed_custom` and `assert_invalid_custom`
   as alternates that route to the same script command types.

### Version bumps

- `WACS` 0.10.0 → 0.11.0 (Module API addition)
- `WACS.Transpiler.Lib` 0.5.0 → 0.6.0 (CIL emission change for
  hinted modules; identical for unhinted)

Other shipping packages untouched.

### Optimistic by design

The IL expresses the hint via ordering and branch sense. We don't
promise downstream JIT/AOT honors it beyond what its own block-layout
pass already does (RyuJIT tier-1 will eventually overrule us with
profile data). The bet pays off most for `wacs aot` / NativeAOT cold
paths where there's no profile data to rely on.

## Test plan

- [x] `dotnet test Wacs.Compilation.Test --filter "BranchHintParsingTests"` — 5/5
- [x] `dotnet test Wacs.Compilation.Test --filter "BranchHintWatAnnotationTests"` — 6/6
- [x] `dotnet test Wacs.Compilation.Test --filter "BranchHintSpecWastTests"` — 1/1 (the upstream proposal spec fixture)
- [x] `dotnet test Wacs.Transpiler.Test --filter "BranchHintEmissionTests"` — 4/4
- [x] `dotnet test Wacs.Transpiler.Test` — 698/698 (no regressions)
- [x] `dotnet test Wacs.Compilation.Test` — 60/62 (2 pre-existing call_indirect failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)