### PR TITLE
WASIp1: 0.12.0 release

### DIFF
--- a/Wacs.WASI.Preview1/Wacs.WASI.Preview1.csproj
+++ b/Wacs.WASI.Preview1/Wacs.WASI.Preview1.csproj
@@ -6,16 +6,16 @@
         <Title>Wacs WASI Preview 1</Title>
         <PackageId>WACS.WASI.Preview1</PackageId>
         <Authors>Kelvin Nishikawa</Authors>
-        <Description>WASI Preview 1 implementation for WACS. Successor to the deprecated WACS.WASIp1 package; identical API under the new Wacs.WASI.Preview1 namespace. C# `TypeForwardedTo` cannot bridge a namespace rename, so the deprecated WACS.WASIp1 package is now a metapackage that pulls this assembly in transitively while consumers update their `using Wacs.WASIp1;` lines to `using Wacs.WASI.Preview1;` (one-shot sed in docs/MIGRATION_WASIp1_to_WASI.md).</Description>
+        <Description>WASI Preview 1 implementation for WACS. Successor to the deprecated WACS.WASIp1 package; identical API under the new Wacs.WASI.Preview1 namespace. C# `TypeForwardedTo` cannot bridge a namespace rename, so the deprecated WACS.WASIp1 package is now a metapackage that pulls this assembly in transitively while consumers update their `using Wacs.WASIp1;` lines to `using Wacs.WASI.Preview1;` (one-shot sed in docs/MIGRATION_WASIp1_to_WASI.md). v0.12.0 lifts 23 wasi-testsuite fixtures (Phase 4): symlink behavior modes (no-follow lstat, dangling-target unlink, ELOOP on path_open), trailing-slash semantics, fd_readdir . / .., directory FD own-vs-inherited rights split, real Unix st_ino via stat(2), Clock.ToDateTimeUtc nanosecond fix, plus errno tightening (BADF for invalid fds, ENOTDIR / ISDIR / PERM in path_open). 67/72 fixtures pass; remaining 5 are OS-API-specific (lutimes, rename(2)) or runtime-quirk.</Description>
         <Copyright>(c) 2024 Kelvin Nishikawa</Copyright>
         <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview1</AssemblyName>
         <RootNamespace>Wacs.WASI.Preview1</RootNamespace>
-        <AssemblyVersion>0.11.0</AssemblyVersion>
+        <AssemblyVersion>0.12.0</AssemblyVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.11.0</Version>
+        <Version>0.12.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>

--- a/Wacs.WASIp1/Wacs.WASIp1.csproj
+++ b/Wacs.WASIp1/Wacs.WASIp1.csproj
@@ -22,8 +22,8 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASIp1</AssemblyName>
         <RootNamespace>Wacs.WASIp1</RootNamespace>
-        <AssemblyVersion>0.11.0</AssemblyVersion>
-        <Version>0.11.0</Version>
+        <AssemblyVersion>0.12.0</AssemblyVersion>
+        <Version>0.12.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>


### PR DESCRIPTION
Bumps both `WACS.WASIp1` (deprecated metapackage) and `WACS.WASI.Preview1` from 0.11.0 → 0.12.0. Per `.github/workflows/nuget.yml`, both ship under the `WASIp1-v*` tag prefix and must publish in lockstep — the deprecated metapackage transitively pulls in `WACS.WASI.Preview1` at the same version.

## What changed since 0.11.0
PR #101 (Phase 4) lifts 23 wasi-testsuite fixtures, taking the in-process harness from 43/72 → 67/72. Headlines:

- **Symlink behavior modes** — no-follow lstat, ELOOP on path_open of symlink, dangling-target unlink, EPERM on absolute symlink target.
- **POSIX trailing-slash semantics** in `path_unlink_file`, `path_remove_directory`, `path_symlink`, `path_link`, `path_open`.
- **Directory FD own-vs-inherited rights split** — `Rights` strips file-only flags so `rust/directory_seek` / `rust/truncation_rights` see a clean dir base; `InheritedRights` keeps them so `PathOpen` can hand them down to child files.
- **Real Unix st_ino** via P/Invoke to `libc::stat` (macOS + Linux struct variants), so hard-linked files share inodes.
- **`Clock.ToDateTimeUtc` nanosecond fix** — previously used WASI nanoseconds as raw DateTime ticks, producing year-0001 timestamps that filesystem rounding silently corrupted.
- **`fd_readdir` synthesizes `.` and `..`** that `Directory.EnumerateFileSystemEntries` omits.
- **`linkat` with AT_SYMLINK_NOFOLLOW** so dangling-symlink hardlinks link the link itself.
- **Errno tightening** — `BADF` for invalid fds (was `NoEnt`), `ENOTDIR` / `ISDIR` / `PERM` / `INVAL` in path_open, `NameTooLong` in fd_prestat_dir_name, `IsDir` for fd_allocate on a directory.
- **`fd_filestat_get` reads live `FileStream.Length`** rather than `FileInfo.Length` so unflushed writes are reflected.
- **`fd_filestat_set_times`** only touches the timestamp the caller asked for via FSTFLAGS_*.

## Still skipped (5)
All OS- or runtime-specific:
- `assemblyscript/fd_write-to-invalid-fd` — assemblyscript abort propagation
- `c/pwrite-with-access` — wasi-libc `fd_pwrite` stream interaction
- `rust/file_unbuffered_write` — `FdFlag.Sync` semantics
- `rust/symlink_filestat` — needs `lutimes`/`utimensat(AT_SYMLINK_NOFOLLOW)` for setting times on the link itself
- `rust/path_rename` — rename-dir-onto-empty-dir needs POSIX `rename(2)` P/Invoke (Directory.Move throws on existing target on macOS/Linux)
- `rust/poll_oneoff_stdio` — write-readiness on stdio quirk
- `rust/interesting_paths` — `..` escape detection from the dirfd boundary

## Test plan
- [x] `dotnet build Wacs.WASI.Preview1/Wacs.WASI.Preview1.csproj -c Release` — clean.
- [x] `dotnet build Wacs.WASIp1/Wacs.WASIp1.csproj -c Release` — clean.
- [x] `dotnet test Wacs.WASI.Preview1.Test` — 72/72 (67 active passes + 5 skip pass-through).
- [ ] After merge: tag `WASIp1-v0.12.0` to fire `nuget.yml`.