### PR TITLE
Eliminate redundant Store[addr] lookup in indirect-call dispatch

### DIFF
--- a/Wacs.Core/Instructions/Control.cs
+++ b/Wacs.Core/Instructions/Control.cs
@@ -1137,7 +1137,7 @@ namespace Wacs.Core.Instructions
             if (!funcInst.Type.Matches(ftExpect.Unroll.Body, context.Frame.Module.Types))
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Expected FunctionType differed.");
             //19.
-            context.Invoke(a);
+            context.InvokeResolved(funcInst);
         }
 
         public override async ValueTask ExecuteAsync(ExecContext context)

--- a/Wacs.Core/Instructions/Reference/Control.cs
+++ b/Wacs.Core/Instructions/Reference/Control.cs
@@ -196,8 +196,8 @@ namespace Wacs.Core.Instructions.Reference
             var ftActual = funcInst.Type;
             if (!cachedFunctionType.Matches(ftActual, context.Frame.Module.Types))
                 throw new TrapException($"Instruction call_ref failed. Expected FunctionType differed.");
-            
-            context.Invoke(a);
+
+            context.InvokeResolved(funcInst);
         }
 
         public override async ValueTask ExecuteAsync(ExecContext context)

--- a/Wacs.Core/Runtime/ExecContext.cs
+++ b/Wacs.Core/Runtime/ExecContext.cs
@@ -488,10 +488,21 @@ namespace Wacs.Core.Runtime
             //1.
             Assert( Store.Contains(addr),
                 $"Failure in Function Invocation. Address does not exist {addr}");
-            
+
             //2.
-            var funcInst = Store[addr];
-            
+            InvokeResolved(Store[addr]);
+        }
+
+        /// <summary>
+        /// Hot-path overload for callers that have already resolved the
+        /// <see cref="IFunctionInstance"/> from the Store. Skips the
+        /// per-call Store[addr] lookup that <see cref="Invoke(FuncAddr)"/>
+        /// would otherwise repeat — call_indirect and call_ref both
+        /// already fetched the funcInst for their type-check, so they
+        /// shouldn't pay the lookup again on dispatch.
+        /// </summary>
+        public void InvokeResolved(IFunctionInstance funcInst)
+        {
             switch (funcInst)
             {
                 case FunctionInstance wasmFunc:


### PR DESCRIPTION
## Summary
Small code-quality fix carved from a larger perf-pass attempt. `call_indirect` and `call_ref` already resolve the target `IFunctionInstance` from the Store for their type-equality check, then call `ExecContext.Invoke(addr)` which re-fetches via `Store[addr]`. New `InvokeResolved(funcInst)` overload skips the redundant lookup; the polymorphic dispatch type-switch is preserved verbatim.

Direct call (`InstCall`) already caches `linkedFunctionInstance` at link time and bypasses `ExecContext.Invoke` entirely. The switch runtime (`ControlHandlers`) already dispatches directly through `InvokeWasm`. Both unchanged.

## Verification
- `Spec.Test` 782/784 (2 pre-existing skips)
- `Wacs.Transpiler.Test` 730/730
- Coremark poly + switch flat (within noise) — coremark's `call_indirect` volume isn't high enough for this to register on the headline number. The benefit lands on `call_indirect`-heavy workloads if any surface.

## Companion finding (separate from this PR — saved to memory)
This PR was originally scoped as a 4-item perf pass (#2/#3/#4/#5 from a speculative audit). Profiling coremark with `Wacs.OpProfile` showed the audit had targeted the wrong hotspots:

| Audit item | Theory | Actual coremark % |
|---|---|---|
| #2 OpStack.ShiftResults | "br/br_if hot" | regressed -4% poly when implemented (slow path rarely fires) |
| #4 Globals address-hop | "global-heavy hot" | **0%** — coremark uses no globals |
| #5 Memory bounds checks | "memory-heavy hot" | 7% combined (i32.load + load8_u + load16_*) — not on critical path |

Actual coremark hot path: **43.6% local.get/set/tee**, **16.1% i32.const**, **8% i32.add**, **6% br_if** — all dominated by per-op virtual `Execute(ctx)` dispatch (audit item #1, architectural). Lesson: profile first, then design. Future perf passes should pull `/tmp/opprofile.tsv` before walking source.

## Test plan
- [ ] CI runs Spec + Transpiler + WASI tests.