### PR TITLE
Round 2: version-tolerant import resolution + diagnostics + exit-code guard

### DIFF
--- a/Wacs.Console/Wacs.Console/Program.cs
+++ b/Wacs.Console/Wacs.Console/Program.cs
@@ -42,6 +42,28 @@ namespace Wacs.Console
 
         static int Main(string[] args)
         {
+            try
+            {
+                return Dispatch(args);
+            }
+            catch (Exception ex)
+            {
+                // Fall-through guard: any verb handler that lets an
+                // exception escape (typically a transpile-time
+                // failure or a host-binding misconfiguration) gets
+                // a non-zero exit code instead of the .NET runtime's
+                // default exit-0-with-stack-trace behavior. Without
+                // this, scripted callers couldn't distinguish a
+                // crashed wacs from a successful run.
+                System.Console.Error.WriteLine(
+                    "error: unhandled exception: " + ex.GetType().FullName);
+                System.Console.Error.WriteLine(ex);
+                return 1;
+            }
+        }
+
+        private static int Dispatch(string[] args)
+        {
             // Direct-run shortcut: if argv[0] looks like a wasm/wat
             // path (and isn't a verb keyword), prepend `run`.
             //   wacs my.wasm                    → wacs run my.wasm

--- a/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
+++ b/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
@@ -603,8 +603,19 @@ namespace Wacs.Console.Verbs
             }
             catch (Exception ex)
             {
+                // Unwrap reflection-invoke wrappers so the diagnostic
+                // surfaces the actual cause (an unbound import, a
+                // canonical-ABI mismatch, etc.) instead of the
+                // useless "Exception has been thrown by the target
+                // of an invocation." outer message.
+                var inner = ex;
+                while (inner is System.Reflection.TargetInvocationException tie
+                       && tie.InnerException != null)
+                    inner = tie.InnerException;
                 System.Console.Error.WriteLine(
-                    $"error: component run failed: {ex.Message}");
+                    $"error: component run failed: {inner.Message}");
+                if (opts.Verbose)
+                    System.Console.Error.WriteLine(inner);
                 return 1;
             }
         }

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/HostPackageResolver.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/HostPackageResolver.cs
@@ -95,6 +95,18 @@ namespace Wacs.Transpiler.AOT.Component
 
         private readonly Dictionary<(string Module, string Entity), Binding>
             _bindings;
+        // Parallel index keyed by (module-without-@version, entity).
+        // Lets WASI guests built against a newer point release of the
+        // spec (e.g. wasi:io/error@0.2.6) resolve against a host
+        // package shipping an older one (wasi:io/error@0.2.3) — the
+        // wasm Component Model treats minor revisions of WASI as
+        // ABI-stable, so wasmtime / jco / wasmer all do the same
+        // version-tolerant match. Exact lookup wins; stripped is a
+        // fallback so a component declaring a specific version
+        // still binds to the matching host first when both are
+        // registered.
+        private readonly Dictionary<(string Module, string Entity), Binding>
+            _bindingsByStrippedModule;
         private readonly HashSet<Type> _resourceInterfaceTypes;
 
         private HostPackageResolver(
@@ -107,6 +119,7 @@ namespace Wacs.Transpiler.AOT.Component
         {
             HostPackages = hostPackages;
             _bindings = bindings;
+            _bindingsByStrippedModule = BuildStrippedIndex(bindings);
             InterfaceTypes = interfaceTypes;
             _resourceInterfaceTypes = resourceInterfaceTypes;
             ResourceInterfaceTypes = resourceInterfaceTypes;
@@ -117,7 +130,51 @@ namespace Wacs.Transpiler.AOT.Component
         public bool TryResolve(string module, string entity,
             out Binding binding)
         {
-            return _bindings.TryGetValue((module, entity), out binding!);
+            // Exact (module-with-@version, entity) match first.
+            if (_bindings.TryGetValue((module, entity), out binding!))
+                return true;
+            // Version-tolerant fallback: strip the trailing
+            // @<version> from the requested module and look up
+            // again. Honors wasm Component Model's stability
+            // contract for WASI minor revisions — the same
+            // (interface, function) is ABI-equivalent across patch
+            // versions of WASI 0.2.x.
+            string stripped = StripVersion(module);
+            if (stripped.Length != module.Length
+                && _bindingsByStrippedModule.TryGetValue(
+                    (stripped, entity), out binding!))
+                return true;
+            return false;
+        }
+
+        // Strip a trailing `@<version>` from a wire module string.
+        // The version is everything after the last `@` — wasm
+        // Component Model wire modules are `<ns>:<pkg>/<iface>@<ver>`,
+        // single `@`, no `@` inside any segment.
+        private static string StripVersion(string module)
+        {
+            int at = module.LastIndexOf('@');
+            return at < 0 ? module : module.Substring(0, at);
+        }
+
+        // Build the secondary lookup index. Multiple bindings sharing
+        // the same (stripped-module, entity) — e.g. when a host
+        // assembly registers both 0.2.3 and 0.2.6 versions of the
+        // same interface — collapse to the first registration; the
+        // exact-match path catches the other.
+        private static Dictionary<(string, string), Binding>
+            BuildStrippedIndex(
+                Dictionary<(string Module, string Entity), Binding> src)
+        {
+            var dst = new Dictionary<(string, string), Binding>(src.Count);
+            foreach (var kv in src)
+            {
+                var stripped = StripVersion(kv.Key.Module);
+                if (stripped.Length == kv.Key.Module.Length) continue;
+                var k = (stripped, kv.Key.Entity);
+                if (!dst.ContainsKey(k)) dst[k] = kv.Value;
+            }
+            return dst;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Closes round-2 issues 6, 7, and 8 from `wasi-nn/WACS-GAPS.md` —
follow-ups that surfaced once the round-1 PR (#118) merged and we
re-ran against modern Rust toolchains.

- **Version-tolerant import resolver** (issues 6 + 7) —
  `HostPackageResolver.TryResolve` now falls back to a
  stripped-version match when the exact `(module-with-@version,
  entity)` lookup misses. WASI minor revisions (`@0.2.3` ↔ `@0.2.6`
  ↔ `@0.2.9`) are ABI-stable per the wasm Component Model; wasmtime,
  jco, and wasmer all do the same fuzzy match. Exact match still
  wins so a component declaring a specific version still binds to
  a matching host first when both are registered. **Concrete impact:**
  a stock 30-line `println!("hello")` `cargo build --target
  wasm32-wasip2` binary now actually prints to stdout/stderr — the
  `wasi:cli/stdout@0.2.6` import that Rust 1.95.0 emits no longer
  trap-stubs against WACS's `@0.2.3` registration.
- **Top-level unhandled-exception guard** (issue 8) — `Program.Main`
  now wraps the verb dispatcher in a `try/catch` that returns 1 on
  fall-through. Previously an unhandled .NET exception (transpile-
  time failure, host-binding misconfiguration, etc.) printed the
  stack to stderr but the process exit code stayed 0, so scripted
  callers couldn't distinguish a crashed `wacs` from a successful
  run. Verb handlers' own catch blocks still get first crack — they
  return their own exit codes for known shapes (`ExitException` →
  guest's code, `TrapException` → 1 with the trap message).
- **Component-path catch unwraps `TargetInvocationException`** —
  `ExecuteComponentTranspiled`'s `catch (Exception ex)` now walks
  through reflection-invoke wrappers so the diagnostic surfaces the
  actual cause (a `TrapException`, a missing import, etc.) instead
  of the useless `"Exception has been thrown by the target of an
  invocation."` outer message. Verbose mode now also prints the
  full inner stack.

## Test plan

- [x] `dotnet test Wacs.ComponentModel.Test` — 347 passed
- [x] `dotnet test Wacs.WASI.NN.Test` — 18 passed
- [x] Reduced reproducer from the gap report (`hello-p2.wasm` with
      `println!` + `eprintln!`):
      `wacs run hello-p2.wasm --wasip2` now prints both lines and
      exits 0 (was: silent, exit=0 with imports trap-stubbed).
- [x] Issue 8 reproducer (`wasi-nn-slm.wasm --wasi-nn` without
      `--wasip2`): now exits 1 with `error: unhandled exception:
      System.NotSupportedException` prefix (was: exit=0 with
      stack trace alone).

## Open follow-up

- `std::process::exit(N)` from wasi-p2 Rust still reports
  `wasm trap: unreachable` from the guest's stdlib cleanup path
  (deep in Rust's pre-exit Drop chain, not from `exit-with-code`
  itself — that import resolves and throws `ExitException`
  correctly under the version-tolerant fallback). Worth a separate
  investigation; not in the gap report's round-2 enumeration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)