### PR TITLE
README: bump latest-releases versions, move below TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@
 
 ## Overview
 
-**Latest releases** (see the [CHANGELOG](CHANGELOG.md) for details):
-WACS `0.11.0` · WACS.Cli `1.2.0` · WACS.WASI.Preview1 `0.11.0` · WACS.HostBindings.Abstractions `0.1.0` · WACS.HostBindings.SourceGen `0.1.0` · WACS.Transpiler.Lib `0.6.0` · WACS.ComponentModel `0.1.0` · WACS.WASI.Preview2 `0.1.0` · WACS.WASI.Preview2.DependencyInjection `0.1.0` · WACS.ComponentModel.Bindgen.Lib `0.1.0` · WACS.WASI.Threads `0.1.0`
-
 > **Renaming notice (0.11.0):** the `WACS.WASIp1` package has been renamed to `WACS.WASI.Preview1` to make room for `WACS.WASI.Preview2` / `.Preview3` under one prefix. The old id still restores (it's now a metapackage) but emits a build-time warning. See [docs/MIGRATION_WASIp1_to_WASI.md](docs/MIGRATION_WASIp1_to_WASI.md) for the one-shot sed.
 
 > **CLI:** install the unified `wacs` global tool with
@@ -46,6 +43,9 @@ WACS supports the latest standardized webassembly feature extensions including *
 - [Performance](#performance)
 - [WebAssembly Text Format (WAT / WAST)](#webassembly-text-format-wat--wast)
 - [License](#license)
+
+**Latest releases** (see the [CHANGELOG](CHANGELOG.md) for details):
+WACS `0.12.1` · WACS.Cli `1.3.0` · WACS.WASI.Preview1 `0.12.0` · WACS.HostBindings.Abstractions `0.1.0` · WACS.HostBindings.SourceGen `0.1.0` · WACS.Transpiler.Lib `0.7.0` · WACS.ComponentModel `0.1.0` · WACS.WASI.Preview2 `0.1.0` · WACS.WASI.Preview2.DependencyInjection `0.1.0` · WACS.ComponentModel.Bindgen.Lib `0.1.0` · WACS.WASI.Threads `0.1.0`
 
 ## Features
 


### PR DESCRIPTION
Versions catch up to current csproj state: WACS 0.11.0→0.12.1, WACS.Cli 1.2.0→1.3.0, WACS.WASI.Preview1 0.11.0→0.12.0, WACS.Transpiler.Lib 0.6.0→0.7.0. Position the line below the Table of Contents so the overview reads as prose without the dense version block in front.