### PR TITLE
WASI 0.2.8 bump + Wacs.Core version-tolerant GetBoundEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [WACS.WASI.Preview2 0.3.0] — Bundled WIT bumped to WASI 0.2.8
+
+Refreshes the vendored WIT tree under `Wacs.WASI.Preview2/wit/`
+from upstream `WebAssembly/wasi-cli@v0.2.8` (latest stable patch,
+released after v0.2.3 with zero ABI changes — only doc clarifications
+and version-string bumps in `use` clauses). All hardcoded
+`wasi:*@0.2.3` strings in the per-subsystem `*Bindings.cs` files
+update in lockstep.
+
+The 0.2.3 → 0.2.8 delta is purely cosmetic at the wire level — the
+Component Model spec stabilizes minor revisions of WASI, so guests
+compiled against any 0.2.x version bind to this version-tolerantly.
+What changes: the version annotation in error messages, the strings
+`wacs inspect --imports` reports, and the canonical `[WitSource]`
+package identity the source-gen emits.
+
+The `Spec.Test/components/wasi-cli` submodule and the test fixtures
+under `Spec.Test/components/fixtures/` stay pinned at v0.2.3 — they
+exercise the loader/emitter against a specific frozen version. The
+two coordinates are deliberately decoupled.
+
+## [WACS.Core 0.12.2] — Version-tolerant GetBoundEntity
+
+Mirrors PR #119's `HostPackageResolver.TryResolve` fallback for the
+interpreter path: when an exact `(module, entity)` lookup misses,
+strip the trailing `@<version>` and try again, then fall back to an
+O(n) scan over all keys for any matching the same stripped module
++ entity. Lets guests built against newer WASI patch revisions
+bind to host packages registered against older ones (or vice
+versa), since wasm Component Model treats minor revisions of WASI
+as ABI-stable.
+
 ## [WACS.ComponentModel 0.2.0] — WIT parser accepts pre-release semver tags
 
 `WitLexer` now emits dedicated `Dash` and `Plus` tokens (only when

--- a/Wacs.ComponentModel/Wacs.ComponentModel.Test/CSharpEmitterTests.cs
+++ b/Wacs.ComponentModel/Wacs.ComponentModel.Test/CSharpEmitterTests.cs
@@ -1245,6 +1245,11 @@ world w { export def; }";
             // All should merge into a single wasi:cli package with
             // every interface visible.
             var cli = Assert.Single(packages);
+            // Tracks the wasi-cli submodule pinned in
+            // Spec.Test/components/wasi-cli (currently v0.2.3).
+            // The runtime-side Wacs.WASI.Preview2 ships @0.2.8 WIT
+            // separately; this test exercises the WIT loader
+            // against the submodule fixture.
             Assert.Equal("wasi:cli@0.2.3", cli.Name.ToString());
             Assert.Contains(cli.Interfaces, i => i.Name == "run");
             Assert.Contains(cli.Interfaces, i => i.Name == "environment");
@@ -1271,6 +1276,10 @@ world w { export def; }";
             var packages = WitLoader.LoadDirectoryTree(witDir);
 
             var names = packages.Select(p => p.Name.ToString()).ToArray();
+            // Tracks the wasi-cli submodule pinned at v0.2.3 (see
+            // WitLoader_merges_headerless_files_into_named_package
+            // for the rationale on why the submodule and the
+            // runtime-shipped @0.2.8 WIT diverge).
             Assert.Contains("wasi:cli@0.2.3", names);
             Assert.Contains("wasi:io@0.2.3", names);
             Assert.Contains("wasi:clocks@0.2.3", names);

--- a/Wacs.ComponentModel/Wacs.ComponentModel.Test/WitResolverTests.cs
+++ b/Wacs.ComponentModel/Wacs.ComponentModel.Test/WitResolverTests.cs
@@ -106,14 +106,14 @@ namespace Wacs.ComponentModel.Test
         public void Versioned_ref_matches_exact_version_string()
         {
             var providerSrc = @"
-                package wasi:io@0.2.3;
+                package wasi:io@0.2.8;
                 interface streams {
                     dummy: func() -> u32;
                 }";
             var consumerSrc = @"
                 package local:consumer;
                 world app {
-                    import wasi:io/streams@0.2.3;
+                    import wasi:io/streams@0.2.8;
                 }";
             var packages = new List<CtPackage>();
             packages.AddRange(ParseAndConvert(providerSrc));
@@ -132,7 +132,7 @@ namespace Wacs.ComponentModel.Test
             // 0.x versions are exact-match per the scope plan. 0.2.2
             // consumer can't bind to 0.2.3 provider.
             var providerSrc = @"
-                package wasi:io@0.2.3;
+                package wasi:io@0.2.8;
                 interface streams { dummy: func() -> u32; }";
             var consumerSrc = @"
                 package local:consumer;
@@ -164,7 +164,7 @@ namespace Wacs.ComponentModel.Test
         {
             // End-to-end: parse hello.wit + wasi-cli/run.wit from the
             // submodule, build the package set, resolve. The export
-            // `wasi:cli/run@0.2.3` ref on hello's world should bind
+            // `wasi:cli/run@0.2.8` ref on hello's world should bind
             // to wasi-cli's run interface.
             var root = FindSubmoduleRoot();
             var helloWit = File.ReadAllText(Path.Combine(root,

--- a/Wacs.ComponentModel/Wacs.ComponentModel.Test/WitToTypesTests.cs
+++ b/Wacs.ComponentModel/Wacs.ComponentModel.Test/WitToTypesTests.cs
@@ -305,7 +305,7 @@ namespace Wacs.ComponentModel.Test
             var pkgs = Convert(@"
                 package test:pkg;
                 world app {
-                    import wasi:io/streams@0.2.3;
+                    import wasi:io/streams@0.2.8;
                 }");
             var w = pkgs[0].Worlds[0];
             var imp = Assert.Single(w.Imports);
@@ -313,7 +313,7 @@ namespace Wacs.ComponentModel.Test
             Assert.NotNull(iref.Package);
             Assert.Equal("wasi", iref.Package!.Namespace);
             Assert.Equal("streams", iref.InterfaceName);
-            Assert.Equal("0.2.3", iref.Package.Version);
+            Assert.Equal("0.2.8", iref.Package.Version);
         }
 
         // ---- Fixture smoke tests over WASI 0.2.3 ---------------------------
@@ -399,6 +399,8 @@ namespace Wacs.ComponentModel.Test
 
             var pkgs = WitToTypes.Convert(WitParser.Parse(src));
             var pkg = Assert.Single(pkgs);
+            // Asserts the version pinned in
+            // Spec.Test/components/wasi-cli (currently v0.2.3).
             Assert.Equal("wasi:io@0.2.3", pkg.Name.ToString());
 
             var streams = Assert.Single(pkg.Interfaces);

--- a/Wacs.Core/Wacs.Core/Runtime/WasmRuntimeBinding.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/WasmRuntimeBinding.cs
@@ -338,8 +338,50 @@ namespace Wacs.Core.Runtime
             GetExecContext().Store.ReplaceFunction(addr, replacement);
         }
 
-        private IAddress? GetBoundEntity((string module, string entity) id) =>
-            _entityBindings.GetValueOrDefault(id);
+        private IAddress? GetBoundEntity((string module, string entity) id)
+        {
+            if (_entityBindings.TryGetValue(id, out var direct))
+                return direct;
+
+            // Version-tolerant fallback: when the lookup misses,
+            // try with the trailing `@<version>` stripped from the
+            // module string. The wasm Component Model treats minor
+            // revisions of WASI as ABI-stable, so a guest built
+            // against `wasi:cli/stdout@0.2.6` should bind to a host
+            // package shipping `@0.2.8` — same shape, ABI-equivalent.
+            // wasmtime / jco / wasmer do the same fuzzy match.
+            //
+            // Stripped entries land in the same dict keyed by the
+            // stripped module name when BindHostFunction sees an
+            // `@<version>` suffix; this is a fallback when only one
+            // side carries the version annotation.
+            int at = id.module.LastIndexOf('@');
+            if (at < 0) return null;
+            string stripped = id.module.Substring(0, at);
+
+            // Try the stripped lookup directly (matches when host
+            // bound under the un-versioned name).
+            if (_entityBindings.TryGetValue((stripped, id.entity),
+                    out var strippedHit))
+                return strippedHit;
+
+            // Final pass: the host bound under a DIFFERENT
+            // @<version>. Scan keys for any that strip to the same
+            // module + match the entity. O(n) on miss only; the
+            // typical bound entity count is in the hundreds and
+            // this branch fires at most once per failed import.
+            foreach (var kv in _entityBindings)
+            {
+                if (kv.Key.Item2 != id.entity) continue;
+                int kvAt = kv.Key.Item1.LastIndexOf('@');
+                if (kvAt < 0) continue;
+                if (string.CompareOrdinal(
+                        kv.Key.Item1, 0, stripped, 0, stripped.Length) == 0
+                    && kvAt == stripped.Length)
+                    return kv.Value;
+            }
+            return null;
+        }
 
         /// <summary>
         /// Enumerate every <c>(module, entity)</c> import currently

--- a/Wacs.Core/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.12.1</AssemblyVersion>
-    <Version>0.12.1</Version>
+    <AssemblyVersion>0.12.2</AssemblyVersion>
+    <Version>0.12.2</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter. v0.12 brings the in-process WAT/WAST parser to full parity with the binary parser — every wast in the WebAssembly spec testsuite (SIMD, GC, relaxed-SIMD, hex-float edge cases) round-trips identically through both pipelines, dropping the wasm-tools / wast2json CI dependency. v0.12.1 tracks the wasm-3.0 spec submodule to tip d7aada5: inclusive memory page-count limit (PRs #105/#106/#108), tail-call to imported host functions (PR #1872), `array.new_data` bounds (PR #1881), malformed memop reserved bits (PRs #1886/#1936), table64 u64 limits (PR #104), `(module definition …)` validate-only support, u32 offset enforcement on memory32, and `;;` line-comment CR termination.</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/Wacs.Transpiler/Wacs.Transpiler.Test/WasiPreview2BundleResolverTests.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Test/WasiPreview2BundleResolverTests.cs
@@ -59,25 +59,25 @@ namespace Wacs.Transpiler.Test
             // one must resolve to a concrete typed-method binding;
             // any miss means a guest can't direct-link that import.
             AssertResolves(resolver,
-                "wasi:random/random@0.2.3", "get-random-u64");
+                "wasi:random/random@0.2.8", "get-random-u64");
             AssertResolves(resolver,
-                "wasi:cli/exit@0.2.3", "exit-with-code");
+                "wasi:cli/exit@0.2.8", "exit-with-code");
             AssertResolves(resolver,
-                "wasi:clocks/monotonic-clock@0.2.3", "now");
+                "wasi:clocks/monotonic-clock@0.2.8", "now");
             AssertResolves(resolver,
-                "wasi:cli/stdout@0.2.3", "get-stdout");
+                "wasi:cli/stdout@0.2.8", "get-stdout");
 
             // Resource methods on stream resources — the canonical
             // WASI write pattern.
             AssertResolves(resolver,
-                "wasi:io/streams@0.2.3", "[method]output-stream.write");
+                "wasi:io/streams@0.2.8", "[method]output-stream.write");
             AssertResolves(resolver,
-                "wasi:io/streams@0.2.3",
+                "wasi:io/streams@0.2.8",
                 "[method]output-stream.blocking-write-and-flush");
 
             // Resource constructor — exercises the kind detection.
             AssertResolves(resolver,
-                "wasi:http/types@0.2.3", "[constructor]fields");
+                "wasi:http/types@0.2.8", "[constructor]fields");
         }
 
         private static void AssertResolves(HostPackageResolver r,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/DependencyInjectionTests.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/DependencyInjectionTests.cs
@@ -82,15 +82,15 @@ namespace Wacs.WASI.Preview2.Test
             // the linker's tracked binding set.
             var bindings = linker.Bindings;
             Assert.Contains(bindings, b =>
-                b.Module == "wasi:cli/exit@0.2.3");
+                b.Module == "wasi:cli/exit@0.2.8");
             Assert.Contains(bindings, b =>
-                b.Module == "wasi:random/random@0.2.3");
+                b.Module == "wasi:random/random@0.2.8");
             Assert.Contains(bindings, b =>
-                b.Module == "wasi:io/streams@0.2.3");
+                b.Module == "wasi:io/streams@0.2.8");
             Assert.Contains(bindings, b =>
-                b.Module == "wasi:http/types@0.2.3");
+                b.Module == "wasi:http/types@0.2.8");
             Assert.Contains(bindings, b =>
-                b.Module == "wasi:sockets/tcp@0.2.3");
+                b.Module == "wasi:sockets/tcp@0.2.8");
         }
 
         // ---------- Selective override -------------------------
@@ -163,15 +163,15 @@ namespace Wacs.WASI.Preview2.Test
             // canonical entries — exact-arity matching is
             // a separate concern.
             Assert.DoesNotContain(report.Issues, i =>
-                i.Module == "wasi:io/streams@0.2.3"
+                i.Module == "wasi:io/streams@0.2.8"
                 && i.Entity == "[method]input-stream.read"
                 && i.Kind == ValidationIssueKind.MissingBinding);
             Assert.DoesNotContain(report.Issues, i =>
-                i.Module == "wasi:random/random@0.2.3"
+                i.Module == "wasi:random/random@0.2.8"
                 && i.Entity == "get-random-bytes"
                 && i.Kind == ValidationIssueKind.MissingBinding);
             Assert.DoesNotContain(report.Issues, i =>
-                i.Module == "wasi:http/types@0.2.3"
+                i.Module == "wasi:http/types@0.2.8"
                 && i.Entity == "[constructor]fields"
                 && i.Kind == ValidationIssueKind.MissingBinding);
         }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/HelloWorldTests.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/HelloWorldTests.cs
@@ -65,8 +65,8 @@ namespace Wacs.WASI.Preview2.Test
         public void Hello_world_writes_through_stdout_chain()
         {
             // Component:
-            //   import wasi:cli/stdout@0.2.3;
-            //   import wasi:io/streams@0.2.3;
+            //   import wasi:cli/stdout@0.2.8;
+            //   import wasi:io/streams@0.2.8;
             //   export greet: func();
             // greet() calls stdout.get-stdout() → handle,
             // streams.[method]output-stream.blocking-write-and-flush(handle, "hello\n"),

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/ValidationTests.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/ValidationTests.cs
@@ -49,7 +49,7 @@ namespace Wacs.WASI.Preview2.Test
             // wasi:random/random has 2 free functions:
             // get-random-bytes, get-random-u64.
             var randomKeys = linker.Bindings
-                .Where(b => b.Module == "wasi:random/random@0.2.3")
+                .Where(b => b.Module == "wasi:random/random@0.2.8")
                 .Select(b => b.Entity)
                 .ToHashSet();
             Assert.Contains("get-random-bytes", randomKeys);
@@ -66,7 +66,7 @@ namespace Wacs.WASI.Preview2.Test
             // Don't bind anything; the contract requires
             // wasi:random/random imports — but Off skips checks.
             var contract = WitContract.FromText(@"
-                package wasi:random@0.2.3;
+                package wasi:random@0.2.8;
                 interface random {
                     get-random-bytes: func(len: u64) -> list<u8>;
                 }
@@ -84,7 +84,7 @@ namespace Wacs.WASI.Preview2.Test
             var linker = new Linker(runtime, ValidationLevel.Warnings);
             // No bindings registered; contract demands one.
             var contract = WitContract.FromText(@"
-                package wasi:random@0.2.3;
+                package wasi:random@0.2.8;
                 interface random {
                     get-random-bytes: func(len: u64) -> list<u8>;
                     get-random-u64: func() -> u64;
@@ -106,7 +106,7 @@ namespace Wacs.WASI.Preview2.Test
             linker.Bind(new RandomBindings(new Random.Random()));
 
             var contract = WitContract.FromText(@"
-                package wasi:random@0.2.3;
+                package wasi:random@0.2.8;
                 interface random {
                     get-random-bytes: func(len: u64) -> list<u8>;
                     get-random-u64: func() -> u64;
@@ -126,7 +126,7 @@ namespace Wacs.WASI.Preview2.Test
             var linker = new Linker(runtime, ValidationLevel.Strict);
 
             var contract = WitContract.FromText(@"
-                package wasi:random@0.2.3;
+                package wasi:random@0.2.8;
                 interface random {
                     get-random-bytes: func(len: u64) -> list<u8>;
                 }
@@ -247,7 +247,7 @@ namespace Wacs.WASI.Preview2.Test
             Assert.False(report.IsClean);
             Assert.Contains(report.Issues, i =>
                 i.Kind == ValidationIssueKind.MissingBinding
-                && i.Module == "wasi:random/random@0.2.3"
+                && i.Module == "wasi:random/random@0.2.8"
                 && i.Entity == "get-random-bytes");
         }
 
@@ -265,9 +265,9 @@ namespace Wacs.WASI.Preview2.Test
             var packages = WitContract.LoadAssemblyPackages(asm);
 
             var importsContract = WitContract.FromWorld(packages,
-                "wasi:cli/imports@0.2.3");
+                "wasi:cli/imports@0.2.8");
             var commandContract = WitContract.FromWorld(packages,
-                "wasi:cli/command@0.2.3");
+                "wasi:cli/command@0.2.8");
 
             // Both worlds should pull in CLI + clocks + io +
             // random + sockets + filesystem imports.
@@ -277,11 +277,11 @@ namespace Wacs.WASI.Preview2.Test
                 var modules = c.Imports.Select(i => i.Module)
                     .Distinct().ToList();
                 Assert.Contains(modules, m =>
-                    m == "wasi:cli/environment@0.2.3");
+                    m == "wasi:cli/environment@0.2.8");
                 Assert.Contains(modules, m =>
-                    m == "wasi:io/streams@0.2.3");
+                    m == "wasi:io/streams@0.2.8");
                 Assert.Contains(modules, m =>
-                    m == "wasi:filesystem/types@0.2.3");
+                    m == "wasi:filesystem/types@0.2.8");
             }
 
             // Neither contract should include guest-export
@@ -291,7 +291,7 @@ namespace Wacs.WASI.Preview2.Test
                 commandContract })
             {
                 Assert.DoesNotContain(c.Imports, i =>
-                    i.Module == "wasi:cli/run@0.2.3");
+                    i.Module == "wasi:cli/run@0.2.8");
             }
         }
 
@@ -324,7 +324,7 @@ namespace Wacs.WASI.Preview2.Test
                 .Assembly;
             var contract = WitContract.FromAssembly(asm);
             Assert.DoesNotContain(contract.Imports, i =>
-                i.Module == "wasi:cli/run@0.2.3");
+                i.Module == "wasi:cli/run@0.2.8");
         }
 
         [Fact]
@@ -366,7 +366,7 @@ namespace Wacs.WASI.Preview2.Test
             var packages = WitContract.LoadAssemblyPackages(
                 typeof(Wacs.WASI.Preview2.Cli.CliBindings).Assembly);
             var contract = WitContract.FromWorld(packages,
-                "wasi:cli/imports@0.2.3");
+                "wasi:cli/imports@0.2.8");
 
             // Validate; cli/imports world's bindings should
             // all be present even if some arity-mismatch noise

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Cli/CliBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Cli/CliBindings.cs
@@ -84,7 +84,7 @@ namespace Wacs.WASI.Preview2.Cli
             {
                 var t = _resources.Table<TerminalInput>();
                 runtime.BindHostFunction<Action<ExecContext, int>>(
-                    ("wasi:cli/terminal-input@0.2.3",
+                    ("wasi:cli/terminal-input@0.2.8",
                      "[resource-drop]terminal-input"),
                     (_, h) => t.Drop(h));
             }
@@ -92,20 +92,20 @@ namespace Wacs.WASI.Preview2.Cli
             {
                 var t = _resources.Table<TerminalOutput>();
                 runtime.BindHostFunction<Action<ExecContext, int>>(
-                    ("wasi:cli/terminal-output@0.2.3",
+                    ("wasi:cli/terminal-output@0.2.8",
                      "[resource-drop]terminal-output"),
                     (_, h) => t.Drop(h));
             }
         }
 
-        // wasi:cli/environment@0.2.3
+        // wasi:cli/environment@0.2.8
         //   get-environment: func() -> list<tuple<string, string>>
         //   get-arguments: func() -> list<string>
         //   initial-cwd: func() -> option<string>
         private static void BindEnvironment(WasmRuntime runtime,
             Realloc alloc, IEnvironment impl)
         {
-            const string ns = "wasi:cli/environment@0.2.3";
+            const string ns = "wasi:cli/environment@0.2.8";
 
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ns, "get-arguments"),
@@ -138,13 +138,13 @@ namespace Wacs.WASI.Preview2.Cli
                 });
         }
 
-        // wasi:cli/exit@0.2.3
+        // wasi:cli/exit@0.2.8
         //   exit: func(status: result)        ; result<_,_> flat → 1 i32
         //   exit-with-code: func(status-code: u8) ; u8 widens to i32
         // Both diverge — the impl typically throws ExitException.
         private static void BindExit(WasmRuntime runtime, IExit impl)
         {
-            const string ns = "wasi:cli/exit@0.2.3";
+            const string ns = "wasi:cli/exit@0.2.8";
 
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ns, "exit"),
@@ -163,40 +163,40 @@ namespace Wacs.WASI.Preview2.Cli
                 (_, code) => impl.ExitWithCode((byte)code));
         }
 
-        // wasi:cli/stdin@0.2.3 — get-stdin: func() -> own<input-stream>
+        // wasi:cli/stdin@0.2.8 — get-stdin: func() -> own<input-stream>
         private static void BindStdin(WasmRuntime runtime,
             ResourceContext resources, IStdin impl)
         {
-            const string ns = "wasi:cli/stdin@0.2.3";
+            const string ns = "wasi:cli/stdin@0.2.8";
             var streams = resources.Table<InputStream>();
             runtime.BindHostFunction<Func<ExecContext, int>>(
                 (ns, "get-stdin"),
                 _ => streams.Allocate(impl.GetStdin()));
         }
 
-        // wasi:cli/stdout@0.2.3 — get-stdout: func() -> own<output-stream>
+        // wasi:cli/stdout@0.2.8 — get-stdout: func() -> own<output-stream>
         private static void BindStdout(WasmRuntime runtime,
             ResourceContext resources, IStdout impl)
         {
-            const string ns = "wasi:cli/stdout@0.2.3";
+            const string ns = "wasi:cli/stdout@0.2.8";
             var streams = resources.Table<OutputStream>();
             runtime.BindHostFunction<Func<ExecContext, int>>(
                 (ns, "get-stdout"),
                 _ => streams.Allocate(impl.GetStdout()));
         }
 
-        // wasi:cli/stderr@0.2.3 — get-stderr: func() -> own<output-stream>
+        // wasi:cli/stderr@0.2.8 — get-stderr: func() -> own<output-stream>
         private static void BindStderr(WasmRuntime runtime,
             ResourceContext resources, IStderr impl)
         {
-            const string ns = "wasi:cli/stderr@0.2.3";
+            const string ns = "wasi:cli/stderr@0.2.8";
             var streams = resources.Table<OutputStream>();
             runtime.BindHostFunction<Func<ExecContext, int>>(
                 (ns, "get-stderr"),
                 _ => streams.Allocate(impl.GetStderr()));
         }
 
-        // wasi:cli/terminal-stdin@0.2.3
+        // wasi:cli/terminal-stdin@0.2.8
         //   get-terminal-stdin: func() -> option<own<terminal-input>>
         // retArea: 8 bytes — disc(u8) + 3 pad + handle(i32).
         // Generated impl returns Option<ITerminalInput> — TryGet
@@ -204,7 +204,7 @@ namespace Wacs.WASI.Preview2.Cli
         private static void BindTerminalStdin(WasmRuntime runtime,
             ResourceContext resources, ITerminalStdin impl)
         {
-            const string ns = "wasi:cli/terminal-stdin@0.2.3";
+            const string ns = "wasi:cli/terminal-stdin@0.2.8";
             var t = resources.Table<TerminalInput>();
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ns, "get-terminal-stdin"),
@@ -219,7 +219,7 @@ namespace Wacs.WASI.Preview2.Cli
         private static void BindTerminalStdout(WasmRuntime runtime,
             ResourceContext resources, ITerminalStdout impl)
         {
-            const string ns = "wasi:cli/terminal-stdout@0.2.3";
+            const string ns = "wasi:cli/terminal-stdout@0.2.8";
             var t = resources.Table<TerminalOutput>();
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ns, "get-terminal-stdout"),
@@ -234,7 +234,7 @@ namespace Wacs.WASI.Preview2.Cli
         private static void BindTerminalStderr(WasmRuntime runtime,
             ResourceContext resources, ITerminalStderr impl)
         {
-            const string ns = "wasi:cli/terminal-stderr@0.2.3";
+            const string ns = "wasi:cli/terminal-stderr@0.2.8";
             var t = resources.Table<TerminalOutput>();
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ns, "get-terminal-stderr"),

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Clocks/ClockBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Clocks/ClockBindings.cs
@@ -50,7 +50,7 @@ namespace Wacs.WASI.Preview2.Clocks
                 BindTimezone(runtime, _timezone);
         }
 
-        // wasi:clocks/monotonic-clock@0.2.3
+        // wasi:clocks/monotonic-clock@0.2.8
         //   now: func() -> instant            (u64)
         //   resolution: func() -> duration    (u64)
         //   subscribe-instant: func(when: instant) -> own<pollable>
@@ -58,7 +58,7 @@ namespace Wacs.WASI.Preview2.Clocks
         private static void BindMonotonicClock(WasmRuntime runtime,
             ResourceContext resources, IMonotonicClock impl)
         {
-            const string ns = "wasi:clocks/monotonic-clock@0.2.3";
+            const string ns = "wasi:clocks/monotonic-clock@0.2.8";
             var pollables = resources.Table<Pollable>();
 
             runtime.BindHostFunction<Func<ExecContext, long>>(
@@ -80,7 +80,7 @@ namespace Wacs.WASI.Preview2.Clocks
                     pollables.Allocate(impl.SubscribeDuration((ulong)when)));
         }
 
-        // wasi:clocks/wall-clock@0.2.3
+        // wasi:clocks/wall-clock@0.2.8
         //   record datetime { seconds: u64, nanoseconds: u32 }
         //   now: func() -> datetime           (retArea 16B, align 8)
         //   resolution: func() -> datetime    (same)
@@ -90,7 +90,7 @@ namespace Wacs.WASI.Preview2.Clocks
         private static void BindWallClock(WasmRuntime runtime,
             IWallClock impl)
         {
-            const string ns = "wasi:clocks/wall-clock@0.2.3";
+            const string ns = "wasi:clocks/wall-clock@0.2.8";
 
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ns, "now"),
@@ -102,7 +102,7 @@ namespace Wacs.WASI.Preview2.Clocks
                     WriteDatetime(ctx, retArea, impl.Resolution()));
         }
 
-        // wasi:clocks/timezone@0.2.3
+        // wasi:clocks/timezone@0.2.8
         //   utc-offset: func(when: datetime) -> s32
         //   display: func(when: datetime) -> timezone-display
         //
@@ -119,7 +119,7 @@ namespace Wacs.WASI.Preview2.Clocks
         private static void BindTimezone(WasmRuntime runtime,
             ITimezone impl)
         {
-            const string ns = "wasi:clocks/timezone@0.2.3";
+            const string ns = "wasi:clocks/timezone@0.2.8";
             var alloc = new Realloc(runtime);
 
             runtime.BindHostFunction<Func<ExecContext, long, int, int>>(

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/Descriptor.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/Descriptor.cs
@@ -23,7 +23,7 @@ namespace Wacs.WASI.Preview2.Filesystem
     // land in this namespace.
 
     /// <summary>
-    /// Host representation of <c>wasi:filesystem/types@0.2.3</c>'s
+    /// Host representation of <c>wasi:filesystem/types@0.2.8</c>'s
     /// <c>descriptor</c> resource. Implements
     /// <see cref="IDescriptor"/> directly — every method returns
     /// the faithful canonical-ABI <c>result&lt;X,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Descriptor.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Descriptor.cs
@@ -16,7 +16,7 @@ namespace Wacs.WASI.Preview2.Filesystem
 {
     public sealed partial class FilesystemBindings
     {
-        // wasi:filesystem/types@0.2.3 — descriptor resource.
+        // wasi:filesystem/types@0.2.8 — descriptor resource.
         // Each binding line wires one wire shape to its host
         // method on Descriptor. Host methods return
         // Result<X, ErrorCode>; the Write* helpers encode both

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Directory.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Directory.cs
@@ -15,7 +15,7 @@ namespace Wacs.WASI.Preview2.Filesystem
 {
     public sealed partial class FilesystemBindings
     {
-        // wasi:filesystem/types@0.2.3 — directory-entry-stream
+        // wasi:filesystem/types@0.2.8 — directory-entry-stream
         // resource. Single method:
         //   read-directory-entry: func()
         //     -> result<option<directory-entry>, error-code>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.ErrorCode.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.ErrorCode.cs
@@ -16,7 +16,7 @@ namespace Wacs.WASI.Preview2.Filesystem
 {
     public sealed partial class FilesystemBindings
     {
-        // wasi:filesystem/types@0.2.3 — top-level
+        // wasi:filesystem/types@0.2.8 — top-level
         //   filesystem-error-code: func(err: borrow<error>)
         //     -> option<error-code>
         //

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Preopens.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Preopens.cs
@@ -14,7 +14,7 @@ namespace Wacs.WASI.Preview2.Filesystem
 {
     public sealed partial class FilesystemBindings
     {
-        // wasi:filesystem/preopens@0.2.3
+        // wasi:filesystem/preopens@0.2.8
         //   get-directories: func()
         //     -> list<tuple<own<descriptor>, string>>
         //

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.cs
@@ -18,12 +18,12 @@ namespace Wacs.WASI.Preview2.Filesystem
     /// Orchestrator for the two <c>wasi:filesystem/*</c>
     /// interfaces:
     ///
-    ///   wasi:filesystem/types@0.2.3     — the Descriptor +
+    ///   wasi:filesystem/types@0.2.8     — the Descriptor +
     ///                                     DirectoryEntryStream
     ///                                     resources, plus the
     ///                                     top-level
     ///                                     filesystem-error-code
-    ///   wasi:filesystem/preopens@0.2.3  — get-directories
+    ///   wasi:filesystem/preopens@0.2.8  — get-directories
     ///
     /// <para>Constructor takes an optional
     /// <see cref="IPreopens"/> +
@@ -42,8 +42,8 @@ namespace Wacs.WASI.Preview2.Filesystem
     /// </summary>
     public sealed partial class FilesystemBindings : IBindable
     {
-        private const string Ns = "wasi:filesystem/types@0.2.3";
-        private const string PreopensNs = "wasi:filesystem/preopens@0.2.3";
+        private const string Ns = "wasi:filesystem/types@0.2.8";
+        private const string PreopensNs = "wasi:filesystem/preopens@0.2.8";
 
         private readonly ResourceContext _resources;
         private readonly IPreopens? _preopens;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.cs
@@ -15,7 +15,7 @@ using Wacs.WASI.Preview2.HostBinding.CanonicalAbi;
 namespace Wacs.WASI.Preview2.Http
 {
     /// <summary>
-    /// Orchestrator for <c>wasi:http/types@0.2.3</c> — the
+    /// Orchestrator for <c>wasi:http/types@0.2.8</c> — the
     /// 11 HTTP resources (Fields, OutgoingRequest,
     /// IncomingRequest, OutgoingResponse, IncomingResponse,
     /// OutgoingBody, IncomingBody, FutureIncomingResponse,
@@ -37,7 +37,7 @@ namespace Wacs.WASI.Preview2.Http
     /// </summary>
     public sealed partial class HttpTypes : IBindable
     {
-        private const string Ns = "wasi:http/types@0.2.3";
+        private const string Ns = "wasi:http/types@0.2.8";
 
         private readonly ResourceContext _resources;
         private readonly IHttpErrorCodeMapper? _errorCodeMapper;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/OutgoingHandlerBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/OutgoingHandlerBindings.cs
@@ -14,7 +14,7 @@ using Wacs.WASI.Preview2.HostBinding.CanonicalAbi;
 namespace Wacs.WASI.Preview2.Http
 {
     /// <summary>
-    /// Bindings for <c>wasi:http/outgoing-handler@0.2.3</c>:
+    /// Bindings for <c>wasi:http/outgoing-handler@0.2.8</c>:
     /// <code>handle: func(
     ///     request: own&lt;outgoing-request&gt;,
     ///     options: option&lt;own&lt;request-options&gt;&gt;,
@@ -39,7 +39,7 @@ namespace Wacs.WASI.Preview2.Http
     /// </summary>
     public sealed class OutgoingHandlerBindings : IBindable
     {
-        private const string Ns = "wasi:http/outgoing-handler@0.2.3";
+        private const string Ns = "wasi:http/outgoing-handler@0.2.8";
 
         private readonly ResourceContext _resources;
         private readonly IOutgoingHandler _impl;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/InputStream.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/InputStream.cs
@@ -12,7 +12,7 @@ using Wacs.WASI.Preview2.HostBinding;
 namespace Wacs.WASI.Preview2.Io
 {
     /// <summary>
-    /// Host representation of <c>wasi:io/streams@0.2.3</c>'s
+    /// Host representation of <c>wasi:io/streams@0.2.8</c>'s
     /// <c>input-stream</c> resource. The class implements
     /// <see cref="IInputStream"/> directly — every method
     /// returns the faithful canonical-ABI <c>result&lt;X,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/IoBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/IoBindings.cs
@@ -14,8 +14,8 @@ namespace Wacs.WASI.Preview2.Io
 {
     /// <summary>
     /// Orchestrator for two foundational WASI IO interfaces:
-    /// <c>wasi:io/error@0.2.3</c> (the <see cref="Error"/>
-    /// resource) and <c>wasi:io/poll@0.2.3</c> (the
+    /// <c>wasi:io/error@0.2.8</c> (the <see cref="Error"/>
+    /// resource) and <c>wasi:io/poll@0.2.8</c> (the
     /// <see cref="Pollable"/> resource + top-level <c>poll</c>).
     ///
     /// <para>Both register a resource into the shared
@@ -45,7 +45,7 @@ namespace Wacs.WASI.Preview2.Io
                 BindPoll(runtime, _resources, alloc, _poll);
         }
 
-        // wasi:io/error@0.2.3
+        // wasi:io/error@0.2.8
         //   resource error {
         //     to-debug-string: func() -> string;
         //   }
@@ -55,7 +55,7 @@ namespace Wacs.WASI.Preview2.Io
         private static void BindError(WasmRuntime runtime,
             ResourceContext resources, Realloc alloc)
         {
-            const string ns = "wasi:io/error@0.2.3";
+            const string ns = "wasi:io/error@0.2.8";
             var errors = resources.Table<Error>();
 
             runtime.BindHostFunction<Action<ExecContext, int>>(
@@ -74,7 +74,7 @@ namespace Wacs.WASI.Preview2.Io
                 });
         }
 
-        // wasi:io/poll@0.2.3
+        // wasi:io/poll@0.2.8
         //   resource pollable {
         //     ready: func() -> bool;
         //     block: func();
@@ -84,7 +84,7 @@ namespace Wacs.WASI.Preview2.Io
         private static void BindPollable(WasmRuntime runtime,
             ResourceContext resources)
         {
-            const string ns = "wasi:io/poll@0.2.3";
+            const string ns = "wasi:io/poll@0.2.8";
             var pollables = resources.Table<Pollable>();
 
             runtime.BindHostFunction<Action<ExecContext, int>>(
@@ -102,7 +102,7 @@ namespace Wacs.WASI.Preview2.Io
                     ((Pollable)pollables.Get(handle)).Block());
         }
 
-        // wasi:io/poll@0.2.3 top-level
+        // wasi:io/poll@0.2.8 top-level
         //   poll: func(in: list<borrow<pollable>>) -> list<u32>
         //
         // Wire: (param listPtr i32, listLen i32, retArea i32)
@@ -112,7 +112,7 @@ namespace Wacs.WASI.Preview2.Io
         private static void BindPoll(WasmRuntime runtime,
             ResourceContext resources, Realloc alloc, IPoll impl)
         {
-            const string ns = "wasi:io/poll@0.2.3";
+            const string ns = "wasi:io/poll@0.2.8";
             var pollables = resources.Table<Pollable>();
 
             runtime.BindHostFunction<Action<ExecContext, int, int, int>>(

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/OutputStream.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/OutputStream.cs
@@ -12,7 +12,7 @@ using Wacs.WASI.Preview2.HostBinding;
 namespace Wacs.WASI.Preview2.Io
 {
     /// <summary>
-    /// Host representation of <c>wasi:io/streams@0.2.3</c>'s
+    /// Host representation of <c>wasi:io/streams@0.2.8</c>'s
     /// <c>output-stream</c> resource. Implements
     /// <see cref="IOutputStream"/> directly — every method
     /// returns the canonical-ABI <c>result&lt;X,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.Input.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.Input.cs
@@ -14,7 +14,7 @@ namespace Wacs.WASI.Preview2.Io
 {
     public sealed partial class StreamBindings
     {
-        // wasi:io/streams@0.2.3
+        // wasi:io/streams@0.2.8
         //   resource input-stream {
         //     read: func(len: u64) -> result<list<u8>, stream-error>;
         //     blocking-read: func(len: u64) -> result<list<u8>, stream-error>;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.Output.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.Output.cs
@@ -14,7 +14,7 @@ namespace Wacs.WASI.Preview2.Io
 {
     public sealed partial class StreamBindings
     {
-        // wasi:io/streams@0.2.3
+        // wasi:io/streams@0.2.8
         //   resource output-stream {
         //     check-write: func() -> result<u64, stream-error>;
         //     write: func(contents: list<u8>) -> result<_, stream-error>;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.cs
@@ -14,7 +14,7 @@ using Wacs.WASI.Preview2.HostBinding.CanonicalAbi;
 namespace Wacs.WASI.Preview2.Io
 {
     /// <summary>
-    /// Orchestrator for <c>wasi:io/streams@0.2.3</c> — both
+    /// Orchestrator for <c>wasi:io/streams@0.2.8</c> — both
     /// the <see cref="InputStream"/> and
     /// <see cref="OutputStream"/> resources, plus their
     /// (resource-drop) destructors.
@@ -29,7 +29,7 @@ namespace Wacs.WASI.Preview2.Io
     /// </summary>
     public sealed partial class StreamBindings : IBindable
     {
-        private const string Ns = "wasi:io/streams@0.2.3";
+        private const string Ns = "wasi:io/streams@0.2.8";
         private readonly ResourceContext _resources;
 
         public StreamBindings(ResourceContext resources)

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Random/RandomBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Random/RandomBindings.cs
@@ -50,13 +50,13 @@ namespace Wacs.WASI.Preview2.Random
                 BindInsecureSeed(runtime, _insecureSeed);
         }
 
-        // wasi:random/random@0.2.3
+        // wasi:random/random@0.2.8
         //   get-random-bytes: func(len: u64) -> list<u8>
         //   get-random-u64: func() -> u64
         private static void BindRandom(WasmRuntime runtime,
             Realloc alloc, IRandom impl)
         {
-            const string ns = "wasi:random/random@0.2.3";
+            const string ns = "wasi:random/random@0.2.8";
 
             runtime.BindHostFunction<Func<ExecContext, long>>(
                 (ns, "get-random-u64"),
@@ -69,13 +69,13 @@ namespace Wacs.WASI.Preview2.Random
                         impl.GetRandomBytes((ulong)len)));
         }
 
-        // wasi:random/insecure@0.2.3
+        // wasi:random/insecure@0.2.8
         //   get-insecure-random-bytes: func(len: u64) -> list<u8>
         //   get-insecure-random-u64: func() -> u64
         private static void BindInsecureRandom(WasmRuntime runtime,
             Realloc alloc, IInsecure impl)
         {
-            const string ns = "wasi:random/insecure@0.2.3";
+            const string ns = "wasi:random/insecure@0.2.8";
 
             runtime.BindHostFunction<Func<ExecContext, long>>(
                 (ns, "get-insecure-random-u64"),
@@ -88,13 +88,13 @@ namespace Wacs.WASI.Preview2.Random
                         impl.GetInsecureRandomBytes((ulong)len)));
         }
 
-        // wasi:random/insecure-seed@0.2.3
+        // wasi:random/insecure-seed@0.2.8
         //   insecure-seed: func() -> tuple<u64, u64>
         // Tuple of primitives: 16-byte retArea (two u64s, align 8).
         private static void BindInsecureSeed(WasmRuntime runtime,
             IInsecureSeed impl)
         {
-            const string ns = "wasi:random/insecure-seed@0.2.3";
+            const string ns = "wasi:random/insecure-seed@0.2.8";
 
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ns, "insecure-seed"),

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/Datagrams.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/Datagrams.cs
@@ -20,7 +20,7 @@ namespace Wacs.WASI.Preview2.Sockets
 
     /// <summary>
     /// Host representation of
-    /// <c>wasi:sockets/udp@0.2.3</c>'s
+    /// <c>wasi:sockets/udp@0.2.8</c>'s
     /// <c>incoming-datagram-stream</c> resource. Pull-stream
     /// of UDP datagrams the socket has received from the
     /// network. Pairs with <see cref="OutgoingDatagramStream"/>
@@ -50,7 +50,7 @@ namespace Wacs.WASI.Preview2.Sockets
 
     /// <summary>
     /// Host representation of
-    /// <c>wasi:sockets/udp@0.2.3</c>'s
+    /// <c>wasi:sockets/udp@0.2.8</c>'s
     /// <c>outgoing-datagram-stream</c> resource. Push-stream
     /// of UDP datagrams the socket sends to the network.
     /// </summary>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/IpNameLookup.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/IpNameLookup.cs
@@ -16,7 +16,7 @@ namespace Wacs.WASI.Preview2.Sockets
 {
     /// <summary>
     /// Host representation of
-    /// <c>wasi:sockets/ip-name-lookup@0.2.3</c>'s
+    /// <c>wasi:sockets/ip-name-lookup@0.2.8</c>'s
     /// <c>resolve-address-stream</c> resource. A resolver
     /// pull-stream — guest calls
     /// <see cref="ResolveNextAddress"/> in a loop, getting

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/Network.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/Network.cs
@@ -11,7 +11,7 @@ using Wacs.WASI.Preview2.HostBinding;
 namespace Wacs.WASI.Preview2.Sockets
 {
     /// <summary>
-    /// Host representation of <c>wasi:sockets/network@0.2.3</c>'s
+    /// Host representation of <c>wasi:sockets/network@0.2.8</c>'s
     /// <c>network</c> resource. The WIT type carries no
     /// methods in 0.2.3 — it's an opaque capability handle
     /// that gates which sockets a guest can create. Pass to

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.IpNameLookup.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.IpNameLookup.cs
@@ -16,7 +16,7 @@ namespace Wacs.WASI.Preview2.Sockets
 {
     public sealed partial class SocketsBindings
     {
-        // wasi:sockets/ip-name-lookup@0.2.3
+        // wasi:sockets/ip-name-lookup@0.2.8
         //   resolve-addresses: func(network: borrow<network>, name: string)
         //     -> result<own<resolve-address-stream>, error-code>
         // resource methods on resolve-address-stream:

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Network.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Network.cs
@@ -14,7 +14,7 @@ namespace Wacs.WASI.Preview2.Sockets
 {
     public sealed partial class SocketsBindings
     {
-        // wasi:sockets/network@0.2.3 — Network resource (no
+        // wasi:sockets/network@0.2.8 — Network resource (no
         // methods) plus a top-level function:
         //   network-error-code: func(err: borrow<error>)
         //     -> option<error-code>
@@ -48,7 +48,7 @@ namespace Wacs.WASI.Preview2.Sockets
                 });
         }
 
-        // wasi:sockets/instance-network@0.2.3
+        // wasi:sockets/instance-network@0.2.8
         //   instance-network: func() -> own<network>
         private static void BindInstanceNetwork(WasmRuntime runtime,
             ResourceContext resources, IInstanceNetwork impl)
@@ -59,7 +59,7 @@ namespace Wacs.WASI.Preview2.Sockets
                 _ => nets.Allocate((Network)impl.InstanceNetwork()));
         }
 
-        // wasi:sockets/tcp-create-socket@0.2.3
+        // wasi:sockets/tcp-create-socket@0.2.8
         //   create-tcp-socket: func(address-family: ip-address-family)
         //     -> result<own<tcp-socket>, error-code>
         // Result-returning host method: allocate the handle on Ok,
@@ -83,7 +83,7 @@ namespace Wacs.WASI.Preview2.Sockets
                 });
         }
 
-        // wasi:sockets/udp-create-socket@0.2.3
+        // wasi:sockets/udp-create-socket@0.2.8
         //   create-udp-socket: func(address-family: ip-address-family)
         //     -> result<own<udp-socket>, error-code>
         private static void BindUdpCreateSocket(WasmRuntime runtime,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Tcp.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Tcp.cs
@@ -16,7 +16,7 @@ namespace Wacs.WASI.Preview2.Sockets
 {
     public sealed partial class SocketsBindings
     {
-        // wasi:sockets/tcp@0.2.3 — tcp-socket resource. Bare
+        // wasi:sockets/tcp@0.2.8 — tcp-socket resource. Bare
         // bool / enum returns skip the result wrapper; everything
         // else is result<X, error-code> with the Result-returning
         // host method dispatched through WriteResult* helpers.

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Udp.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Udp.cs
@@ -16,7 +16,7 @@ namespace Wacs.WASI.Preview2.Sockets
 {
     public sealed partial class SocketsBindings
     {
-        // wasi:sockets/udp@0.2.3 — udp-socket resource. Smaller
+        // wasi:sockets/udp@0.2.8 — udp-socket resource. Smaller
         // surface than tcp; %stream returns a (incoming, outgoing)
         // datagram-stream pair gated on an option<address>.
         private static void BindUdpSocket(WasmRuntime runtime,
@@ -165,7 +165,7 @@ namespace Wacs.WASI.Preview2.Sockets
                 });
         }
 
-        // wasi:sockets/udp@0.2.3 — incoming-datagram-stream
+        // wasi:sockets/udp@0.2.8 — incoming-datagram-stream
         // resource. receive(maxResults) -> result<list<dgram>, _>
         // where each dgram = 40 bytes (data list 8B + addr 32B).
         private static void BindIncomingDatagramStream(WasmRuntime runtime,
@@ -232,7 +232,7 @@ namespace Wacs.WASI.Preview2.Sockets
                 });
         }
 
-        // wasi:sockets/udp@0.2.3 — outgoing-datagram-stream
+        // wasi:sockets/udp@0.2.8 — outgoing-datagram-stream
         // resource. send(list<dgram>) -> result<u64, _>; each
         // dgram on the param side is 44 bytes.
         private static void BindOutgoingDatagramStream(WasmRuntime runtime,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.cs
@@ -25,13 +25,13 @@ namespace Wacs.WASI.Preview2.Sockets
     ///
     /// <para>WIT namespaces covered:
     /// <list type="bullet">
-    /// <item><c>wasi:sockets/network@0.2.3</c> (Network resource)</item>
-    /// <item><c>wasi:sockets/instance-network@0.2.3</c> (top-level)</item>
-    /// <item><c>wasi:sockets/tcp@0.2.3</c> (TcpSocket resource)</item>
-    /// <item><c>wasi:sockets/udp@0.2.3</c> (UdpSocket + datagram streams)</item>
-    /// <item><c>wasi:sockets/tcp-create-socket@0.2.3</c></item>
-    /// <item><c>wasi:sockets/udp-create-socket@0.2.3</c></item>
-    /// <item><c>wasi:sockets/ip-name-lookup@0.2.3</c></item>
+    /// <item><c>wasi:sockets/network@0.2.8</c> (Network resource)</item>
+    /// <item><c>wasi:sockets/instance-network@0.2.8</c> (top-level)</item>
+    /// <item><c>wasi:sockets/tcp@0.2.8</c> (TcpSocket resource)</item>
+    /// <item><c>wasi:sockets/udp@0.2.8</c> (UdpSocket + datagram streams)</item>
+    /// <item><c>wasi:sockets/tcp-create-socket@0.2.8</c></item>
+    /// <item><c>wasi:sockets/udp-create-socket@0.2.8</c></item>
+    /// <item><c>wasi:sockets/ip-name-lookup@0.2.8</c></item>
     /// </list></para>
     ///
     /// <para>Every host method that the WIT spec marks
@@ -47,13 +47,13 @@ namespace Wacs.WASI.Preview2.Sockets
     /// </summary>
     public sealed partial class SocketsBindings : IBindable
     {
-        private const string NetworkNs        = "wasi:sockets/network@0.2.3";
-        private const string InstanceNs       = "wasi:sockets/instance-network@0.2.3";
-        private const string TcpNs            = "wasi:sockets/tcp@0.2.3";
-        private const string UdpNs            = "wasi:sockets/udp@0.2.3";
-        private const string TcpCreateNs      = "wasi:sockets/tcp-create-socket@0.2.3";
-        private const string UdpCreateNs      = "wasi:sockets/udp-create-socket@0.2.3";
-        private const string IpNameLookupNs   = "wasi:sockets/ip-name-lookup@0.2.3";
+        private const string NetworkNs        = "wasi:sockets/network@0.2.8";
+        private const string InstanceNs       = "wasi:sockets/instance-network@0.2.8";
+        private const string TcpNs            = "wasi:sockets/tcp@0.2.8";
+        private const string UdpNs            = "wasi:sockets/udp@0.2.8";
+        private const string TcpCreateNs      = "wasi:sockets/tcp-create-socket@0.2.8";
+        private const string UdpCreateNs      = "wasi:sockets/udp-create-socket@0.2.8";
+        private const string IpNameLookupNs   = "wasi:sockets/ip-name-lookup@0.2.8";
 
         private readonly ResourceContext _resources;
         private readonly IInstanceNetwork? _instanceNetwork;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2</AssemblyName>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
+        <Version>0.3.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/command.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.3;
+package wasi:cli@0.2.8;
 
 @since(version = 0.2.0)
 world command {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps.lock
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps.lock
@@ -1,24 +1,24 @@
 [clocks]
-url = "https://github.com/WebAssembly/wasi-clocks/archive/main.tar.gz"
-sha256 = "93a701968a7dd3c5d69031bc0601681c468972fdf7e28a93bb6150a67d6ebe8b"
-sha512 = "98fca567c7a01887b0fb38981f1772169b6ea8de475b546508f8b86738d84e44ba95cae81def40ac34e8809f5f60e85224077ab8cb6d6d5d6296acc1df73c159"
+sha256 = "be1d8c61e2544e2b48d902c60df73577e293349063344ce752cda4d323f8b913"
+sha512 = "0fd7962c62b135da0e584c2b58a55147bf09873848b0bb5bd3913019bc3f8d4b5969fbd6f7f96fd99a015efaf562a3eeafe3bc13049f8572a6e13ef9ef0e7e75"
 
 [filesystem]
-url = "https://github.com/WebAssembly/wasi-filesystem/archive/main.tar.gz"
-sha256 = "69d42fb10a04a33545b17e055f13db9b1e10e82ba0ed5bdb52334e40dc07c679"
-sha512 = "612effbac6f4804fe0c29dae20b78bbba59e52cb754c15402f5fe229c3153a221e0fbdff1d9d00ceaa3fe049c6a95523a5b99f772f1c16d972eade2c88326a30"
+url = "https://github.com/WebAssembly/wasi-filesystem/archive/v0.2.8.tar.gz"
+sha256 = "57c2e5e40c57d54a2eacb55d8855d2963a6c0b33971a3620c1468b732233d593"
+sha512 = "11d1dee738bea1fdd15f5cc07ea10bfb9953a4e84361bbdc2c1051f9520463329ec839caffe0e5cf22870584846f9bfe627c1b77ee4b555fcc990b8106791c68"
+deps = ["clocks", "io"]
 
 [io]
-url = "https://github.com/WebAssembly/wasi-io/archive/main.tar.gz"
-sha256 = "1cccbfe4122686ea57a25cd368e8cdfc408cbcad089f47fb6685b6f92e96f050"
-sha512 = "7a95f964c13da52611141acd89bc8876226497f128e99dd176a4270c5b5efbd8cc847b5fbd1a91258d028c646db99e0424d72590cf1caf20f9f3a3343fad5017"
+sha256 = "9f1ad5da70f621bbd4c69e3bd90250a0c12ecfde266aa8f99684fc44bc1e7c15"
+sha512 = "6d0a9db6848f24762933d1c168a5b5b1065ba838c253ee20454afeb8dd1a049b918d25deff556083d68095dd3126ae131ac3e738774320eee5d918f5a4b5354e"
 
 [random]
-url = "https://github.com/WebAssembly/wasi-random/archive/main.tar.gz"
-sha256 = "dd0c91e7125172eb8fd4568e15ad9fc7305643015e6ece4396c3cc5e8c2bf79a"
-sha512 = "d1ca2e7b0616a94a3b39d1b9450bb3fb595b01fd94a8626ad75433038dde40988ecb41ab93a374d569ab72163af3b30038d7bfc3499b9c07193181f4f1d9292a"
+url = "https://github.com/WebAssembly/wasi-random/archive/v0.2.8.tar.gz"
+sha256 = "febd6f75dec1fa733b8e25c1cdee4de9acd922ddf755a192d85f479b1f96b445"
+sha512 = "1689d2eee3c64b9fc91faaf43741ff95f343b05acc758342dbf3aa86830de1ec66b4bcd0fe22bf1f77abc4a1feeaae90cdc2c06eedc30952a6667f70edca7d8f"
 
 [sockets]
-url = "https://github.com/WebAssembly/wasi-sockets/archive/main.tar.gz"
-sha256 = "2bc0f65a8046207ee3330ad7d63f6fafeafd4cc0ea4084f081bd5e4f7b177e74"
-sha512 = "3e5490e41547dffa78d52631825d93da8d60f4af0246cbaf97e1ecb879285953a86d5f1f390b10c32f91dd7eaec6f43e625a26b1c92c32a0c86fde428aedaaab"
+url = "https://github.com/WebAssembly/wasi-sockets/archive/v0.2.8.tar.gz"
+sha256 = "e82bb0502324f44ef22f6fdadec51f4963faf8ccd21187c37397ea872c0548c0"
+sha512 = "b8139db2b26a95d6948e345cf036497883943134ea832abfabd7267682d9f84b4c86ff38fc771125f1a8e2bcd237ea0a731d83bf22df9d78f19e452061227d77"
+deps = ["clocks", "io"]

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/monotonic-clock.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.8;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -10,7 +10,7 @@ package wasi:clocks@0.2.3;
 @since(version = 0.2.0)
 interface monotonic-clock {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.8.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from
@@ -26,6 +26,11 @@ interface monotonic-clock {
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
+    ///
+    /// For completeness, this function traps if it's not possible to represent
+    /// the value of the clock in an `instant`. Consequently, implementations
+    /// should ensure that the starting time is low enough to avoid the
+    /// possibility of overflow in practice.
     @since(version = 0.2.0)
     now: func() -> instant;
 

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/timezone.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/timezone.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.8;
 
 @unstable(feature = clocks-timezone)
 interface timezone {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/wall-clock.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.8;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/world.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.8;
 
 @since(version = 0.2.0)
 world imports {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/filesystem/preopens.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/filesystem/preopens.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.3;
+package wasi:filesystem@0.2.8;
 
 @since(version = 0.2.0)
 interface preopens {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/filesystem/types.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.3;
+package wasi:filesystem@0.2.8;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -26,9 +26,9 @@ package wasi:filesystem@0.2.3;
 @since(version = 0.2.0)
 interface types {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.3.{input-stream, output-stream, error};
+    use wasi:io/streams@0.2.8.{input-stream, output-stream, error};
     @since(version = 0.2.0)
-    use wasi:clocks/wall-clock@0.2.3.{datetime};
+    use wasi:clocks/wall-clock@0.2.8.{datetime};
 
     /// File size or length of a region within a file.
     @since(version = 0.2.0)
@@ -507,6 +507,10 @@ interface types {
         ) -> result<_, error-code>;
 
         /// Create a hard link.
+        ///
+        /// Fails with `error-code::no-entry` if the old path does not exist,
+        /// with `error-code::exist` if the new path already exists, and
+        /// `error-code::not-permitted` if the old path is not a file.
         ///
         /// Note: This is similar to `linkat` in POSIX.
         @since(version = 0.2.0)

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/filesystem/world.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.3;
+package wasi:filesystem@0.2.8;
 
 @since(version = 0.2.0)
 world imports {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/http/types.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/http/types.wit
@@ -1,10 +1,10 @@
-package wasi:http@0.2.3;
+package wasi:http@0.2.8;
 
 interface types {
-    use wasi:clocks/monotonic-clock@0.2.3.{duration};
-    use wasi:io/streams@0.2.3.{input-stream, output-stream};
-    use wasi:io/error@0.2.3.{error as io-error};
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:clocks/monotonic-clock@0.2.8.{duration};
+    use wasi:io/streams@0.2.8.{input-stream, output-stream};
+    use wasi:io/error@0.2.8.{error as io-error};
+    use wasi:io/poll@0.2.8.{pollable};
 
     variant method {
         get,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/error.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.8;
 
 @since(version = 0.2.0)
 interface error {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/poll.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.8;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
@@ -8,19 +8,19 @@ interface poll {
     @since(version = 0.2.0)
     resource pollable {
 
-      /// Return the readiness of a pollable. This function never blocks.
-      ///
-      /// Returns `true` when the pollable is ready, and `false` otherwise.
-      @since(version = 0.2.0)
-      ready: func() -> bool;
+        /// Return the readiness of a pollable. This function never blocks.
+        ///
+        /// Returns `true` when the pollable is ready, and `false` otherwise.
+        @since(version = 0.2.0)
+        ready: func() -> bool;
 
-      /// `block` returns immediately if the pollable is ready, and otherwise
-      /// blocks until ready.
-      ///
-      /// This function is equivalent to calling `poll.poll` on a list
-      /// containing only this pollable.
-      @since(version = 0.2.0)
-      block: func();
+        /// `block` returns immediately if the pollable is ready, and otherwise
+        /// blocks until ready.
+        ///
+        /// This function is equivalent to calling `poll.poll` on a list
+        /// containing only this pollable.
+        @since(version = 0.2.0)
+        block: func();
     }
 
     /// Poll for completion on a set of pollables.

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/streams.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.8;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -154,27 +154,13 @@ interface streams {
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
         ///
-        /// This is a convenience wrapper around the use of `check-write`,
-        /// `subscribe`, `write`, and `flush`, and is implemented with the
-        /// following pseudo-code:
-        ///
-        /// ```text
-        /// let pollable = this.subscribe();
-        /// while !contents.is_empty() {
-        ///     // Wait for the stream to become writable
-        ///     pollable.block();
-        ///     let Ok(n) = this.check-write(); // eliding error handling
-        ///     let len = min(n, contents.len());
-        ///     let (chunk, rest) = contents.split_at(len);
-        ///     this.write(chunk  );            // eliding error handling
-        ///     contents = rest;
-        /// }
-        /// this.flush();
-        /// // Wait for completion of `flush`
-        /// pollable.block();
-        /// // Check for any errors that arose during `flush`
-        /// let _ = this.check-write();         // eliding error handling
-        /// ```
+        /// Returns success when all of the contents written are successfully
+        /// flushed to output. If an error occurs at any point before all
+        /// contents are successfully flushed, that error is returned as soon as
+        /// possible. If writing and flushing the complete contents causes the
+        /// stream to become closed, this call should return success, and
+        /// subsequent calls to check-write or other interfaces should return
+        /// stream-error::closed.
         @since(version = 0.2.0)
         blocking-write-and-flush: func(
             contents: list<u8>
@@ -227,26 +213,8 @@ interface streams {
         /// Block until all of these operations are complete, or an error
         /// occurs.
         ///
-        /// This is a convenience wrapper around the use of `check-write`,
-        /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-        /// the following pseudo-code:
-        ///
-        /// ```text
-        /// let pollable = this.subscribe();
-        /// while num_zeroes != 0 {
-        ///     // Wait for the stream to become writable
-        ///     pollable.block();
-        ///     let Ok(n) = this.check-write(); // eliding error handling
-        ///     let len = min(n, num_zeroes);
-        ///     this.write-zeroes(len);         // eliding error handling
-        ///     num_zeroes -= len;
-        /// }
-        /// this.flush();
-        /// // Wait for completion of `flush`
-        /// pollable.block();
-        /// // Check for any errors that arose during `flush`
-        /// let _ = this.check-write();         // eliding error handling
-        /// ```
+        /// Functionality is equivelant to `blocking-write-and-flush` with
+        /// contents given as a list of len containing only zeroes.
         @since(version = 0.2.0)
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/world.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.8;
 
 @since(version = 0.2.0)
 world imports {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/insecure-seed.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/insecure-seed.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.8;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/insecure.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/insecure.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.8;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/random.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.8;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/world.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.8;
 
 @since(version = 0.2.0)
 world imports {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/ip-name-lookup.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/ip-name-lookup.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface ip-name-lookup {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.8.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-address};
 

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/network.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/network.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface network {
     @unstable(feature = network-error-code)
-    use wasi:io/error@0.2.3.{error};
+    use wasi:io/error@0.2.8.{error};
 
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/tcp.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/tcp.wit
@@ -1,11 +1,11 @@
 @since(version = 0.2.0)
 interface tcp {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.3.{input-stream, output-stream};
+    use wasi:io/streams@0.2.8.{input-stream, output-stream};
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.8.{pollable};
     @since(version = 0.2.0)
-    use wasi:clocks/monotonic-clock@0.2.3.{duration};
+    use wasi:clocks/monotonic-clock@0.2.8.{duration};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/udp.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface udp {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.8.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/world.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.3;
+package wasi:sockets@0.2.8;
 
 @since(version = 0.2.0)
 world imports {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/imports.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/imports.wit
@@ -1,17 +1,17 @@
-package wasi:cli@0.2.3;
+package wasi:cli@0.2.8;
 
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  include wasi:clocks/imports@0.2.3;
+  include wasi:clocks/imports@0.2.8;
   @since(version = 0.2.0)
-  include wasi:filesystem/imports@0.2.3;
+  include wasi:filesystem/imports@0.2.8;
   @since(version = 0.2.0)
-  include wasi:sockets/imports@0.2.3;
+  include wasi:sockets/imports@0.2.8;
   @since(version = 0.2.0)
-  include wasi:random/imports@0.2.3;
+  include wasi:random/imports@0.2.8;
   @since(version = 0.2.0)
-  include wasi:io/imports@0.2.3;
+  include wasi:io/imports@0.2.8;
 
   @since(version = 0.2.0)
   import environment;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/stdio.wit
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/wit/stdio.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface stdin {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{input-stream};
+  use wasi:io/streams@0.2.8.{input-stream};
 
   @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
@@ -10,7 +10,7 @@ interface stdin {
 @since(version = 0.2.0)
 interface stdout {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{output-stream};
+  use wasi:io/streams@0.2.8.{output-stream};
 
   @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
@@ -19,7 +19,7 @@ interface stdout {
 @since(version = 0.2.0)
 interface stderr {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{output-stream};
+  use wasi:io/streams@0.2.8.{output-stream};
 
   @since(version = 0.2.0)
   get-stderr: func() -> output-stream;


### PR DESCRIPTION
## Summary

Brings WACS's bundled WASI Preview 2 host bindings up to **WASI 0.2.8**
(the latest stable patch) and adds a symmetric version-tolerant
fallback to `WasmRuntime.GetBoundEntity` so the interpreter path
matches the resolver fallback PR #119 added for the transpiler-direct-link
path.

- **Bundled WIT bumped 0.2.3 → 0.2.8.** Refreshes the vendored WIT
  tree under `Wacs.WASI.Preview2/wit/` from upstream
  `WebAssembly/wasi-cli@v0.2.8`. Zero ABI changes between 0.2.3 and
  0.2.8 — only doc clarifications and version-string bumps in `use`
  clauses. All hardcoded `wasi:*@0.2.3` strings in the per-subsystem
  `*Bindings.cs` files update in lockstep.
- **`Wacs.Core` 0.12.2 — version-tolerant `GetBoundEntity`.** Mirror
  of PR #119's resolver fallback for the interpreter-side
  `BindHostFunction` lookup: exact match wins, then strip
  `@<version>`, then O(n) scan for any matching stripped form. Fires
  at most once per failed import.

The two coordinates stay deliberately decoupled:

- **Production WASI host bindings** — bumped to 0.2.8 so error
  messages, `wacs inspect --imports` output, and source-gen
  `[WitSource]` package identity track the latest spec.
- **Test fixtures** under `Spec.Test/components/wasi-cli@v0.2.3` and
  `Spec.Test/components/fixtures/` — kept at v0.2.3 (frozen). They
  exercise the loader/emitter against a specific pinned version;
  bumping them would mean renaming all 21 `v0_2_3`-baked reference
  files in the hello-world fixture.

## Test plan

- [x] `dotnet test Wacs.ComponentModel.Test` — 347 passed
- [x] `dotnet test Wacs.WASI.Preview2.Test` — 189 passed (was failing
      with hardcoded @0.2.3 strings until the version-tolerant
      `GetBoundEntity` fallback handles them)
- [x] `dotnet test Wacs.WASI.NN.Test` — 18 passed
- [x] `dotnet test Wacs.Transpiler.Test` (Component / Interface
      filter) — 50 passed
- [x] E2E hello-p2 (Rust 1.95.0 wasm32-wasip2 emitting `@0.2.6`
      imports against bumped `@0.2.8` host): stdout / stderr both
      flow correctly under the version-tolerant lookup.

## What remains

- The `std::process::exit(N)` `unreachable` trap from PR #119's
  open-follow-up is unchanged by this bump — it's a guest-side
  cleanup-path issue, not a version-skew issue. Worth its own
  investigation.
- `Spec.Test/components/wasi-cli` submodule pointer stays at v0.2.3.
  Bumping it would require regenerating the entire hello-world
  reference output set; not in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)