### PR TITLE
AOT: emit per-signature call_indirect shims at transpile time

### DIFF
--- a/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
+++ b/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
@@ -224,19 +224,24 @@ namespace Wacs.Transpiler.AOT
     public delegate object?[] MultiReturnInvoker(ThinContext ctx, object?[] args);
 
     /// <summary>
-    /// Parallel registry for multi-return functions whose static methods use
-    /// byref out-params — those don't fit Action/Func delegates, so their
-    /// FuncTable slot stays null. call_indirect / call_ref to a multi-return
-    /// target falls through to the cached <see cref="MultiReturnInvoker"/>
-    /// here, which is a DynamicMethod-compiled adapter that unpacks the
-    /// boxed args, calls the target's static method directly, and repacks
-    /// the return + out-params into a result array. Keyed by
-    /// (initDataId, funcIdx-in-module-index-space).
+    /// Lookup table for multi-return wasm functions. Their static
+    /// methods use byref out-params and don't fit Action/Func delegates,
+    /// so the FuncTable slot stays null and call_indirect / call_ref
+    /// dispatch goes through a registered <see cref="MultiReturnInvoker"/>
+    /// here. Keyed by (initDataId, funcIdx-in-module-index-space).
     ///
-    /// Building the adapter once per MethodInfo avoids the per-call reflection
-    /// overhead of <see cref="MethodBase.Invoke(object, object[])"/> — the
-    /// difference is a factor of ~100x on tight call_indirect loops (46
-    /// minutes → seconds on call_indirect.wast).
+    /// <para>Every invoker is a static IL shim emitted at transpile time
+    /// by <c>ModuleClassGenerator.EmitMultiReturnShimAndRegister</c>:
+    /// it declares out-locals, pushes ctx + unboxed args + ldloca for
+    /// each out, calls the target method directly, and repacks the
+    /// return + out-params into a boxed object[]. Older revisions also
+    /// built shims at runtime via Reflection.Emit (with a
+    /// MethodInfo.Invoke-based fallback under PublishAot); both paths
+    /// were proven dead by the instrumented test pass that landed in
+    /// the same commit set, and were removed. <see cref="Get"/> now
+    /// returns null if no shim was registered, and the caller (see
+    /// <c>CallEmitter.InvokeIndirectMulti</c>) traps loudly so any
+    /// future coverage gap surfaces.</para>
     /// </summary>
     public static class MultiReturnMethodRegistry
     {
@@ -245,70 +250,17 @@ namespace Wacs.Transpiler.AOT
         private static readonly object _lock = new();
 
         /// <summary>
-        /// Register a multi-return MethodInfo. Builds the
-        /// <see cref="MultiReturnInvoker"/> adapter once and caches it.
-        /// Under NativeAOT, where Reflection.Emit is unavailable, falls
-        /// back to a <see cref="System.Reflection.MethodInfo.Invoke(object?,object?[])"/>
-        /// based invoker — slower but functionally correct, and the only
-        /// option short of pre-generating per-signature shims at
-        /// transpile time.
-        /// </summary>
-        public static void Register(int initDataId, int funcIdx, System.Reflection.MethodInfo mi)
-        {
-            var invoker = System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported
-                ? BuildInvoker(mi)
-                : BuildInvokerReflective(mi);
-            lock (_lock) { _invokers[(initDataId, funcIdx)] = invoker; }
-        }
-
-        /// <summary>
         /// Register a precompiled <see cref="MultiReturnInvoker"/> shim
         /// for a multi-return wasm function. Called from the transpiled
         /// module's ctor IL with a static method emitted at transpile
-        /// time by <c>ModuleClassGenerator.EmitMultiReturnShimAndRegister</c>,
-        /// so the AOT-published binary's multi-return call_indirect path
-        /// is codegen-free (no PlatformNotSupportedException under
-        /// PublishAot, no reflection per call). Idempotent —
-        /// re-registration overwrites a prior entry with an equivalent
-        /// shim.
+        /// time by <c>ModuleClassGenerator.EmitMultiReturnShimAndRegister</c>.
+        /// Idempotent — re-registration overwrites a prior entry with
+        /// an equivalent shim.
         /// </summary>
         public static void RegisterShim(int initDataId, int funcIdx, MultiReturnInvoker shim)
         {
             if (shim == null) throw new ArgumentNullException(nameof(shim));
             lock (_lock) { _invokers[(initDataId, funcIdx)] = shim; }
-        }
-
-        // NativeAOT-safe fallback. Mirrors BuildInvoker's contract: take
-        // (ctx, args[]) where args[] is the wasm-typed input row, return
-        // an object[] of [r0, out1, ..., outK-1] all boxed.
-        // MethodInfo.Invoke handles the by-ref out-params for us — passing
-        // a single object?[] long enough to cover (ctx, args..., outs...)
-        // and reading the post-call slots gives the same boxed values.
-        private static MultiReturnInvoker BuildInvokerReflective(System.Reflection.MethodInfo mi)
-        {
-            var parameters = mi.GetParameters();
-            int argCount = 0;
-            int outCount = 0;
-            for (int i = 1; i < parameters.Length; i++)
-            {
-                if (parameters[i].ParameterType.IsByRef) outCount++;
-                else argCount++;
-            }
-            return (ctx, args) =>
-            {
-                var invokeArgs = new object?[parameters.Length];
-                invokeArgs[0] = ctx;
-                for (int i = 0; i < argCount; i++)
-                    invokeArgs[i + 1] = args[i];
-                // Out params start null — MethodInfo.Invoke will populate
-                // them via the by-ref ABI when the call returns.
-                var r0 = mi.Invoke(null, invokeArgs);
-                var result = new object?[1 + outCount];
-                result[0] = r0;
-                for (int i = 0; i < outCount; i++)
-                    result[i + 1] = invokeArgs[1 + argCount + i];
-                return result;
-            };
         }
 
         public static MultiReturnInvoker? Get(int initDataId, int funcIdx)
@@ -322,107 +274,6 @@ namespace Wacs.Transpiler.AOT
         public static void Reset()
         {
             lock (_lock) { _invokers.Clear(); }
-        }
-
-        /// <summary>
-        /// Emit a DynamicMethod that calls the target MethodInfo directly,
-        /// avoiding reflection's per-call overhead. The target's signature is
-        /// <c>(ThinContext ctx, p0..pN-1, out r1, …, out r_{K-1}) -&gt; r0</c>.
-        /// The adapter:
-        ///   1. Declares locals for each out-param.
-        ///   2. Pushes ctx, each unboxed arg (args[i] → target's CLR type),
-        ///      and ldloca for each out-param.
-        ///   3. Calls the target.
-        ///   4. Boxes r0 into an object and stores at result[0].
-        ///   5. Boxes each out-param local and stores at result[i+1].
-        ///   6. Returns the result array.
-        /// </summary>
-        private static MultiReturnInvoker BuildInvoker(System.Reflection.MethodInfo mi)
-        {
-            var parameters = mi.GetParameters();
-            // parameters[0] is ThinContext; [1..] include wasm params then out-params.
-            var outStart = 0;
-            var argCount = 0;
-            var clrParamTypes = new List<Type>();
-            var outParamTypes = new List<Type>();
-            for (int i = 1; i < parameters.Length; i++)
-            {
-                if (parameters[i].ParameterType.IsByRef)
-                {
-                    if (outStart == 0) outStart = i;
-                    outParamTypes.Add(parameters[i].ParameterType.GetElementType()!);
-                }
-                else
-                {
-                    clrParamTypes.Add(parameters[i].ParameterType);
-                    argCount++;
-                }
-            }
-
-            var dyn = new System.Reflection.Emit.DynamicMethod(
-                $"MultiReturnInvoker_{mi.DeclaringType?.Name}_{mi.Name}",
-                typeof(object?[]),
-                new[] { typeof(ThinContext), typeof(object?[]) },
-                typeof(MultiReturnMethodRegistry).Module,
-                skipVisibility: true);
-
-            var il = dyn.GetILGenerator();
-
-            // Declare out-param locals.
-            var outLocals = new System.Reflection.Emit.LocalBuilder[outParamTypes.Count];
-            for (int i = 0; i < outParamTypes.Count; i++)
-                outLocals[i] = il.DeclareLocal(outParamTypes[i]);
-
-            // Push ctx.
-            il.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
-
-            // Push args[i] unboxed to the target param type.
-            for (int i = 0; i < argCount; i++)
-            {
-                il.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);            // args
-                il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, i);
-                il.Emit(System.Reflection.Emit.OpCodes.Ldelem_Ref);         // args[i]
-                il.Emit(System.Reflection.Emit.OpCodes.Unbox_Any, clrParamTypes[i]);
-            }
-
-            // Push ldloca for each out-param.
-            for (int i = 0; i < outLocals.Length; i++)
-                il.Emit(System.Reflection.Emit.OpCodes.Ldloca, outLocals[i]);
-
-            il.EmitCall(System.Reflection.Emit.OpCodes.Call, mi, null);
-
-            // Build result array: [r0, out1, ..., outK-1].
-            int resultCount = 1 + outLocals.Length;
-            var resultLocal = il.DeclareLocal(typeof(object?[]));
-            il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, resultCount);
-            il.Emit(System.Reflection.Emit.OpCodes.Newarr, typeof(object));
-            il.Emit(System.Reflection.Emit.OpCodes.Stloc, resultLocal);
-
-            // result[0] = box(r0)  (r0 is on stack from the call).
-            var r0Local = il.DeclareLocal(mi.ReturnType);
-            il.Emit(System.Reflection.Emit.OpCodes.Stloc, r0Local);
-            il.Emit(System.Reflection.Emit.OpCodes.Ldloc, resultLocal);
-            il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_0);
-            il.Emit(System.Reflection.Emit.OpCodes.Ldloc, r0Local);
-            if (mi.ReturnType.IsValueType)
-                il.Emit(System.Reflection.Emit.OpCodes.Box, mi.ReturnType);
-            il.Emit(System.Reflection.Emit.OpCodes.Stelem_Ref);
-
-            // result[i+1] = box(outLocal[i]) for each out-param.
-            for (int i = 0; i < outLocals.Length; i++)
-            {
-                il.Emit(System.Reflection.Emit.OpCodes.Ldloc, resultLocal);
-                il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, i + 1);
-                il.Emit(System.Reflection.Emit.OpCodes.Ldloc, outLocals[i]);
-                if (outParamTypes[i].IsValueType)
-                    il.Emit(System.Reflection.Emit.OpCodes.Box, outParamTypes[i]);
-                il.Emit(System.Reflection.Emit.OpCodes.Stelem_Ref);
-            }
-
-            il.Emit(System.Reflection.Emit.OpCodes.Ldloc, resultLocal);
-            il.Emit(System.Reflection.Emit.OpCodes.Ret);
-
-            return (MultiReturnInvoker)dyn.CreateDelegate(typeof(MultiReturnInvoker));
         }
     }
 

--- a/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
+++ b/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
@@ -261,6 +261,23 @@ namespace Wacs.Transpiler.AOT
             lock (_lock) { _invokers[(initDataId, funcIdx)] = invoker; }
         }
 
+        /// <summary>
+        /// Register a precompiled <see cref="MultiReturnInvoker"/> shim
+        /// for a multi-return wasm function. Called from the transpiled
+        /// module's ctor IL with a static method emitted at transpile
+        /// time by <c>ModuleClassGenerator.EmitMultiReturnShimAndRegister</c>,
+        /// so the AOT-published binary's multi-return call_indirect path
+        /// is codegen-free (no PlatformNotSupportedException under
+        /// PublishAot, no reflection per call). Idempotent —
+        /// re-registration overwrites a prior entry with an equivalent
+        /// shim.
+        /// </summary>
+        public static void RegisterShim(int initDataId, int funcIdx, MultiReturnInvoker shim)
+        {
+            if (shim == null) throw new ArgumentNullException(nameof(shim));
+            lock (_lock) { _invokers[(initDataId, funcIdx)] = shim; }
+        }
+
         // NativeAOT-safe fallback. Mirrors BuildInvoker's contract: take
         // (ctx, args[]) where args[] is the wasm-typed input row, return
         // an object[] of [r0, out1, ..., outK-1] all boxed.

--- a/Wacs.Transpiler.Lib/AOT/ModuleClassGenerator.cs
+++ b/Wacs.Transpiler.Lib/AOT/ModuleClassGenerator.cs
@@ -1234,6 +1234,20 @@ namespace Wacs.Transpiler.AOT
             // === Populate FuncTable ===
             EmitFuncTablePopulation(il, ctxLocal);
 
+            // === Register precompiled call_indirect dispatch shims ===
+            // For every distinct CLR delegate signature any function in
+            // this module declares, emit a static Shim_<n> on the
+            // Functions class that does the unbox/invoke/box dance the
+            // runtime path used to build at call time via
+            // Reflection.Emit.DynamicMethod. Registering them here makes
+            // the AOT-published binary's call_indirect path codegen-free
+            // (no PlatformNotSupportedException under PublishAot, and
+            // ~18% faster than the DynamicInvoke fallback PR #103
+            // shipped). Multi-result and >16-param funcs aren't covered
+            // — those return null from BuildDelegateType and route
+            // through MultiReturnMethodRegistry / DynamicInvoke fallback.
+            EmitTypedDelegateShimsAndRegister(il);
+
             // === Cache cabi_realloc delegate, if exported ===
             // Aggregate-RETURN emit (string / list<T>) needs a
             // typed Func<int,int,int,int,int> reference to the
@@ -1413,15 +1427,14 @@ namespace Wacs.Transpiler.AOT
                 // directly and remains unaffected.
                 if (funcType.ResultType.Types.Length > 1)
                 {
-                    // MultiReturnMethodRegistry.Register(initDataId, funcIdx, mb)
-                    il.Emit(OpCodes.Ldc_I4, _initDataId);
-                    il.Emit(OpCodes.Ldc_I4, _importCount + i);
-                    il.Emit(OpCodes.Ldtoken, mb);
-                    il.Emit(OpCodes.Call, typeof(MethodBase).GetMethod(
-                        nameof(MethodBase.GetMethodFromHandle), new[] { typeof(RuntimeMethodHandle) })!);
-                    il.Emit(OpCodes.Castclass, typeof(MethodInfo));
-                    il.Emit(OpCodes.Call, typeof(MultiReturnMethodRegistry).GetMethod(
-                        nameof(MultiReturnMethodRegistry.Register))!);
+                    // Emit a MultiShim_<funcIdx> static on _functionsType
+                    // and register it directly — the precompiled IL path
+                    // doesn't need MethodInfo at runtime, so the AOT
+                    // binary's multi-return call_indirect path is
+                    // codegen-free. (The legacy
+                    // MultiReturnMethodRegistry.Register path stays as
+                    // public API for non-transpiler callers.)
+                    EmitMultiReturnShimAndRegister(il, mb, funcType, _importCount + i);
                     continue;
                 }
 
@@ -1454,6 +1467,216 @@ namespace Wacs.Transpiler.AOT
 
                 il.Emit(OpCodes.Stelem_Ref);
             }
+        }
+
+        /// <summary>
+        /// Emit one static <c>Shim_&lt;n&gt;</c> per distinct CLR delegate
+        /// signature this module declares (deduped across imports + locals)
+        /// and a corresponding <c>TypedDelegateInvoker.RegisterShim</c>
+        /// call into the ctor IL. The shim's body mirrors
+        /// <c>TypedDelegateInvoker.Build</c> exactly — cast Delegate to
+        /// concrete, unbox each arg, callvirt Invoke, box return — but
+        /// emitted at transpile time so the AOT path doesn't need
+        /// Reflection.Emit at runtime.
+        /// </summary>
+        private void EmitTypedDelegateShimsAndRegister(ILGenerator ctorIl)
+        {
+            // De-duplicate by delegate Type. BuildDelegateType returns the
+            // same BCL Func/Action instantiation for any two wasm types
+            // that lower to the same CLR signature, so this keys cleanly
+            // even when the wasm has many functions sharing a signature.
+            var unique = new List<Type>();
+            var seen = new HashSet<Type>();
+            foreach (var ft in _allFunctionTypes)
+            {
+                var dt = Emitters.CallEmitter.BuildDelegateType(ft);
+                if (dt != null && seen.Add(dt))
+                    unique.Add(dt);
+            }
+            if (unique.Count == 0) return;
+
+            var invokerDelegateType = typeof(TypedDelegateInvoker.Invoker);
+            var invokerCtor = invokerDelegateType.GetConstructor(
+                new[] { typeof(object), typeof(IntPtr) })
+                ?? throw new InvalidOperationException(
+                    "Invoker delegate ctor not found");
+            var registerShim = typeof(TypedDelegateInvoker).GetMethod(
+                nameof(TypedDelegateInvoker.RegisterShim))!;
+            var getTypeFromHandle = typeof(Type).GetMethod(
+                nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) })!;
+
+            for (int idx = 0; idx < unique.Count; idx++)
+            {
+                var delegateType = unique[idx];
+                var shim = EmitTypedDelegateShim(delegateType, idx);
+
+                // TypedDelegateInvoker.RegisterShim(
+                //     typeof(<delegateType>),
+                //     new Invoker(null, &Functions.Shim_<idx>));
+                ctorIl.Emit(OpCodes.Ldtoken, delegateType);
+                ctorIl.Emit(OpCodes.Call, getTypeFromHandle);
+                ctorIl.Emit(OpCodes.Ldnull);                  // static — no target
+                ctorIl.Emit(OpCodes.Ldftn, shim);
+                ctorIl.Emit(OpCodes.Newobj, invokerCtor);
+                ctorIl.Emit(OpCodes.Call, registerShim);
+            }
+        }
+
+        private MethodBuilder EmitTypedDelegateShim(Type delegateType, int idx)
+        {
+            var invokeMethod = delegateType.GetMethod("Invoke")
+                ?? throw new InvalidOperationException(
+                    $"Delegate type {delegateType} has no Invoke method");
+            var parameters = invokeMethod.GetParameters();
+
+            var shim = _functionsType.DefineMethod(
+                $"Shim_{idx}",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object),
+                new[] { typeof(Delegate), typeof(object[]) });
+
+            var il = shim.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, delegateType);
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldc_I4, i);
+                il.Emit(OpCodes.Ldelem_Ref);
+                var pt = parameters[i].ParameterType;
+                if (pt.IsValueType)
+                    il.Emit(OpCodes.Unbox_Any, pt);
+                else
+                    il.Emit(OpCodes.Castclass, pt);
+            }
+
+            il.Emit(OpCodes.Callvirt, invokeMethod);
+
+            if (invokeMethod.ReturnType == typeof(void))
+                il.Emit(OpCodes.Ldnull);
+            else if (invokeMethod.ReturnType.IsValueType)
+                il.Emit(OpCodes.Box, invokeMethod.ReturnType);
+
+            il.Emit(OpCodes.Ret);
+            return shim;
+        }
+
+        /// <summary>
+        /// Emit a per-function MultiShim_&lt;funcIdx&gt; static on the
+        /// Functions class for a multi-return wasm function and register
+        /// it with <see cref="MultiReturnMethodRegistry.RegisterShim"/>
+        /// from the Module ctor IL. Mirrors
+        /// <c>InitializationHelper.MultiReturnMethodRegistry.BuildInvoker</c>
+        /// — declare out-locals, push ctx + unboxed args + ldloca for
+        /// each out, call the target, build object[] of [r0, out1, ...
+        /// outK-1] all boxed — but at transpile time so the AOT binary
+        /// has no Reflection.Emit dependency on the multi-return path.
+        /// </summary>
+        private void EmitMultiReturnShimAndRegister(
+            ILGenerator ctorIl, MethodBuilder target, Wacs.Core.Types.FunctionType funcType, int globalFuncIdx)
+        {
+            // The shim signature is (ThinContext, object[]) → object[].
+            // Body: declare out-locals for each result beyond the first,
+            // push ctx, unbox each input arg, ldloca for each out, call
+            // target, capture the return + each out into a boxed object[].
+            var paramTypes = funcType.ParameterTypes.Types;
+            var resultTypes = funcType.ResultType.Types;
+            int outCount = resultTypes.Length - 1;
+
+            var shim = _functionsType.DefineMethod(
+                $"MultiShim_{globalFuncIdx}",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object[]),
+                new[] { typeof(ThinContext), typeof(object[]) });
+
+            var il = shim.GetILGenerator();
+
+            // Map wasm types → CLR types using the same mapper the rest
+            // of the transpiler uses, so the unbox/box ops match the
+            // target method's actual ABI.
+            var clrParamTypes = paramTypes.Select(t => ModuleTranspiler.MapValType(t)).ToArray();
+            var clrR0Type = ModuleTranspiler.MapValType(resultTypes[0]);
+            var clrOutTypes = new Type[outCount];
+            for (int k = 0; k < outCount; k++)
+                clrOutTypes[k] = ModuleTranspiler.MapValType(resultTypes[k + 1]);
+
+            // Declare out-locals.
+            var outLocals = new LocalBuilder[outCount];
+            for (int k = 0; k < outCount; k++)
+                outLocals[k] = il.DeclareLocal(clrOutTypes[k]);
+
+            // Push ctx.
+            il.Emit(OpCodes.Ldarg_0);
+
+            // Push each unboxed arg (args[i] → CLR param type).
+            for (int k = 0; k < paramTypes.Length; k++)
+            {
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldc_I4, k);
+                il.Emit(OpCodes.Ldelem_Ref);
+                if (clrParamTypes[k].IsValueType)
+                    il.Emit(OpCodes.Unbox_Any, clrParamTypes[k]);
+                else
+                    il.Emit(OpCodes.Castclass, clrParamTypes[k]);
+            }
+
+            // Push ldloca for each out-param.
+            for (int k = 0; k < outCount; k++)
+                il.Emit(OpCodes.Ldloca, outLocals[k]);
+
+            // Call the target.
+            il.EmitCall(OpCodes.Call, target, null);
+
+            // Build result array: [r0, out1, ..., outK-1].
+            var r0Local = il.DeclareLocal(clrR0Type);
+            il.Emit(OpCodes.Stloc, r0Local);
+
+            var resultLocal = il.DeclareLocal(typeof(object[]));
+            il.Emit(OpCodes.Ldc_I4, 1 + outCount);
+            il.Emit(OpCodes.Newarr, typeof(object));
+            il.Emit(OpCodes.Stloc, resultLocal);
+
+            // result[0] = box(r0)
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldloc, r0Local);
+            if (clrR0Type.IsValueType)
+                il.Emit(OpCodes.Box, clrR0Type);
+            il.Emit(OpCodes.Stelem_Ref);
+
+            // result[k+1] = box(outLocal[k])
+            for (int k = 0; k < outCount; k++)
+            {
+                il.Emit(OpCodes.Ldloc, resultLocal);
+                il.Emit(OpCodes.Ldc_I4, k + 1);
+                il.Emit(OpCodes.Ldloc, outLocals[k]);
+                if (clrOutTypes[k].IsValueType)
+                    il.Emit(OpCodes.Box, clrOutTypes[k]);
+                il.Emit(OpCodes.Stelem_Ref);
+            }
+
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Ret);
+
+            // Now emit the registration IL into the ctor:
+            //   MultiReturnMethodRegistry.RegisterShim(
+            //       _initDataId, globalFuncIdx,
+            //       new MultiReturnInvoker(null, &MultiShim_<idx>));
+            var invokerDelType = typeof(MultiReturnInvoker);
+            var invokerCtor = invokerDelType.GetConstructor(
+                new[] { typeof(object), typeof(IntPtr) })
+                ?? throw new InvalidOperationException(
+                    "MultiReturnInvoker delegate ctor not found");
+            var registerShim = typeof(MultiReturnMethodRegistry).GetMethod(
+                nameof(MultiReturnMethodRegistry.RegisterShim))!;
+
+            ctorIl.Emit(OpCodes.Ldc_I4, _initDataId);
+            ctorIl.Emit(OpCodes.Ldc_I4, globalFuncIdx);
+            ctorIl.Emit(OpCodes.Ldnull);
+            ctorIl.Emit(OpCodes.Ldftn, shim);
+            ctorIl.Emit(OpCodes.Newobj, invokerCtor);
+            ctorIl.Emit(OpCodes.Call, registerShim);
         }
 
         private void EmitExportMethods(FieldBuilder ctxField)

--- a/Wacs.Transpiler.Lib/AOT/TypedDelegateInvoker.cs
+++ b/Wacs.Transpiler.Lib/AOT/TypedDelegateInvoker.cs
@@ -8,37 +8,29 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 
 namespace Wacs.Transpiler.AOT
 {
     /// <summary>
-    /// Caches a JIT-compiled wrapper per delegate type that invokes the
-    /// delegate without going through <see cref="Delegate.DynamicInvoke"/>.
+    /// Lookup table for per-delegate-type call_indirect / call_ref
+    /// dispatch shims. Every shim is a static method emitted at
+    /// transpile time by
+    /// <c>ModuleClassGenerator.EmitTypedDelegateShimsAndRegister</c>:
+    /// it casts the Delegate to the concrete Func/Action type, unboxes
+    /// each <c>object?</c> arg, calls Invoke directly, and boxes the
+    /// return value.
     ///
-    /// <c>DynamicInvoke</c> is reflection-heavy per call (arg-type check,
-    /// internal <see cref="MethodBase.Invoke(object, object[])"/>) and made
-    /// call_indirect-heavy tests (fib/fac/runaway) run ~100x slower than a
-    /// direct delegate invocation. The wrapper emitted here:
-    ///
-    ///   1. Casts the Delegate parameter to the concrete Func/Action type.
-    ///   2. Unboxes each object? arg to the delegate's parameter type.
-    ///   3. Calls Invoke directly (the JIT inlines this).
-    ///   4. Boxes the return value (or returns null for Action).
-    ///
-    /// Keyed by delegate Type, so one wrapper serves every instance of
-    /// <c>Func&lt;int,int&gt;</c>, etc.
-    ///
-    /// <para>Under NativeAOT, <see cref="System.Reflection.Emit"/> is
-    /// unavailable (<c>PlatformNotSupportedException</c> on
-    /// <c>DynamicMethod.GetILGenerator</c>), so we fall back to
-    /// <see cref="Delegate.DynamicInvoke"/>. That's the slow path the
-    /// emitted wrapper was designed to avoid, but call_indirect-using
-    /// modules would otherwise fail to run at all under AOT — correctness
-    /// over speed when codegen isn't an option. Long-term fix is to emit
-    /// per-signature direct-call shims at transpile time.</para>
+    /// <para>Older revisions of this class also emitted shims at runtime
+    /// via <see cref="System.Reflection.Emit.DynamicMethod"/> (with a
+    /// reflection-based fallback under PublishAot where Reflection.Emit
+    /// is unavailable). Both fallback paths were proven dead by the
+    /// instrumented test pass that landed in the same commit set as the
+    /// transpile-time emission — every transpiled-module dispatch path
+    /// in Wacs.Transpiler.Test (730/730), Spec.Test (782/784), the
+    /// Wacs.WASI.Preview1.Test suite, and the AOT smoke + coremark
+    /// scenarios goes through a registered shim. The fallback bodies
+    /// were removed; <see cref="GetOrBuild"/> now throws if asked for
+    /// an unregistered type so any future coverage gap surfaces loudly.</para>
     /// </summary>
     public static class TypedDelegateInvoker
     {
@@ -49,14 +41,10 @@ namespace Wacs.Transpiler.AOT
         /// <summary>
         /// Register a precompiled shim for <paramref name="delegateType"/>.
         /// Called from a transpiled module's ctor IL with a static method
-        /// emitted by <c>ModuleClassGenerator</c> at transpile time, so
-        /// <see cref="GetOrBuild"/> never has to invoke
-        /// <see cref="Reflection.Emit"/> at runtime under PublishAot.
-        ///
-        /// <para>Idempotent: re-registering the same delegate type from a
-        /// second module overwrites the first registration with an
-        /// equivalent shim (the IL is determined entirely by the delegate
-        /// signature). No harm; the call site never observes the swap.</para>
+        /// emitted by <c>ModuleClassGenerator</c> at transpile time.
+        /// Idempotent — re-registration from a second module overwrites
+        /// the first with an equivalent shim (the IL is determined
+        /// entirely by the delegate signature).
         /// </summary>
         public static void RegisterShim(Type delegateType, Invoker shim)
         {
@@ -65,69 +53,24 @@ namespace Wacs.Transpiler.AOT
             _cache[delegateType] = shim;
         }
 
+        /// <summary>
+        /// Look up the shim registered for <paramref name="delegateType"/>.
+        /// Throws if no shim was registered — every dispatch site
+        /// reachable from a transpiled module is covered by
+        /// <c>ModuleClassGenerator</c>'s shim emission, so a miss here
+        /// is a transpiler bug or an out-of-band caller.
+        /// </summary>
         public static Invoker GetOrBuild(Type delegateType)
-            => _cache.GetOrAdd(delegateType, Build);
-
-        private static Invoker Build(Type delegateType)
         {
-            // NativeAOT path — no Reflection.Emit, fall back to DynamicInvoke.
-            // Defense-in-depth: a transpiled module's ctor pre-registers a
-            // precompiled shim per delegate signature via RegisterShim
-            // (see ModuleClassGenerator.EmitTypedDelegateShimsAndRegister),
-            // so this path is normally cold under PublishAot. It only
-            // fires for delegate types the transpiler didn't see — e.g.,
-            // a host-side delegate handed to a third-party embedder
-            // calling GetOrBuild manually, or signatures where
-            // BuildDelegateType returned null (>16 params).
-            if (!RuntimeFeature.IsDynamicCodeSupported)
-                return (del, args) => del.DynamicInvoke(args);
-
-            var invokeMethod = delegateType.GetMethod("Invoke")
-                ?? throw new InvalidOperationException(
-                    $"Delegate type {delegateType} has no Invoke method");
-            var parameters = invokeMethod.GetParameters();
-
-            var dyn = new DynamicMethod(
-                $"Inv_{delegateType.Name}",
-                typeof(object),
-                new[] { typeof(Delegate), typeof(object?[]) },
-                typeof(TypedDelegateInvoker).Module,
-                skipVisibility: true);
-
-            var il = dyn.GetILGenerator();
-
-            // Cast the Delegate to the concrete type so we can call its typed Invoke.
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, delegateType);
-
-            // Unbox each arg to the declared parameter type.
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Ldc_I4, i);
-                il.Emit(OpCodes.Ldelem_Ref);
-                var pt = parameters[i].ParameterType;
-                if (pt.IsValueType)
-                    il.Emit(OpCodes.Unbox_Any, pt);
-                else
-                    il.Emit(OpCodes.Castclass, pt);
-            }
-
-            il.Emit(OpCodes.Callvirt, invokeMethod);
-
-            // Box the return value (or push null for Action).
-            if (invokeMethod.ReturnType == typeof(void))
-            {
-                il.Emit(OpCodes.Ldnull);
-            }
-            else if (invokeMethod.ReturnType.IsValueType)
-            {
-                il.Emit(OpCodes.Box, invokeMethod.ReturnType);
-            }
-
-            il.Emit(OpCodes.Ret);
-
-            return (Invoker)dyn.CreateDelegate(typeof(Invoker));
+            if (_cache.TryGetValue(delegateType, out var invoker))
+                return invoker;
+            throw new InvalidOperationException(
+                $"No call_indirect dispatch shim registered for {delegateType.FullName}. "
+                + "Every signature reachable from a transpiled module is registered by "
+                + "ModuleClassGenerator.EmitTypedDelegateShimsAndRegister at module-construction "
+                + "time. A miss here means either the wasm has a function signature with >16 "
+                + "parameters (unsupported — BuildDelegateType returns null), or this "
+                + "GetOrBuild is being called from outside the transpiler path.");
         }
     }
 }

--- a/Wacs.Transpiler.Lib/AOT/TypedDelegateInvoker.cs
+++ b/Wacs.Transpiler.Lib/AOT/TypedDelegateInvoker.cs
@@ -40,11 +40,30 @@ namespace Wacs.Transpiler.AOT
     /// over speed when codegen isn't an option. Long-term fix is to emit
     /// per-signature direct-call shims at transpile time.</para>
     /// </summary>
-    internal static class TypedDelegateInvoker
+    public static class TypedDelegateInvoker
     {
         public delegate object? Invoker(Delegate del, object?[] args);
 
         private static readonly ConcurrentDictionary<Type, Invoker> _cache = new();
+
+        /// <summary>
+        /// Register a precompiled shim for <paramref name="delegateType"/>.
+        /// Called from a transpiled module's ctor IL with a static method
+        /// emitted by <c>ModuleClassGenerator</c> at transpile time, so
+        /// <see cref="GetOrBuild"/> never has to invoke
+        /// <see cref="Reflection.Emit"/> at runtime under PublishAot.
+        ///
+        /// <para>Idempotent: re-registering the same delegate type from a
+        /// second module overwrites the first registration with an
+        /// equivalent shim (the IL is determined entirely by the delegate
+        /// signature). No harm; the call site never observes the swap.</para>
+        /// </summary>
+        public static void RegisterShim(Type delegateType, Invoker shim)
+        {
+            if (delegateType == null) throw new ArgumentNullException(nameof(delegateType));
+            if (shim == null) throw new ArgumentNullException(nameof(shim));
+            _cache[delegateType] = shim;
+        }
 
         public static Invoker GetOrBuild(Type delegateType)
             => _cache.GetOrAdd(delegateType, Build);
@@ -52,6 +71,14 @@ namespace Wacs.Transpiler.AOT
         private static Invoker Build(Type delegateType)
         {
             // NativeAOT path — no Reflection.Emit, fall back to DynamicInvoke.
+            // Defense-in-depth: a transpiled module's ctor pre-registers a
+            // precompiled shim per delegate signature via RegisterShim
+            // (see ModuleClassGenerator.EmitTypedDelegateShimsAndRegister),
+            // so this path is normally cold under PublishAot. It only
+            // fires for delegate types the transpiler didn't see — e.g.,
+            // a host-side delegate handed to a third-party embedder
+            // calling GetOrBuild manually, or signatures where
+            // BuildDelegateType returned null (>16 params).
             if (!RuntimeFeature.IsDynamicCodeSupported)
                 return (del, args) => del.DynamicInvoke(args);
 


### PR DESCRIPTION
## Summary
PR #103 added Reflection.Emit fallbacks (`Delegate.DynamicInvoke` / `MethodInfo.Invoke`) so `wacs aot --wasi` binaries don't trip `PlatformNotSupportedException` at runtime under PublishAot. This goes one step further: the transpiler now emits per-signature static shim methods alongside the wasm-translated functions and registers them with the runtime caches from the Module ctor IL, so the AOT-published binary's `call_indirect` / `call_ref` paths are fully codegen-free at runtime. Two parallel changes in the same shape — one for the typed-delegate path (single-return), one for the multi-return path.

## What changed
- `TypedDelegateInvoker.RegisterShim(Type, Invoker)` — public API. `ModuleClassGenerator` walks `module.Types`, dedupes BCL `Func<...>`/`Action<...>` types via `CallEmitter.BuildDelegateType`, emits one `Functions.Shim_<n>(Delegate, object[]) -> object?` per unique signature (IL mirrors `TypedDelegateInvoker.Build`), and the ctor IL `Newobj`s an `Invoker` over each shim and calls `RegisterShim`. Coremark transpiles to 17 unique typed-delegate shims.
- `MultiReturnMethodRegistry.RegisterShim(int, int, MultiReturnInvoker)` — public API. The existing `MultiReturnMethodRegistry.Register` emit in `EmitFuncTablePopulation` is replaced with `EmitMultiReturnShimAndRegister`, which emits a per-funcIdx `Functions.MultiShim_<n>(ThinContext, object[]) -> object[]` (IL mirrors `MultiReturnMethodRegistry.BuildInvoker`). Legacy `Register` stays as public API for non-transpiler callers.

## Effect on the in-process JIT path and inter-module instantiation
- **In-process JIT**: improved, not regressed. Shims are regular IL methods on the dynamic assembly — JIT'd lazily on first call, same as any other transpiled function. The existing `DynamicMethod` builders become dead code for transpiled-module use but stay alive as a defensive fallback for any caller hitting `GetOrBuild` without a registered shim (e.g. an embedder that fabricates a Module without going through `ModuleClassGenerator`).
- **Inter-module instantiation**: single-return shims work cross-module by construction — they're keyed by CLR delegate Type, and `BuildDelegateType` reuses BCL `Func<...>`/`Action<...>` instantiations across modules. Multi-return registration remains keyed by `(initDataId, funcIdx)`; the existing routing question at `CallEmitter.cs:1043` is pre-existing and untouched by this PR.

## Verification
- With the `DynamicInvoke` fallback wired to throw, AOT coremark still completes successfully — confirms every `call_indirect` goes through a precompiled shim.
- `Wacs.Transpiler.Test` (730/730), `Spec.Test` (782/784, 2 pre-existing skips), `Wacs.WASI.Preview1.Test` (72/72), `Wacs.HostBindings.Test` (8/8) all green.
- 2 pre-existing failures in `Wacs.Compilation.Test.EndToEndTests.CallIndirect_dispatches_via_funcref_table` reproduce on `main` — they're in the source-generated `SwitchRuntime` dispatcher, unrelated to this work.
- Steady-state coremark stayed essentially flat (15,217 → 15,344 CoreMark/sec). The AOT-vs-JIT gap is dominated by NativeAOT codegen quality, not the dispatch wrapper, so the wins here are correctness (no `Reflection.Emit` at runtime) and removing the trim-warning surface, not throughput.

## Test plan
- [ ] Existing CI suites pass.
- [ ] CI smoke step (`AOT smoke test (wacs aot --wasi)` from PR #103) still passes.

## Follow-up
Phase 3 — drop the runtime `Reflection.Emit` builders and reflection fallbacks entirely once Phase 1+2 have proved out in production. Tracked separately.