### PR TITLE
Fix flaky WASIp2 tests on CI: pin sequential xunit execution

### DIFF
--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/Wacs.WASI.Preview2.Test.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/Wacs.WASI.Preview2.Test.csproj
@@ -17,6 +17,21 @@
       <ProjectReference Include="..\Wacs.WASI.Preview2.DependencyInjection\Wacs.WASI.Preview2.DependencyInjection.csproj" />
     </ItemGroup>
 
+    <!-- Component-instantiation tests share process-wide
+         BinaryModuleParser / SpecFactory / WasmRuntime static
+         state that's not parallel-safe — same flake the
+         Wacs.Core.Test and Wacs.ComponentModel.Test projects
+         document. Linux CI surfaced it as 105/189 sporadic
+         failures with empty instruction lists from
+         InstructionSequence.ctor; xunit.runner.json disables
+         collection parallelism, which Spec.Test + Core.Test
+         use for the same reason. -->
+    <ItemGroup>
+        <None Include="xunit.runner.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/xunit.runner.json
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## Summary

The CI run for #113's merge surfaced **105/189 failures in `Wacs.WASI.Preview2.Test` on Linux** — every one a parser-stage `InvalidOperationException: Sequence contains no elements` at `InstructionSequence.ctor`'s `_instructions.Last()`, with stack traces bottoming out at `ComponentInstance.InstantiateMultiCore` → `BinaryModuleParser.ParseWasm`.

Same shape as the documented parallelism flake on `Wacs.Core.Test` and `Wacs.ComponentModel.Test`: `BinaryModuleParser` / `SpecFactory` / `WasmRuntime` carry process-wide static state that's not parallel-safe when concurrent test threads instantiate components. Linux CI on commit `2024ef20` lost the scheduling race; PR #112's run happened to win it (the same step there reported 189/189).

## Fix

Add a `xunit.runner.json` to `Wacs.WASI.Preview2.Test` with `parallelizeTestCollections: false` — matches the existing config in:
- `Spec.Test/xunit.runner.json`
- `Wacs.Core/Wacs.Core.Test/xunit.runner.json`

Wired through the csproj as `CopyToOutputDirectory="Always"` so the runner picks it up next to the test dll.

## Test plan

- [x] `Wacs.WASI.Preview2.Test` runs **189/189** locally with the config in place.
- [x] Solution still builds clean (`dotnet build -c Release WACS.sln`).
- [x] CI green on `ubuntu-latest`.

## Long-term

Removing the static state from the parser + runtime altogether is the proper fix and would let every suite parallelize. This PR is the surgical CI-stabilizer matching what the other affected suites already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)