### PR TITLE
Linear-memory storage modes, memory64, and component-model lift fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## WACS.Cli 1.4.2 / WACS.Transpiler.Lib 0.7.5 — gap 12 phases C.4c + C.5: `wacs run --native-memory`
+
+End-to-end CLI plumbing for NativePointer storage. With this
+release, `wacs run --native-memory model.wasm` (or
+`--wasip2 --native-memory ...` for components) runs the entire
+guest — interpreter or transpiler engine, core or component
+module, wasip1 or wasip2 host bindings — against native-pointer-
+backed linear memory. The 2 GiB byte[] cap stops mattering for
+this invocation; the wasm32 spec's 4 GiB limit applies instead.
+
+### `Wacs.Console` — phase C.5 (the flag)
+
+`RunOptions.NativeMemory` (`--native-memory`) flips
+`RuntimeOptions.MemoryStorage` to `NativePointer` for the
+interpreter `InstantiateModule` call (single-core run) and pins
+`ModuleInit.CurrentMemoryStorage` for the duration of the run
+so transpiler/component paths observe it too.
+`ExecuteSingleCore` and `ExecuteComponent` wrap their
+implementations in a try/finally that sets and restores the
+static, so subsequent in-process callers (test harnesses,
+library hosts) see the original mode.
+
+### `Wacs.Transpiler.Lib` — phase C.4c (transpiled module ctor)
+
+`ModuleInit.CurrentMemoryStorage` (new public static field,
+default `MemoryStorageMode.ManagedArray`) is read by
+`InitializationHelper.InitializeCore` when the transpiled module
+class allocates each linear memory via `new MemoryInstance(memType,
+storage)`. Single-threaded transpile/dispatch sequence — the static
+flag is set just before module construction and not consulted
+afterwards, so no AsyncLocal&lt;T&gt; ceremony.
+
+### Tests
+
+Wacs.Core 391, Wacs.Transpiler 751, Wacs.ComponentModel 350,
+Wacs.WASI.Preview2 189, Wacs.WASI.Preview1 72, Wacs.HostBindings
+14 — all green. ManagedArray default keeps every existing test
+byte-stable; NativePointer path was already covered by
+`MemoryNativePointerEndToEndTests` (Wacs.Core) and
+`MemoryInstanceNativeStorageTests` from phases A/B.
+
+### Net effect for the SLM use case from `wasi-nn/WACS-GAPS.md`
+
+`wacs run --wasip2 --wasi-nn --native-memory -d models slm.wasm`
+now allocates >2 GiB of linear memory through every layer:
+component-transpiled module ctor (C.4c) → wasip2 host bindings
+(C.4b) → memory access in interpreter + transpiler emit (B + C.3).
+Gap 12 closed for the wasm32 4 GiB ceiling. memory64
+(`WasmMaxPages64 = 2^48`) still sits behind phase D's
+i64-address widening.
+
 ## WACS.WASI.Preview2 0.3.2 — gap 12 phase C.4b: wasip2 host-binding migration to MemoryInstance
 
 `MemoryReader` / `MemoryWriter` (~30 helpers), `ExecContextExtensions`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## WACS 0.12.4 — gap 12 phase D: memory64 support
+
+memory64 modules (`(memory i64 N)`) now run end-to-end through the
+interpreter and transpiler when paired with NativePointer storage.
+The cap shifts from `WasmMaxPages` (2^16, 4 GiB for memory32) to
+`WasmMaxPages64` (2^48). All 4 spec.test fixtures under
+`spec/test/core/memory64/` pass on both the WAST and
+WAST-transpiled paths.
+
+### Bounds-check arithmetic
+
+The historical `if (ea < 0) trap; if (ea + W > Length) trap;`
+pattern was correct for memory32 (PopAddr trapped on negative
+addresses, addr+offset stayed in long range) but broke for
+memory64: a u64 address with the high bit set is legitimate, and
+ea+width can wrap into negative when addr is near 2^64. Switched
+every memory-op bounds check (single-byte loads/stores, narrow
+loads/stores, full-width, SIMD, atomics, bulk ops) to a wrap-safe
+unsigned form:
+
+```csharp
+if ((ulong)ea > (ulong)mem.ByteLength
+    || (ulong)mem.ByteLength - (ulong)ea < (ulong)width)
+    trap;
+```
+
+Negative `ea` casts to a huge ulong that fails the first
+clause; small `ea` near `ByteLength` fails via the subtract-and-
+compare without overflow risk.
+
+### Other changes
+
+- `OpStack.PopAddr` no longer traps on negative — memory64
+  addresses with the high bit set are valid wasm. Bounds-check
+  sites are now responsible for trapping on out-of-bounds.
+- `MemoryInstance.MaxPagesForMode` reads `Type.Limits.AddressType`
+  and returns `WasmMaxPages64` (2^48) for `i64`-address NativePointer
+  memories; `WasmMaxPages` (2^16) for `i32`; `HostMaxPages` (2^15)
+  for ManagedArray either way (byte[] cap is hard).
+- `InstTableGet` / `InstTableSet` switched to unsigned
+  `(ulong)i >= (ulong)tab.Elements.Count` so table64 (`(table i64 …)`)
+  indices behave correctly.
+
+### Bulk ops
+
+`memory.copy` / `memory.fill` / `memory.init` already used long
+arithmetic for their `(s + n)` / `(d + n)` overflow checks; for
+memory64 those wrap silently. Switched to the same wrap-safe
+unsigned form.
+
+### Tests
+
+Three new theory cases in `MemoryNativePointerEndToEndTests`
+(`Memory64_Pages_AllocationCapsAtWasmMaxPages64`,
+`Memory64_StoreLoad_RoundTripsAtHighAddress`,
+`Memory64_OutOfBoundsLoad_Traps`) plus all 4 spec.test memory64
+fixtures pass. Wacs.Core 394 (was 391), Spec.Test 770/772, every
+other suite unchanged.
+
+### What's not in phase D
+
+- Transpiler-emit memory-op IL still uses `int addr, long offset`
+  on the helper signatures and `(int)ea` truncation at the
+  AsSpan call site. memory64 modules going through the AOT
+  saved-DLL path (`wacs aot --wasi`) work today only when ea
+  fits in int32 (i.e., the 4 GiB sub-window of a memory64
+  address space). Spec memory64 tests pass because they wrap to
+  small ea values; arbitrary memory64 transpiled use of
+  ea > int.MaxValue will still trap on AsSpan. A follow-up phase
+  D.2 widens the helper signatures to `nuint addr, ulong offset`
+  if that use case ever shows up in practice.
+- `WacsHostMemory.AsSpan(int, int)` is `int`-bounded; host
+  bindings reading >2 GiB views need the future `MemoryHandle`
+  surface (also phase D.2).
+
 ## WACS.Cli 1.4.2 / WACS.Transpiler.Lib 0.7.5 — gap 12 phases C.4c + C.5: `wacs run --native-memory`
 
 End-to-end CLI plumbing for NativePointer storage. With this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## WACS 0.12.3 — gap 12 phase A: NativePointer storage mode for MemoryInstance
+## WACS 0.12.3 — gap 12 phases A + B: NativePointer storage mode end-to-end through the interpreter
 
-Phase A of the byte[]→native-pointer migration from gap 12 of
-`wasi-nn/WACS-GAPS.md`. Lifts the type-system surface so subsequent
-phases can flip access sites; this phase ships no behavior change
-for default-mode callers.
+Phases A + B of the byte[]→native-pointer migration from gap 12 of
+`wasi-nn/WACS-GAPS.md`. Phase A added the type surface; Phase B
+threaded the runtime option through instantiation and migrated
+every interpreter memory access site to the mode-dispatching API.
+A wasm module instantiated with `RuntimeOptions.MemoryStorage =
+NativePointer` now executes load/store/narrow/bulk/grow/size
+through native-pointer storage end-to-end via the interpreter.
+
+### Phase A (type surface)
 
 `MemoryInstance` now has two backing storages selected via
 `MemoryStorageMode`:
@@ -42,6 +47,51 @@ Wacs.WASI.Preview2 189) passes unchanged. Eight new tests in
 `MemoryInstanceNativeStorageTests` cover allocation, grow
 preservation + zero-fill, indexer + AsSpan, dispose
 idempotency, and `HostMaxPages` rejection in native mode.
+
+### Phase B (interpreter wiring)
+
+`RuntimeOptions.MemoryStorage` now flows from
+`WasmRuntime.InstantiateModule` through `AllocateModule` →
+`AllocateMemory` → `new MemoryInstance(memType, mode)`. Embedders
+that pass `MemoryStorage = NativePointer` get native-pointer
+storage on every memory the runtime owns.
+
+Every interpreter memory access site has been migrated from raw
+`mem.Data[i]` / `mem.Data.AsSpan(...)` / `mem.Data.Length` to the
+mode-dispatching surface (`mem.AsSpan(int, int)`,
+`(long)mem.ByteLength`):
+
+- `MemoryHandlers.MemSlice` — the chokepoint for all 25+
+  `[OpHandler]` load/store/narrow/bulk/size/grow handlers on the
+  monolithic-switch path.
+- `Memory/I32MemoryLoad.cs`, `I64MemoryLoad.cs`, `FMemoryLoad.cs`
+  — full-width and narrow loads (i32.load, i32.load8_s/u,
+  i32.load16_s/u, i64.load, i64.load8/16/32_s/u, f32.load,
+  f64.load).
+- `Memory/InstI32Store.cs`, `InstI64Store.cs`, `FMemoryStore.cs`
+  — full-width and narrow stores.
+- `Instructions/MemoryBulk.cs` — `memory.init`, `memory.copy`
+  (overlap via `Span<byte>.CopyTo` → `Buffer.Memmove`),
+  `memory.fill` (`Span<byte>.Fill`).
+- `Instructions/SIMD/VMemory.cs` — every v128 load/store/lane op.
+
+Atomic instructions (`Instructions/Atomic/AtomicLoadStore.cs`,
+`AtomicHandlers.cs`) are deferred — they use `ref byte` semantics
+that need a slightly different mode-aware helper. They keep
+working in the default `ManagedArray` mode, and the spec test
+suite covers them there. NativePointer-mode atomic access is on
+the Phase C punch list alongside the byte[] retirement.
+
+Twelve new tests in `MemoryNativePointerEndToEndTests` exercise
+load/store/narrow/grow/fill/copy/init through the interpreter in
+both modes, including overlapping `memory.copy` and an
+out-of-bounds trap. Each [Theory] case runs once for
+`ManagedArray` and once for `NativePointer` so any divergence
+between the two paths surfaces immediately.
+
+Tests: Wacs.Core 383 (was 363), Wacs.Transpiler 751,
+Wacs.ComponentModel 350, Wacs.WASI.Preview2 189 — all green, no
+regressions.
 
 ## WACS.ComponentModel 0.2.1 / WACS.Transpiler.Lib 0.7.4 — gaps 10 + 11: descriptor-stat lifting and post-grow byte[] safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## WACS 0.12.3 — gap 12 phase A: NativePointer storage mode for MemoryInstance
+
+Phase A of the byte[]→native-pointer migration from gap 12 of
+`wasi-nn/WACS-GAPS.md`. Lifts the type-system surface so subsequent
+phases can flip access sites; this phase ships no behavior change
+for default-mode callers.
+
+`MemoryInstance` now has two backing storages selected via
+`MemoryStorageMode`:
+
+- `ManagedArray` (default): historical `byte[] Data` +
+  `Array.Resize` on grow. ~2 GiB cap.
+- `NativePointer`: `byte* NativeBase` + `nuint NativeSize` allocated
+  via `NativeMemory.AllocZeroed` (.NET 6+) or `Marshal.AllocHGlobal`
+  + `InitBlockUnaligned` (legacy). Grow allocates a new buffer,
+  `Buffer.MemoryCopy`s the live bytes, frees the old. No 2 GiB cap.
+
+New public surface on `MemoryInstance`:
+
+- `StorageMode` (read-only) — which backing this instance uses.
+- `byte* NativeBase` + `nuint NativeSize` — exposed for emit code in
+  later phases.
+- `nuint ByteLength` — authoritative byte length, both modes.
+- `Span<byte> AsSpan(int offset, int length)` — mode-dispatched
+  span access. Existing `[Range]` indexer also dispatches.
+- `IDisposable` — Dispose frees the native buffer in
+  `NativePointer` mode and is a no-op in `ManagedArray` mode (the
+  GC reclaims the byte[]). A finalizer backstops native-mode
+  leaks.
+
+`RuntimeOptions.MemoryStorage` (default `ManagedArray`) is the
+runtime-level switch; phases B/C will thread it through
+`WasmRuntimeInstantiation` and the transpiler's emitted IL so the
+mode the user requested is the mode every memory in the runtime
+gets.
+
+Phase A is byte-stable for default-mode callers — every existing
+test (Wacs.Core 355, Wacs.Transpiler 751, Wacs.ComponentModel 350,
+Wacs.WASI.Preview2 189) passes unchanged. Eight new tests in
+`MemoryInstanceNativeStorageTests` cover allocation, grow
+preservation + zero-fill, indexer + AsSpan, dispose
+idempotency, and `HostMaxPages` rejection in native mode.
+
 ## WACS.ComponentModel 0.2.1 / WACS.Transpiler.Lib 0.7.4 — gaps 10 + 11: descriptor-stat lifting and post-grow byte[] safety
 
 Closes the next two gaps from `wasi-nn/WACS-GAPS.md` (round 4):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## WACS.HostBindings.Abstractions 0.2.1 / WACS.WASI.Preview1 0.12.1 — gap 12 phase C.4a: WacsHostMemory mode-aware
+
+The host-binding ABI now carries a NativePointer-mode case alongside
+the historical byte[] mode. Wasip1 hosts running with
+`MemoryStorageMode.NativePointer` produce a `WacsHostMemory` that
+dispatches reads/writes against native memory instead of dereferencing
+an empty-array sentinel.
+
+### `Wacs.HostBindings.Abstractions.WacsHostMemory`
+
+- New `WacsHostMemory(IntPtr nativeBase, int length)` constructor.
+  The struct internally tracks both backings (byte[] _data nullable +
+  IntPtr _nativeBase) and dispatches every accessor through a
+  null-check on _data — JIT inlines to a single branch per access.
+- New `IsNative` property — true when the view is over native memory.
+- All accessors (`ReadByte`/`WriteByte`/`AsSpan`/`ReadInt32LE`/
+  `WriteInt32LE`/`ReadInt64LE`/`WriteInt64LE`/`Contains`/
+  `WriteUtf8String`/`ReadUtf8String`/`ReadStruct`/`ReadStructs`/
+  `WriteStruct`) work in either mode.
+- `Data` getter still returns a `byte[]` for back-compat — but in
+  NativePointer mode it returns `Array.Empty<byte>()`. Legacy
+  callers that reach for `.Data` directly to read memory fail loud
+  (AOOR on first index) instead of silently zero-reading; they must
+  migrate to `AsSpan` for mode-agnostic access.
+
+### `Wacs.WASI.Preview1.Clock.WacsHost`
+
+The Preview1 ExecContext → WacsHostMemory adapter now branches by
+`MemoryInstance.StorageMode`. NativePointer-backed memories take the
+`(IntPtr, int)` ctor with `(IntPtr)mem.NativeBase` and
+`min(NativeSize, int.MaxValue)` length. ManagedArray-backed memories
+keep using the historical `(byte[], int)` ctor.
+
+### Tests
+
+`Wacs.HostBindings.Test`: 14 tests (was 8) — six new cases cover
+`NativePointer_ReadWriteByte_RoundTrips`,
+`NativePointer_AsSpan_RoundTrips`,
+`NativePointer_Int32LERoundTrip`,
+`NativePointer_Utf8String_RoundTrips`,
+`NativePointer_ZeroLength_AcceptsZeroPointer`,
+`NativePointer_NonZeroLengthRequiresPointer`. Each allocates via
+`NativeMemory.AllocZeroed`, exercises the accessors, and frees the
+buffer — verifying writes hit native memory and reads come back
+untouched.
+
+### Still ahead in phase C.4
+
+- **C.4b: wasip2 host-binding migration** — `MemoryReader` /
+  `MemoryWriter` (~50 helpers) and `ExecContextExtensions.Memory()`
+  in `Wacs.WASI.Preview2/HostBinding/CanonicalAbi/` still take
+  `byte[] memory` directly. ~127 callsites use
+  `ctx.DefaultMemory.Data` or `ctx.Memory()` and fail in
+  NativePointer mode (sentinel empty array). Migrating them to
+  `MemoryInstance` (or to `Span<byte>` constructed via the
+  mode-aware `mem.AsSpan`) is the bulk of work before the SLM
+  use case runs end-to-end through wasip2 in NativePointer mode.
+- **C.4c: AOT emitted module surface** — the transpiler's
+  `ModuleClassGenerator` emits a `byte[] Memory` property on the
+  generated standalone module. AOT-published modules use the
+  `WacsHostMemory(byte[], int)` ctor from `wacs aot --wasi`'s
+  generated Program.cs. Lifting this to a mode-aware shape needs
+  a new `EmissionTarget` option or per-module flag.
+- **C.5: CLI flag** — `wacs run --native-memory` opts the run into
+  NativePointer storage end-to-end. Trivial after C.4b/c.
+
 ## WACS 0.12.3 / WACS.Transpiler.Lib 0.7.4 — gap 12 phases A → C.3: NativePointer storage mode through interpreter and transpiler
 
 Phases A → C.3 of the byte[]→native-pointer migration from gap 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,66 @@
 # Changelog
 
-## WACS 0.12.4 — gap 12 phase D: memory64 support
+## WACS 0.13.0 / WACS.Cli 1.5.0 / WACS.Transpiler.Lib 0.8.0 / WACS.ComponentModel 0.3.0 / WACS.WASI.Preview2 0.4.0 / WACS.WASI.Preview1 0.13.0 / WACS.HostBindings.Abstractions 0.3.0 — Linear-memory storage modes, memory64, and component-model lift fixes
 
-memory64 modules (`(memory i64 N)`) now run end-to-end through the
-interpreter and transpiler when paired with NativePointer storage.
-The cap shifts from `WasmMaxPages` (2^16, 4 GiB for memory32) to
-`WasmMaxPages64` (2^48). All 4 spec.test fixtures under
-`spec/test/core/memory64/` pass on both the WAST and
-WAST-transpiled paths.
+Lifts WACS's linear-memory backing to a host-selected mode and
+plumbs that mode through every layer of the runtime, so the wasm32
+4 GiB ceiling and memory64's 2^48 ceiling are both reachable.
+Also closes two component-model lift correctness bugs that
+surfaced under realistic host-side memory growth.
 
-### Bounds-check arithmetic
+### Linear-memory storage modes
 
-The historical `if (ea < 0) trap; if (ea + W > Length) trap;`
-pattern was correct for memory32 (PopAddr trapped on negative
-addresses, addr+offset stayed in long range) but broke for
-memory64: a u64 address with the high bit set is legitimate, and
-ea+width can wrap into negative when addr is near 2^64. Switched
-every memory-op bounds check (single-byte loads/stores, narrow
-loads/stores, full-width, SIMD, atomics, bulk ops) to a wrap-safe
-unsigned form:
+`MemoryInstance` carries two backings selected via
+`RuntimeOptions.MemoryStorage`:
+
+- **`ManagedArray`** (default): managed `byte[]` grown via
+  `Array.Resize`. Capped at `Array.MaxLength` (~2 GiB).
+- **`NativePointer`**: `byte* NativeBase` + `nuint NativeSize`
+  allocated via `NativeMemory.AllocZeroed` (.NET 6+) or
+  `Marshal.AllocHGlobal` + `InitBlockUnaligned` (legacy). Grow
+  allocates a new buffer, `Buffer.MemoryCopy`s the live bytes,
+  frees the old. Capped at `WasmMaxPages` (4 GiB) for memory32
+  modules and `WasmMaxPages64` (2^48) for memory64.
+
+New public surface on `MemoryInstance`:
+
+- `StorageMode` (read-only) — which backing this instance uses.
+- `byte* NativeBase` + `nuint NativeSize` — public for emit code.
+- `nuint ByteLength` — authoritative byte length, both modes.
+- `Span<byte> AsSpan(int offset, int length)` — mode-dispatched
+  span access. The existing `[Range]` indexer also dispatches.
+- `ref T RefAs<T>(int ea) where T : unmanaged` — mode-dispatched
+  `ref T`. Atomic load/store/RMW routes through this so the same
+  `Interlocked.*` / `Volatile.*` sites work on both backings.
+- `IDisposable` — `Dispose` frees the native buffer in
+  NativePointer mode, no-op in ManagedArray. A finalizer
+  backstops native-mode leaks.
+
+`RuntimeOptions.MemoryStorage` (default `ManagedArray`) flows from
+`WasmRuntime.InstantiateModule` through to the `MemoryInstance`
+ctor. Every interpreter memory-access site (the `MemSlice`
+chokepoint covering 25+ `[OpHandler]` load/store/narrow/bulk
+ops, the per-instruction memory load/store classes, bulk init/
+copy/fill, SIMD v128, and atomics) dispatches through the
+mode-aware surface. The transpiler's emit follows the same
+pattern: `MemoryHelpers` and `BulkHelpers` take `MemoryInstance`
+and dispatch per access; `MemoryEmitter` / `SimdEmitter` /
+`BulkEmitter` pass `MemoryInstance` to the helpers directly;
+`EmitMemorySize` uses `Call get_Size` instead of
+`Ldfld Data; Ldlen`.
+
+`ManagedArray` callers stay byte-stable; NativePointer is
+covered by `MemoryInstanceNativeStorageTests` (allocation, grow
+preservation + zero-fill, indexer + AsSpan parity, dispose
+idempotency) and `MemoryNativePointerEndToEndTests` ([Theory]
+cases running every memory op in both modes through real wasm
+fixtures).
+
+### memory64
+
+memory64 modules (`(memory i64 N)`) execute end-to-end through
+the interpreter and transpiler when paired with NativePointer.
+Bounds checks use a wrap-safe unsigned form:
 
 ```csharp
 if ((ulong)ea > (ulong)mem.ByteLength
@@ -27,498 +69,187 @@ if ((ulong)ea > (ulong)mem.ByteLength
 ```
 
 Negative `ea` casts to a huge ulong that fails the first
-clause; small `ea` near `ByteLength` fails via the subtract-and-
-compare without overflow risk.
+clause; `ea` near `ByteLength` fails via subtract-and-compare
+without overflow risk. The check covers single-byte / narrow /
+full-width loads and stores, SIMD, atomics, and bulk
+init/copy/fill. `OpStack.PopAddr` no longer traps on negative —
+memory64 addresses with the high bit set are valid wasm.
+`InstTableGet` / `InstTableSet` also moved to unsigned compare
+so table64 (`(table i64 …)`) indices behave correctly.
 
-### Other changes
+All four spec.test fixtures under `spec/test/core/memory64/`
+pass on both the WAST and WAST-transpiled paths.
 
-- `OpStack.PopAddr` no longer traps on negative — memory64
-  addresses with the high bit set are valid wasm. Bounds-check
-  sites are now responsible for trapping on out-of-bounds.
-- `MemoryInstance.MaxPagesForMode` reads `Type.Limits.AddressType`
-  and returns `WasmMaxPages64` (2^48) for `i64`-address NativePointer
-  memories; `WasmMaxPages` (2^16) for `i32`; `HostMaxPages` (2^15)
-  for ManagedArray either way (byte[] cap is hard).
-- `InstTableGet` / `InstTableSet` switched to unsigned
-  `(ulong)i >= (ulong)tab.Elements.Count` so table64 (`(table i64 …)`)
-  indices behave correctly.
+memory64 modules going through the AOT saved-DLL path
+(`wacs aot --wasi`) work today only when the effective address
+fits in int32 — the transpiler's emitted memory-op IL truncates
+`(int)ea` at the AsSpan call site. Spec memory64 tests pass
+because the test wat wraps to small `ea`; arbitrary >2 GiB
+transpiled access does not. The interpreter and direct
+`wacs run` paths are unaffected. `WacsHostMemory.AsSpan(int, int)`
+is also int-bounded; host bindings reading >2 GiB views need a
+future `MemoryHandle`-style API.
 
-### Bulk ops
+### `wacs run --native-memory`
 
-`memory.copy` / `memory.fill` / `memory.init` already used long
-arithmetic for their `(s + n)` / `(d + n)` overflow checks; for
-memory64 those wrap silently. Switched to the same wrap-safe
-unsigned form.
+`wacs run --native-memory model.wasm` (or
+`--wasip2 --native-memory ...` for components) backs the
+guest's linear memory with native-pointer storage. The flag
+flips `RuntimeOptions.MemoryStorage` for the interpreter
+`InstantiateModule` call and pins the static
+`ModuleInit.CurrentMemoryStorage` (a new public field, default
+`MemoryStorageMode.ManagedArray`) that the transpiler's
+`InitializationHelper` reads when constructing transpiled
+module classes. `ExecuteSingleCore` and `ExecuteComponent`
+restore the prior values on exit so subsequent in-process
+callers (test harnesses, library hosts) see the original mode.
 
-### Tests
+### `WacsHostMemory` mode-aware
 
-Three new theory cases in `MemoryNativePointerEndToEndTests`
-(`Memory64_Pages_AllocationCapsAtWasmMaxPages64`,
-`Memory64_StoreLoad_RoundTripsAtHighAddress`,
-`Memory64_OutOfBoundsLoad_Traps`) plus all 4 spec.test memory64
-fixtures pass. Wacs.Core 394 (was 391), Spec.Test 770/772, every
-other suite unchanged.
+The host-binding ABI carries a NativePointer-mode case alongside
+the managed `byte[]` case. Wasip1 hosts running with
+`MemoryStorageMode.NativePointer` produce a `WacsHostMemory`
+that dispatches reads and writes against native memory.
 
-### What's not in phase D
+`Wacs.HostBindings.Abstractions.WacsHostMemory`:
 
-- Transpiler-emit memory-op IL still uses `int addr, long offset`
-  on the helper signatures and `(int)ea` truncation at the
-  AsSpan call site. memory64 modules going through the AOT
-  saved-DLL path (`wacs aot --wasi`) work today only when ea
-  fits in int32 (i.e., the 4 GiB sub-window of a memory64
-  address space). Spec memory64 tests pass because they wrap to
-  small ea values; arbitrary memory64 transpiled use of
-  ea > int.MaxValue will still trap on AsSpan. A follow-up phase
-  D.2 widens the helper signatures to `nuint addr, ulong offset`
-  if that use case ever shows up in practice.
-- `WacsHostMemory.AsSpan(int, int)` is `int`-bounded; host
-  bindings reading >2 GiB views need the future `MemoryHandle`
-  surface (also phase D.2).
-
-## WACS.Cli 1.4.2 / WACS.Transpiler.Lib 0.7.5 — gap 12 phases C.4c + C.5: `wacs run --native-memory`
-
-End-to-end CLI plumbing for NativePointer storage. With this
-release, `wacs run --native-memory model.wasm` (or
-`--wasip2 --native-memory ...` for components) runs the entire
-guest — interpreter or transpiler engine, core or component
-module, wasip1 or wasip2 host bindings — against native-pointer-
-backed linear memory. The 2 GiB byte[] cap stops mattering for
-this invocation; the wasm32 spec's 4 GiB limit applies instead.
-
-### `Wacs.Console` — phase C.5 (the flag)
-
-`RunOptions.NativeMemory` (`--native-memory`) flips
-`RuntimeOptions.MemoryStorage` to `NativePointer` for the
-interpreter `InstantiateModule` call (single-core run) and pins
-`ModuleInit.CurrentMemoryStorage` for the duration of the run
-so transpiler/component paths observe it too.
-`ExecuteSingleCore` and `ExecuteComponent` wrap their
-implementations in a try/finally that sets and restores the
-static, so subsequent in-process callers (test harnesses,
-library hosts) see the original mode.
-
-### `Wacs.Transpiler.Lib` — phase C.4c (transpiled module ctor)
-
-`ModuleInit.CurrentMemoryStorage` (new public static field,
-default `MemoryStorageMode.ManagedArray`) is read by
-`InitializationHelper.InitializeCore` when the transpiled module
-class allocates each linear memory via `new MemoryInstance(memType,
-storage)`. Single-threaded transpile/dispatch sequence — the static
-flag is set just before module construction and not consulted
-afterwards, so no AsyncLocal&lt;T&gt; ceremony.
-
-### Tests
-
-Wacs.Core 391, Wacs.Transpiler 751, Wacs.ComponentModel 350,
-Wacs.WASI.Preview2 189, Wacs.WASI.Preview1 72, Wacs.HostBindings
-14 — all green. ManagedArray default keeps every existing test
-byte-stable; NativePointer path was already covered by
-`MemoryNativePointerEndToEndTests` (Wacs.Core) and
-`MemoryInstanceNativeStorageTests` from phases A/B.
-
-### Net effect for the SLM use case from `wasi-nn/WACS-GAPS.md`
-
-`wacs run --wasip2 --wasi-nn --native-memory -d models slm.wasm`
-now allocates >2 GiB of linear memory through every layer:
-component-transpiled module ctor (C.4c) → wasip2 host bindings
-(C.4b) → memory access in interpreter + transpiler emit (B + C.3).
-Gap 12 closed for the wasm32 4 GiB ceiling. memory64
-(`WasmMaxPages64 = 2^48`) still sits behind phase D's
-i64-address widening.
-
-## WACS.WASI.Preview2 0.3.2 — gap 12 phase C.4b: wasip2 host-binding migration to MemoryInstance
-
-`MemoryReader` / `MemoryWriter` (~30 helpers), `ExecContextExtensions`,
-and the ~150 callsites across `SocketsBindings`, `FilesystemBindings`,
-`HttpTypes`, `Cli`, `Clocks`, `Io`, `Random`, and 39 private
-`Write*` helpers in those binding files now thread
-`MemoryInstance` instead of raw `byte[] memory`. The historical
-return type of `ExecContextExtensions.Memory()` (which silently
-broke in NativePointer mode where `Data` is the empty-array
-sentinel) is gone — every callsite consults the mode-aware
-`mem.AsSpan(...)`, `mem.RefAs<T>(...)`, `mem.ByteLength` surface
-the gap-12 phases A → C.3 already wired through the runtime.
-
-Helper signatures changed:
-
-- `MemoryReader.{ReadUtf8String, ReadByteArray, ReadByteArrayList,
-   ReadI32LE, ReadU16LE, ReadU32LE, ReadU64LE}`: `byte[] memory` →
-  `MemoryInstance memory`.
-- `MemoryWriter.{WriteI32LE, WriteU16LE, WriteU32LE, WriteU64LE,
-   WritePrimitiveLE, WriteResultUnitOk, ZeroRange}`: same.
-- `MemoryWriter.WriteUtf8StringAllocated`: `Func<byte[]> getMemory`
-  → `MemoryInstance memory`. The post-cabi_realloc refresh now
-  happens inside `mem.AsSpan` (gap 11 pattern).
-- `MemoryWriter.WriteOptionString`: same — now takes
-  `MemoryInstance` directly.
-- `ExecContextExtensions.Memory(this ExecContext ctx)`: returns
-  `MemoryInstance`, not `byte[]`. Callers that pass `ctx.Memory`
-  as a method group (e.g. `WriteUtf8StringAllocated(ctx.Memory, ...)`)
-  now invoke it as `ctx.Memory()`.
-
-Per-binding file changes follow the same pattern: every
-`mem[ptr]` indexer becomes `mem.AsSpan(ptr, 1)[0]` (with the
-exception of legitimate `Range` indexers, which the regex
-preserves); every `Array.Copy(src, X, mem, Y, len)` becomes
-`new ReadOnlySpan<byte>(src, X, len).CopyTo(mem.AsSpan(Y, len))`;
-every `Encoding.UTF8.GetString(mem, ptr, len)` becomes
-`Encoding.UTF8.GetString(mem.AsSpan(ptr, len))`.
-
-`Wacs.WASI.Preview2.Test.ErrorCodeEncoderTests` got the same
-treatment — its `BumpAllocator` test fixture now wraps a real
-`MemoryInstance` (1-page) instead of a raw `byte[]`, and assertions
-go through a thin indexer / span helper that hides the
-`AsSpan(N, 1)[0]` boilerplate.
-
-Tests: Wacs.Core 391, Wacs.Transpiler 751, Wacs.ComponentModel
-350, Wacs.WASI.Preview2 189, Wacs.WASI.Preview1 72,
-Wacs.HostBindings 14 — all green, no regressions.
-
-After C.4b, an embedder running `wacs run --wasip2 ... model.wasm`
-with `MemoryStorage = NativePointer` exercises native-backed
-memory through every wasip2 host binding. The remaining gap-12
-work is the CLI flag (C.5 — trivial) and the AOT-emitted module
-surface (C.4c — `module.Memory` byte[] in transpiler-emitted
-`Program.cs` template + `WacsHostMemory` ctor).
-
-## WACS.HostBindings.Abstractions 0.2.1 / WACS.WASI.Preview1 0.12.1 — gap 12 phase C.4a: WacsHostMemory mode-aware
-
-The host-binding ABI now carries a NativePointer-mode case alongside
-the historical byte[] mode. Wasip1 hosts running with
-`MemoryStorageMode.NativePointer` produce a `WacsHostMemory` that
-dispatches reads/writes against native memory instead of dereferencing
-an empty-array sentinel.
-
-### `Wacs.HostBindings.Abstractions.WacsHostMemory`
-
-- New `WacsHostMemory(IntPtr nativeBase, int length)` constructor.
-  The struct internally tracks both backings (byte[] _data nullable +
-  IntPtr _nativeBase) and dispatches every accessor through a
-  null-check on _data — JIT inlines to a single branch per access.
-- New `IsNative` property — true when the view is over native memory.
+- New `WacsHostMemory(IntPtr nativeBase, int length)` ctor.
+  The struct tracks both backings (`byte[]? _data` +
+  `IntPtr _nativeBase`) and dispatches every accessor through
+  a null-check on `_data` — JIT inlines to a single branch per
+  access.
+- New `IsNative` property — true when the view is over native
+  memory.
 - All accessors (`ReadByte`/`WriteByte`/`AsSpan`/`ReadInt32LE`/
   `WriteInt32LE`/`ReadInt64LE`/`WriteInt64LE`/`Contains`/
   `WriteUtf8String`/`ReadUtf8String`/`ReadStruct`/`ReadStructs`/
   `WriteStruct`) work in either mode.
-- `Data` getter still returns a `byte[]` for back-compat — but in
-  NativePointer mode it returns `Array.Empty<byte>()`. Legacy
-  callers that reach for `.Data` directly to read memory fail loud
-  (AOOR on first index) instead of silently zero-reading; they must
-  migrate to `AsSpan` for mode-agnostic access.
+- `Data` getter still returns a `byte[]` for back-compat — but
+  in NativePointer mode it returns `Array.Empty<byte>()`.
+  Legacy callers that reach for `.Data` directly fail loud
+  (AOOR on first index) instead of silently zero-reading; they
+  should migrate to `AsSpan`.
 
-### `Wacs.WASI.Preview1.Clock.WacsHost`
+`Wacs.WASI.Preview1.Clock.WacsHost` (the Preview1 ExecContext →
+WacsHostMemory adapter) branches by `MemoryInstance.StorageMode`.
+NativePointer-backed memories take the `(IntPtr, int)` ctor
+with `(IntPtr)mem.NativeBase` and
+`min(NativeSize, int.MaxValue)` length.
 
-The Preview1 ExecContext → WacsHostMemory adapter now branches by
-`MemoryInstance.StorageMode`. NativePointer-backed memories take the
-`(IntPtr, int)` ctor with `(IntPtr)mem.NativeBase` and
-`min(NativeSize, int.MaxValue)` length. ManagedArray-backed memories
-keep using the historical `(byte[], int)` ctor.
+`Wacs.HostBindings.Test`: 14 tests (was 8). Six new cases
+allocate via `NativeMemory.AllocZeroed`, exercise the
+accessors, and free the buffer.
 
-### Tests
+### wasip2 host bindings
 
-`Wacs.HostBindings.Test`: 14 tests (was 8) — six new cases cover
-`NativePointer_ReadWriteByte_RoundTrips`,
-`NativePointer_AsSpan_RoundTrips`,
-`NativePointer_Int32LERoundTrip`,
-`NativePointer_Utf8String_RoundTrips`,
-`NativePointer_ZeroLength_AcceptsZeroPointer`,
-`NativePointer_NonZeroLengthRequiresPointer`. Each allocates via
-`NativeMemory.AllocZeroed`, exercises the accessors, and frees the
-buffer — verifying writes hit native memory and reads come back
-untouched.
+The wasip2 host-binding stack threads `MemoryInstance` instead
+of raw `byte[]` everywhere — about 30 helpers in `MemoryReader`
+/ `MemoryWriter`, the `ExecContextExtensions` shortcuts, ~150
+callsites across `SocketsBindings`, `FilesystemBindings`,
+`HttpTypes`, `Cli`, `Clocks`, `Io`, and `Random`, plus 39
+private `Write*` helpers in those binding files. Every read and
+write goes through the mode-dispatching `mem.AsSpan(...)` /
+`mem.RefAs<T>(...)` / `mem.ByteLength` surface, so a wasip2
+binding works against either backing without per-binding
+awareness.
 
-### Still ahead in phase C.4
+API changes:
 
-- **C.4b: wasip2 host-binding migration** — `MemoryReader` /
-  `MemoryWriter` (~50 helpers) and `ExecContextExtensions.Memory()`
-  in `Wacs.WASI.Preview2/HostBinding/CanonicalAbi/` still take
-  `byte[] memory` directly. ~127 callsites use
-  `ctx.DefaultMemory.Data` or `ctx.Memory()` and fail in
-  NativePointer mode (sentinel empty array). Migrating them to
-  `MemoryInstance` (or to `Span<byte>` constructed via the
-  mode-aware `mem.AsSpan`) is the bulk of work before the SLM
-  use case runs end-to-end through wasip2 in NativePointer mode.
-- **C.4c: AOT emitted module surface** — the transpiler's
-  `ModuleClassGenerator` emits a `byte[] Memory` property on the
-  generated standalone module. AOT-published modules use the
-  `WacsHostMemory(byte[], int)` ctor from `wacs aot --wasi`'s
-  generated Program.cs. Lifting this to a mode-aware shape needs
-  a new `EmissionTarget` option or per-module flag.
-- **C.5: CLI flag** — `wacs run --native-memory` opts the run into
-  NativePointer storage end-to-end. Trivial after C.4b/c.
+- `MemoryReader.{ReadUtf8String, ReadByteArray, ReadByteArrayList,
+   ReadI32LE, ReadU16LE, ReadU32LE, ReadU64LE}`: `byte[] memory`
+  → `MemoryInstance memory`.
+- `MemoryWriter.{WriteI32LE, WriteU16LE, WriteU32LE, WriteU64LE,
+   WritePrimitiveLE, WriteResultUnitOk, ZeroRange}`: same.
+- `MemoryWriter.WriteUtf8StringAllocated` / `WriteOptionString`:
+  `Func<byte[]> getMemory` → `MemoryInstance memory`. Callers
+  no longer need to model the post-`cabi_realloc` re-fetch —
+  `mem.AsSpan` reads the live backing on each access.
+- `ExecContextExtensions.Memory(this ExecContext ctx)`: returns
+  `MemoryInstance`, not `byte[]`. Callers passing `ctx.Memory`
+  as a method group invoke it as `ctx.Memory()`.
 
-## WACS 0.12.3 / WACS.Transpiler.Lib 0.7.4 — gap 12 phases A → C.3: NativePointer storage mode through interpreter and transpiler
+Per-binding-file changes follow a uniform pattern: `mem[ptr]`
+→ `mem.AsSpan(ptr, 1)[0]`; `Array.Copy(src, X, mem, Y, len)`
+→ `new ReadOnlySpan<byte>(src, X, len).CopyTo(mem.AsSpan(Y, len))`;
+`Encoding.UTF8.GetString(mem, ptr, len)` →
+`Encoding.UTF8.GetString(mem.AsSpan(ptr, len))`.
 
-Phases A → C.3 of the byte[]→native-pointer migration from gap 12
-of `wasi-nn/WACS-GAPS.md`. Previous CHANGELOG entries below cover
-A and B; this entry adds C.1 (atomic ref helper), C.2 (cap lift),
-and C.3 (transpiler emit migration).
+`ErrorCodeEncoderTests`'s `BumpAllocator` test fixture wraps a
+real `MemoryInstance` (1-page) instead of a raw `byte[]`;
+assertions go through a thin indexer/Span helper.
 
-### Phase C.1 — atomic ref helper
+### Component-model lift fixes
 
-`MemoryInstance.RefAs<T>(int ea)` (public, generic-on-T-unmanaged)
-returns a `ref T` over the requested byte offset, dispatching by
-`StorageMode`. ManagedArray returns
-`ref Unsafe.As<byte, T>(ref Data[ea])`; NativePointer returns
-`ref Unsafe.AsRef<T>(NativeBase + ea)`. Every atomic helper on
-`MemoryInstance` (Load/Store/CmpExchange/Add/And/Or/Xor in i32+i64)
-and every subword `Volatile.Read/Write` site in
-`Atomic/AtomicLoadStore.cs` and `Atomic/AtomicHandlers.cs` migrated
-to use it. `Interlocked.*` and `Volatile.*` are ref-T-based, so
-flipping the ref's source is invisible to them.
+Two correctness bugs in `DirectLinkedImportEmit`:
 
-Fixes a stray `CachedMem.Data.Length` in `AtomicBase.CheckEa`
-bounds check → `(long)CachedMem.ByteLength`.
-
-### Phase C.2 — cap lift for NativePointer
-
-ManagedArray stays capped at `Constants.HostMaxPages` (0x8000 =
-2 GiB, the byte[] hard limit). NativePointer lifts the cap to
-`Constants.WasmMaxPages` (0x10000 = 4 GiB, the wasm32 spec max).
-`MaxPagesForMode` dispatches both the constructor's initial check
-and `Grow`'s newNumPages check. memory64 (`WasmMaxPages64 = 2^48`)
-stays out-of-scope until phase D wires the i64-address path.
-
-### Phase C.3 — transpiler emit migration
-
-`MemoryHelpers` (`MemoryEmitter.cs`, ~40 helpers) and `BulkHelpers`
-(`BulkEmitter.cs` MemoryCopy/Fill/Init) now take `MemoryInstance`
-instead of `byte[]`. Helper bodies dispatch by mode via
-`mem.AsSpan` / `mem.RefAs<T>` / `mem.ByteLength`. The transpiler's
-emit sites in `MemoryEmitter`, `SimdEmitter`, and `BulkEmitter`
-drop the `Ldfld MemoryDataField` step and pass `MemoryInstance`
-directly. `EmitMemorySize` uses `Call get_Size` (mode-aware
-property) instead of `Ldfld Data; Ldlen`.
-
-Cleaned up two leftover `/tmp/mem_trace.log` debug-print lines in
-`LoadI64_32S` and `StoreI32_8` from earlier diagnostic work.
-
-`InitializationHelper.cs` (the standalone-AOT-loader path for
-saved .dll modules) still defaults memories to `ManagedArray`;
-threading NativePointer through that path needs a separate option
-on `TranspilerOptions` or `ModuleInitData` and lands with C.4.
-
-### Still ahead in phase C / D
-
-- **C.4: drop byte[] dual storage** — touches `WacsHostMemory`
-  (host-binding ABI), the `MemoryReader`/`MemoryWriter` helpers in
-  `Wacs.WASI.Preview2/HostBinding/CanonicalAbi/`, and every wasip2
-  binding callsite that takes a raw `byte[] memory`. Without
-  C.4, NativePointer mode works inside the wasm execution engine
-  but host bindings can't see the bytes (Data is an empty-array
-  sentinel in NativePointer mode). C.4 is required before the
-  CLI can offer a `--native-memory` flag.
-- **C.5: CLI flag** — `wacs run --native-memory` opts the run
-  into NativePointer storage end-to-end. Trivial once C.4 is in.
-- **Phase D: memory64** — widen `OpStack.PopAddr` to `nuint`,
-  switch bounds-check arithmetic to unsigned, lift cap to
-  `WasmMaxPages64`. The default-mode-aware bounds checks in
-  C.1/C.2/C.3 are already 64-bit-clean; phase D is mostly the
-  i64-address plumbing through the OpStack and validator.
-
-### Tests
-
-| Suite | Total | Note |
-|---|---|---|
-| Wacs.Core | 391 | +28 from gap 12 work (8 unit + 12 e2e + 8 atomic theory pairs) |
-| Wacs.Transpiler | 752 | unchanged |
-| Wacs.ComponentModel | 350 | unchanged |
-| Wacs.WASI.Preview2 | 189 | unchanged |
-
-All suites byte-stable on default `ManagedArray` mode; new
-`NativePointer` paths covered by `MemoryInstanceNativeStorageTests`
-(8 unit) and `MemoryNativePointerEndToEndTests` (12 [Theory]×
-2-mode end-to-end through the interpreter).
-
-## WACS 0.12.3 — gap 12 phases A + B: NativePointer storage mode end-to-end through the interpreter
-
-Phases A + B of the byte[]→native-pointer migration from gap 12 of
-`wasi-nn/WACS-GAPS.md`. Phase A added the type surface; Phase B
-threaded the runtime option through instantiation and migrated
-every interpreter memory access site to the mode-dispatching API.
-A wasm module instantiated with `RuntimeOptions.MemoryStorage =
-NativePointer` now executes load/store/narrow/bulk/grow/size
-through native-pointer storage end-to-end via the interpreter.
-
-### Phase A (type surface)
-
-`MemoryInstance` now has two backing storages selected via
-`MemoryStorageMode`:
-
-- `ManagedArray` (default): historical `byte[] Data` +
-  `Array.Resize` on grow. ~2 GiB cap.
-- `NativePointer`: `byte* NativeBase` + `nuint NativeSize` allocated
-  via `NativeMemory.AllocZeroed` (.NET 6+) or `Marshal.AllocHGlobal`
-  + `InitBlockUnaligned` (legacy). Grow allocates a new buffer,
-  `Buffer.MemoryCopy`s the live bytes, frees the old. No 2 GiB cap.
-
-New public surface on `MemoryInstance`:
-
-- `StorageMode` (read-only) — which backing this instance uses.
-- `byte* NativeBase` + `nuint NativeSize` — exposed for emit code in
-  later phases.
-- `nuint ByteLength` — authoritative byte length, both modes.
-- `Span<byte> AsSpan(int offset, int length)` — mode-dispatched
-  span access. Existing `[Range]` indexer also dispatches.
-- `IDisposable` — Dispose frees the native buffer in
-  `NativePointer` mode and is a no-op in `ManagedArray` mode (the
-  GC reclaims the byte[]). A finalizer backstops native-mode
-  leaks.
-
-`RuntimeOptions.MemoryStorage` (default `ManagedArray`) is the
-runtime-level switch; phases B/C will thread it through
-`WasmRuntimeInstantiation` and the transpiler's emitted IL so the
-mode the user requested is the mode every memory in the runtime
-gets.
-
-Phase A is byte-stable for default-mode callers — every existing
-test (Wacs.Core 355, Wacs.Transpiler 751, Wacs.ComponentModel 350,
-Wacs.WASI.Preview2 189) passes unchanged. Eight new tests in
-`MemoryInstanceNativeStorageTests` cover allocation, grow
-preservation + zero-fill, indexer + AsSpan, dispose
-idempotency, and `HostMaxPages` rejection in native mode.
-
-### Phase B (interpreter wiring)
-
-`RuntimeOptions.MemoryStorage` now flows from
-`WasmRuntime.InstantiateModule` through `AllocateModule` →
-`AllocateMemory` → `new MemoryInstance(memType, mode)`. Embedders
-that pass `MemoryStorage = NativePointer` get native-pointer
-storage on every memory the runtime owns.
-
-Every interpreter memory access site has been migrated from raw
-`mem.Data[i]` / `mem.Data.AsSpan(...)` / `mem.Data.Length` to the
-mode-dispatching surface (`mem.AsSpan(int, int)`,
-`(long)mem.ByteLength`):
-
-- `MemoryHandlers.MemSlice` — the chokepoint for all 25+
-  `[OpHandler]` load/store/narrow/bulk/size/grow handlers on the
-  monolithic-switch path.
-- `Memory/I32MemoryLoad.cs`, `I64MemoryLoad.cs`, `FMemoryLoad.cs`
-  — full-width and narrow loads (i32.load, i32.load8_s/u,
-  i32.load16_s/u, i64.load, i64.load8/16/32_s/u, f32.load,
-  f64.load).
-- `Memory/InstI32Store.cs`, `InstI64Store.cs`, `FMemoryStore.cs`
-  — full-width and narrow stores.
-- `Instructions/MemoryBulk.cs` — `memory.init`, `memory.copy`
-  (overlap via `Span<byte>.CopyTo` → `Buffer.Memmove`),
-  `memory.fill` (`Span<byte>.Fill`).
-- `Instructions/SIMD/VMemory.cs` — every v128 load/store/lane op.
-
-Atomic instructions (`Instructions/Atomic/AtomicLoadStore.cs`,
-`AtomicHandlers.cs`) are deferred — they use `ref byte` semantics
-that need a slightly different mode-aware helper. They keep
-working in the default `ManagedArray` mode, and the spec test
-suite covers them there. NativePointer-mode atomic access is on
-the Phase C punch list alongside the byte[] retirement.
-
-Twelve new tests in `MemoryNativePointerEndToEndTests` exercise
-load/store/narrow/grow/fill/copy/init through the interpreter in
-both modes, including overlapping `memory.copy` and an
-out-of-bounds trap. Each [Theory] case runs once for
-`ManagedArray` and once for `NativePointer` so any divergence
-between the two paths surfaces immediately.
-
-Tests: Wacs.Core 383 (was 363), Wacs.Transpiler 751,
-Wacs.ComponentModel 350, Wacs.WASI.Preview2 189 — all green, no
-regressions.
-
-## WACS.ComponentModel 0.2.1 / WACS.Transpiler.Lib 0.7.4 — gaps 10 + 11: descriptor-stat lifting and post-grow byte[] safety
-
-Closes the next two gaps from `wasi-nn/WACS-GAPS.md` (round 4):
-metadata-shaped record returns no longer come back zero-filled, and
-list/string returns survive cabi_realloc-triggered memory.grow.
-
-The Rust SLM repro that previously tripped both:
-
-```rust
-let len = std::fs::metadata("/probe/x.bin").unwrap().len();
-// gap 10: returned 0; now returns the real file size.
-let buf = std::fs::read("/probe/x.bin").unwrap();
-// gap 11: AOOR for any single read past ~24 KiB; now round-trips
-// the full file even across page-boundary growth.
-```
-
-### 1. **WACS.Transpiler.Lib (`DirectLinkedImportEmit`)** — gap 10
-
-Closes the silent IImports-stub fallback for record returns whose
-fields include `Option<X>`. `wasi:filesystem/types.descriptor.stat`
-returns `result<descriptor-stat, error-code>` where descriptor-stat
-is `record { type, link-count, size, opt<datetime>×3 }` — pre-fix
-`IsAggregateReturnSupported` rejected the record because
+**Records with `option<X>` fields.**
+`wasi:filesystem/types.descriptor.stat` returns
+`result<descriptor-stat, error-code>`, where descriptor-stat is
+`record { type, link-count, size, opt<datetime>×3 }`. The
+predicate path rejected this record because
 `IsRecordOfPrimitives` walked fields with the non-resolver
-`IsFlatField` and bailed on the option fields, so direct-link emit
-fell back to the `IImports` proxy and the proxy returned a default-
-zero `DescriptorStat`. The fix mirrors PR #124's resource-bearing
-tuple/record extension:
-
-- Resolver-aware `IsFlatField(t, resolver)` now accepts `Option<X>`
-  whenever `IsAggregateReturnSupported(t, resolver)` recognizes the
-  Option's wire form (primitive / resource / string / byte[] /
-  record-of-primitives / nested option-or-result).
-- `IsAggregateReturnSupported`'s record + tuple branches use the
-  resolver-aware predicate so option fields cascade through.
-- `IsResultArmStorable` and `EmitResultArmStore`'s `isAggregate`
-  check accept `IsTupleOfFlatFields` / `IsRecordOfFlatFields` —
-  Result's OK arm can now BE a record-with-options.
-- `EmitTupleOrRecordFieldStore` dispatches Option fields to
-  `EmitOptionStoreAt` with a per-field base-address local. Reuses
-  the existing Option store machinery (handles innerIsRecord,
-  innerIsTuple, innerIsOption, innerIsResource, etc.) so nested
-  shapes like `Option<Datetime>` (record-of-primitives) Just Work.
-- `MaxFieldAlign`, `AlignOfFlatField`, `SizeOfFlatField`, `SizeOf`
-  pick up Option-aware overloads so per-field offsets and array
-  strides align on the inner type's MaxAlignOf.
+`IsFlatField` and bailed on the option fields; direct-link emit
+fell back to the `IImports` proxy and the proxy returned a
+default-zero `DescriptorStat`. Resolver-aware
+`IsFlatField(t, resolver)` now accepts `Option<X>` whenever
+`IsAggregateReturnSupported(t, resolver)` recognizes the
+Option's wire form. `IsAggregateReturnSupported`'s record +
+tuple branches use the resolver-aware predicate so option
+fields cascade through. `EmitTupleOrRecordFieldStore`
+dispatches Option fields to `EmitOptionStoreAt` with a per-
+field base-address local. `MaxFieldAlign`, `AlignOfFlatField`,
+`SizeOfFlatField`, `SizeOf` pick up Option-aware overloads so
+per-field offsets align on the inner type's `MaxAlignOf`.
 
 E2E coverage: new `E2E_DescriptorStat_RecordWithOptionFields`
-exercises `wasi-fs-stat-component`'s `ask-stat-size(handle)` against
-a stub `IDescriptor` that returns a known Size. Pre-fix this returns
-0; post-fix it returns the stub's value byte-for-byte.
+exercises a stub `IDescriptor.Stat()` returning a known `Size`
+through the `wasi-fs-stat-component` fixture.
 
-### 2. **WACS.ComponentModel (`PrimitiveStore`)** + **WACS.Transpiler.Lib (`DirectLinkedImportEmit`)** — gap 11
+**`cabi_realloc`-driven `memory.grow` invalidates captured byte[].**
+`MemoryInstance.Grow` does `Array.Resize(ref Data, …)`, which
+reallocates the backing `byte[]`. Every helper in
+`PrimitiveStore` captured `byte[] dest` BEFORE calling
+`cabi_realloc`, so the post-realloc copy targeted the stale
+(pre-grow) array's `int Length`, throwing AOOR for any
+allocation that crossed a page boundary. Rust std hid the trap
+behind "out of memory" because `fs::read` loops on `read(buf)`
+past 24 KiB.
 
-Closes the AOOR fired by `Buffer.BlockCopy` whenever `cabi_realloc`
-triggers `memory.grow` mid-store. Root cause: `MemoryInstance.Grow`
-does `Array.Resize(ref Data, …)`, which reallocates the backing
-byte[]; every helper in `PrimitiveStore` captured `byte[] dest`
-BEFORE calling cabi_realloc, so the post-realloc copy targeted the
-stale (pre-grow) array's `int Length`, throwing AOOR for any
-allocation that crossed a page boundary. Rust std hides this behind
-"out of memory" because `fs::read` loops on `read(buf)` past 24 KiB.
+Every cabi_realloc-using helper (`StoreString` /
+`StoreStringUtf16` / `StoreStringLatin1OrUtf16` /
+`StoreByteArray` / `StorePrimitiveArray<T>` /
+`StoreByteArrayList` / `StorePrimArrayList<T>` /
+`StoreStringList` / `StoreListOfStringList` /
+`StoreListOfByteArrayList`) now takes `MemoryInstance mem`
+instead of `byte[] dest` and reads `mem.Data` per access.
+`mem.Data` is read AFTER each cabi_realloc, so writes target
+the post-grow array. The fixed-width primitive helpers
+(`StoreI8` / `StoreU8` / … / `StoreBool`) still take
+`byte[] dest` — they have no cabi_realloc and no grow risk.
 
-Fix:
+`DirectLinkedImportEmit`'s emit sites split into two prefixes:
+variable-length helpers receive `MemoryInstance`, fixed-width
+helpers receive `byte[] dest` as before. The split runs through
+the top-level dispatch, `EmitTupleOrRecordFieldStore`,
+`EmitOptionStoreAt`, `EmitVariantStoreAt`, and
+`EmitResultArmStore`.
 
-- Every cabi_realloc-using helper (`StoreString` / `StoreStringUtf16` /
-  `StoreStringLatin1OrUtf16` / `StoreByteArray` / `StorePrimitiveArray<T>` /
-  `StoreByteArrayList` / `StorePrimArrayList<T>` / `StoreStringList` /
-  `StoreListOfStringList` / `StoreListOfByteArrayList`) now takes
-  `MemoryInstance mem` instead of `byte[] dest` and dereferences
-  `mem.Data` per access. `mem.Data` is read AFTER each cabi_realloc
-  invocation, so writes target the post-grow array. The fixed-width
-  primitive helpers (`StoreI8`/`U8`/.../`Bool`) still take
-  `byte[] dest` — they have no cabi_realloc, no grow risk.
-- `DirectLinkedImportEmit`'s emit sites split into two prefixes:
-  variable-length helpers receive `MemoryInstance` (no
-  `Ldfld MemoryDataField`); fixed-width helpers receive `byte[] dest`
-  as before. Restructured the top-level dispatch,
-  `EmitTupleOrRecordFieldStore`, `EmitOptionStoreAt`,
-  `EmitVariantStoreAt`, and `EmitResultArmStore` accordingly.
+Regression coverage: new `PrimitiveStoreGrowTests` (3 cases):
+byte[] across grow, string across grow, byte[][] with
+mid-iteration grow. The cabi_realloc lambda calls
+`mem.Grow(...)` to mirror Rust std's growing realloc.
 
-Regression coverage: new `PrimitiveStoreGrowTests` (3 cases): byte[]
-across grow, string across grow, byte[][] with mid-iteration grow.
-The cabi_realloc lambda calls `mem.Grow(...)` to mirror Rust std's
-growing realloc; pre-fix the helpers throw
-`ArgumentOutOfRangeException` deep in `Buffer.BlockCopy`, post-fix
-the bytes round-trip cleanly through the post-grow array.
+### Tests
 
-### API note
-
-`PrimitiveStore`'s cabi_realloc-using helpers are technically a
-public API surface, but every emit site in WACS proper is the only
-caller — the helpers exist solely to back direct-linked aggregate-
-return emit. Treating the signature change (`byte[] dest` →
-`MemoryInstance mem`) as a patch fix because the previous signature
-is unsafe to call across any cabi_realloc that grows memory.
+| Suite | Total | Notes |
+|---|---|---|
+| Wacs.Core | 394 | +31 (allocation/grow units, [Theory] mode pairs, memory64 fixtures, atomic round-trips) |
+| Wacs.Transpiler | 752 | +1 e2e (DescriptorStat record-with-options) |
+| Wacs.ComponentModel | 350 | +3 (PrimitiveStoreGrowTests) |
+| Wacs.WASI.Preview2 | 189 | unchanged (BumpAllocator fixture rewritten over MemoryInstance) |
+| Wacs.WASI.Preview1 | 72 | unchanged |
+| Wacs.HostBindings | 14 | +6 (NativePointer-mode WacsHostMemory accessors) |
+| Spec.Test | 770/772 | +8 (4 memory64 + 4 table64 fixtures) |
 
 ## WACS.Transpiler.Lib 0.7.3 / WACS.Cli 1.4.1 / WACS.WASI.Preview2 0.3.1 / WACS.WASI.Preview2.DependencyInjection 0.1.1 — gap 9: preopens reach the wasip2 transpiler engine
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## WACS.WASI.Preview2 0.3.2 — gap 12 phase C.4b: wasip2 host-binding migration to MemoryInstance
+
+`MemoryReader` / `MemoryWriter` (~30 helpers), `ExecContextExtensions`,
+and the ~150 callsites across `SocketsBindings`, `FilesystemBindings`,
+`HttpTypes`, `Cli`, `Clocks`, `Io`, `Random`, and 39 private
+`Write*` helpers in those binding files now thread
+`MemoryInstance` instead of raw `byte[] memory`. The historical
+return type of `ExecContextExtensions.Memory()` (which silently
+broke in NativePointer mode where `Data` is the empty-array
+sentinel) is gone — every callsite consults the mode-aware
+`mem.AsSpan(...)`, `mem.RefAs<T>(...)`, `mem.ByteLength` surface
+the gap-12 phases A → C.3 already wired through the runtime.
+
+Helper signatures changed:
+
+- `MemoryReader.{ReadUtf8String, ReadByteArray, ReadByteArrayList,
+   ReadI32LE, ReadU16LE, ReadU32LE, ReadU64LE}`: `byte[] memory` →
+  `MemoryInstance memory`.
+- `MemoryWriter.{WriteI32LE, WriteU16LE, WriteU32LE, WriteU64LE,
+   WritePrimitiveLE, WriteResultUnitOk, ZeroRange}`: same.
+- `MemoryWriter.WriteUtf8StringAllocated`: `Func<byte[]> getMemory`
+  → `MemoryInstance memory`. The post-cabi_realloc refresh now
+  happens inside `mem.AsSpan` (gap 11 pattern).
+- `MemoryWriter.WriteOptionString`: same — now takes
+  `MemoryInstance` directly.
+- `ExecContextExtensions.Memory(this ExecContext ctx)`: returns
+  `MemoryInstance`, not `byte[]`. Callers that pass `ctx.Memory`
+  as a method group (e.g. `WriteUtf8StringAllocated(ctx.Memory, ...)`)
+  now invoke it as `ctx.Memory()`.
+
+Per-binding file changes follow the same pattern: every
+`mem[ptr]` indexer becomes `mem.AsSpan(ptr, 1)[0]` (with the
+exception of legitimate `Range` indexers, which the regex
+preserves); every `Array.Copy(src, X, mem, Y, len)` becomes
+`new ReadOnlySpan<byte>(src, X, len).CopyTo(mem.AsSpan(Y, len))`;
+every `Encoding.UTF8.GetString(mem, ptr, len)` becomes
+`Encoding.UTF8.GetString(mem.AsSpan(ptr, len))`.
+
+`Wacs.WASI.Preview2.Test.ErrorCodeEncoderTests` got the same
+treatment — its `BumpAllocator` test fixture now wraps a real
+`MemoryInstance` (1-page) instead of a raw `byte[]`, and assertions
+go through a thin indexer / span helper that hides the
+`AsSpan(N, 1)[0]` boilerplate.
+
+Tests: Wacs.Core 391, Wacs.Transpiler 751, Wacs.ComponentModel
+350, Wacs.WASI.Preview2 189, Wacs.WASI.Preview1 72,
+Wacs.HostBindings 14 — all green, no regressions.
+
+After C.4b, an embedder running `wacs run --wasip2 ... model.wasm`
+with `MemoryStorage = NativePointer` exercises native-backed
+memory through every wasip2 host binding. The remaining gap-12
+work is the CLI flag (C.5 — trivial) and the AOT-emitted module
+surface (C.4c — `module.Memory` byte[] in transpiler-emitted
+`Program.cs` template + `WacsHostMemory` ctor).
+
 ## WACS.HostBindings.Abstractions 0.2.1 / WACS.WASI.Preview1 0.12.1 — gap 12 phase C.4a: WacsHostMemory mode-aware
 
 The host-binding ABI now carries a NativePointer-mode case alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## WACS 0.12.3 / WACS.Transpiler.Lib 0.7.4 — gap 12 phases A → C.3: NativePointer storage mode through interpreter and transpiler
+
+Phases A → C.3 of the byte[]→native-pointer migration from gap 12
+of `wasi-nn/WACS-GAPS.md`. Previous CHANGELOG entries below cover
+A and B; this entry adds C.1 (atomic ref helper), C.2 (cap lift),
+and C.3 (transpiler emit migration).
+
+### Phase C.1 — atomic ref helper
+
+`MemoryInstance.RefAs<T>(int ea)` (public, generic-on-T-unmanaged)
+returns a `ref T` over the requested byte offset, dispatching by
+`StorageMode`. ManagedArray returns
+`ref Unsafe.As<byte, T>(ref Data[ea])`; NativePointer returns
+`ref Unsafe.AsRef<T>(NativeBase + ea)`. Every atomic helper on
+`MemoryInstance` (Load/Store/CmpExchange/Add/And/Or/Xor in i32+i64)
+and every subword `Volatile.Read/Write` site in
+`Atomic/AtomicLoadStore.cs` and `Atomic/AtomicHandlers.cs` migrated
+to use it. `Interlocked.*` and `Volatile.*` are ref-T-based, so
+flipping the ref's source is invisible to them.
+
+Fixes a stray `CachedMem.Data.Length` in `AtomicBase.CheckEa`
+bounds check → `(long)CachedMem.ByteLength`.
+
+### Phase C.2 — cap lift for NativePointer
+
+ManagedArray stays capped at `Constants.HostMaxPages` (0x8000 =
+2 GiB, the byte[] hard limit). NativePointer lifts the cap to
+`Constants.WasmMaxPages` (0x10000 = 4 GiB, the wasm32 spec max).
+`MaxPagesForMode` dispatches both the constructor's initial check
+and `Grow`'s newNumPages check. memory64 (`WasmMaxPages64 = 2^48`)
+stays out-of-scope until phase D wires the i64-address path.
+
+### Phase C.3 — transpiler emit migration
+
+`MemoryHelpers` (`MemoryEmitter.cs`, ~40 helpers) and `BulkHelpers`
+(`BulkEmitter.cs` MemoryCopy/Fill/Init) now take `MemoryInstance`
+instead of `byte[]`. Helper bodies dispatch by mode via
+`mem.AsSpan` / `mem.RefAs<T>` / `mem.ByteLength`. The transpiler's
+emit sites in `MemoryEmitter`, `SimdEmitter`, and `BulkEmitter`
+drop the `Ldfld MemoryDataField` step and pass `MemoryInstance`
+directly. `EmitMemorySize` uses `Call get_Size` (mode-aware
+property) instead of `Ldfld Data; Ldlen`.
+
+Cleaned up two leftover `/tmp/mem_trace.log` debug-print lines in
+`LoadI64_32S` and `StoreI32_8` from earlier diagnostic work.
+
+`InitializationHelper.cs` (the standalone-AOT-loader path for
+saved .dll modules) still defaults memories to `ManagedArray`;
+threading NativePointer through that path needs a separate option
+on `TranspilerOptions` or `ModuleInitData` and lands with C.4.
+
+### Still ahead in phase C / D
+
+- **C.4: drop byte[] dual storage** — touches `WacsHostMemory`
+  (host-binding ABI), the `MemoryReader`/`MemoryWriter` helpers in
+  `Wacs.WASI.Preview2/HostBinding/CanonicalAbi/`, and every wasip2
+  binding callsite that takes a raw `byte[] memory`. Without
+  C.4, NativePointer mode works inside the wasm execution engine
+  but host bindings can't see the bytes (Data is an empty-array
+  sentinel in NativePointer mode). C.4 is required before the
+  CLI can offer a `--native-memory` flag.
+- **C.5: CLI flag** — `wacs run --native-memory` opts the run
+  into NativePointer storage end-to-end. Trivial once C.4 is in.
+- **Phase D: memory64** — widen `OpStack.PopAddr` to `nuint`,
+  switch bounds-check arithmetic to unsigned, lift cap to
+  `WasmMaxPages64`. The default-mode-aware bounds checks in
+  C.1/C.2/C.3 are already 64-bit-clean; phase D is mostly the
+  i64-address plumbing through the OpStack and validator.
+
+### Tests
+
+| Suite | Total | Note |
+|---|---|---|
+| Wacs.Core | 391 | +28 from gap 12 work (8 unit + 12 e2e + 8 atomic theory pairs) |
+| Wacs.Transpiler | 752 | unchanged |
+| Wacs.ComponentModel | 350 | unchanged |
+| Wacs.WASI.Preview2 | 189 | unchanged |
+
+All suites byte-stable on default `ManagedArray` mode; new
+`NativePointer` paths covered by `MemoryInstanceNativeStorageTests`
+(8 unit) and `MemoryNativePointerEndToEndTests` (12 [Theory]×
+2-mode end-to-end through the interpreter).
+
 ## WACS 0.12.3 — gap 12 phases A + B: NativePointer storage mode end-to-end through the interpreter
 
 Phases A + B of the byte[]→native-pointer migration from gap 12 of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,102 @@
 # Changelog
 
+## WACS.ComponentModel 0.2.1 / WACS.Transpiler.Lib 0.7.4 — gaps 10 + 11: descriptor-stat lifting and post-grow byte[] safety
+
+Closes the next two gaps from `wasi-nn/WACS-GAPS.md` (round 4):
+metadata-shaped record returns no longer come back zero-filled, and
+list/string returns survive cabi_realloc-triggered memory.grow.
+
+The Rust SLM repro that previously tripped both:
+
+```rust
+let len = std::fs::metadata("/probe/x.bin").unwrap().len();
+// gap 10: returned 0; now returns the real file size.
+let buf = std::fs::read("/probe/x.bin").unwrap();
+// gap 11: AOOR for any single read past ~24 KiB; now round-trips
+// the full file even across page-boundary growth.
+```
+
+### 1. **WACS.Transpiler.Lib (`DirectLinkedImportEmit`)** — gap 10
+
+Closes the silent IImports-stub fallback for record returns whose
+fields include `Option<X>`. `wasi:filesystem/types.descriptor.stat`
+returns `result<descriptor-stat, error-code>` where descriptor-stat
+is `record { type, link-count, size, opt<datetime>×3 }` — pre-fix
+`IsAggregateReturnSupported` rejected the record because
+`IsRecordOfPrimitives` walked fields with the non-resolver
+`IsFlatField` and bailed on the option fields, so direct-link emit
+fell back to the `IImports` proxy and the proxy returned a default-
+zero `DescriptorStat`. The fix mirrors PR #124's resource-bearing
+tuple/record extension:
+
+- Resolver-aware `IsFlatField(t, resolver)` now accepts `Option<X>`
+  whenever `IsAggregateReturnSupported(t, resolver)` recognizes the
+  Option's wire form (primitive / resource / string / byte[] /
+  record-of-primitives / nested option-or-result).
+- `IsAggregateReturnSupported`'s record + tuple branches use the
+  resolver-aware predicate so option fields cascade through.
+- `IsResultArmStorable` and `EmitResultArmStore`'s `isAggregate`
+  check accept `IsTupleOfFlatFields` / `IsRecordOfFlatFields` —
+  Result's OK arm can now BE a record-with-options.
+- `EmitTupleOrRecordFieldStore` dispatches Option fields to
+  `EmitOptionStoreAt` with a per-field base-address local. Reuses
+  the existing Option store machinery (handles innerIsRecord,
+  innerIsTuple, innerIsOption, innerIsResource, etc.) so nested
+  shapes like `Option<Datetime>` (record-of-primitives) Just Work.
+- `MaxFieldAlign`, `AlignOfFlatField`, `SizeOfFlatField`, `SizeOf`
+  pick up Option-aware overloads so per-field offsets and array
+  strides align on the inner type's MaxAlignOf.
+
+E2E coverage: new `E2E_DescriptorStat_RecordWithOptionFields`
+exercises `wasi-fs-stat-component`'s `ask-stat-size(handle)` against
+a stub `IDescriptor` that returns a known Size. Pre-fix this returns
+0; post-fix it returns the stub's value byte-for-byte.
+
+### 2. **WACS.ComponentModel (`PrimitiveStore`)** + **WACS.Transpiler.Lib (`DirectLinkedImportEmit`)** — gap 11
+
+Closes the AOOR fired by `Buffer.BlockCopy` whenever `cabi_realloc`
+triggers `memory.grow` mid-store. Root cause: `MemoryInstance.Grow`
+does `Array.Resize(ref Data, …)`, which reallocates the backing
+byte[]; every helper in `PrimitiveStore` captured `byte[] dest`
+BEFORE calling cabi_realloc, so the post-realloc copy targeted the
+stale (pre-grow) array's `int Length`, throwing AOOR for any
+allocation that crossed a page boundary. Rust std hides this behind
+"out of memory" because `fs::read` loops on `read(buf)` past 24 KiB.
+
+Fix:
+
+- Every cabi_realloc-using helper (`StoreString` / `StoreStringUtf16` /
+  `StoreStringLatin1OrUtf16` / `StoreByteArray` / `StorePrimitiveArray<T>` /
+  `StoreByteArrayList` / `StorePrimArrayList<T>` / `StoreStringList` /
+  `StoreListOfStringList` / `StoreListOfByteArrayList`) now takes
+  `MemoryInstance mem` instead of `byte[] dest` and dereferences
+  `mem.Data` per access. `mem.Data` is read AFTER each cabi_realloc
+  invocation, so writes target the post-grow array. The fixed-width
+  primitive helpers (`StoreI8`/`U8`/.../`Bool`) still take
+  `byte[] dest` — they have no cabi_realloc, no grow risk.
+- `DirectLinkedImportEmit`'s emit sites split into two prefixes:
+  variable-length helpers receive `MemoryInstance` (no
+  `Ldfld MemoryDataField`); fixed-width helpers receive `byte[] dest`
+  as before. Restructured the top-level dispatch,
+  `EmitTupleOrRecordFieldStore`, `EmitOptionStoreAt`,
+  `EmitVariantStoreAt`, and `EmitResultArmStore` accordingly.
+
+Regression coverage: new `PrimitiveStoreGrowTests` (3 cases): byte[]
+across grow, string across grow, byte[][] with mid-iteration grow.
+The cabi_realloc lambda calls `mem.Grow(...)` to mirror Rust std's
+growing realloc; pre-fix the helpers throw
+`ArgumentOutOfRangeException` deep in `Buffer.BlockCopy`, post-fix
+the bytes round-trip cleanly through the post-grow array.
+
+### API note
+
+`PrimitiveStore`'s cabi_realloc-using helpers are technically a
+public API surface, but every emit site in WACS proper is the only
+caller — the helpers exist solely to back direct-linked aggregate-
+return emit. Treating the signature change (`byte[] dest` →
+`MemoryInstance mem`) as a patch fix because the previous signature
+is unsafe to call across any cabi_realloc that grows memory.
+
 ## WACS.Transpiler.Lib 0.7.3 / WACS.Cli 1.4.1 / WACS.WASI.Preview2 0.3.1 / WACS.WASI.Preview2.DependencyInjection 0.1.1 — gap 9: preopens reach the wasip2 transpiler engine
 
 Closes the gap that prevented `wacs run --wasip2 -d models repro.wasm`

--- a/Wacs.ComponentModel/Wacs.ComponentModel.Test/PrimitiveStoreGrowTests.cs
+++ b/Wacs.ComponentModel/Wacs.ComponentModel.Test/PrimitiveStoreGrowTests.cs
@@ -1,0 +1,176 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Buffers.Binary;
+using Wacs.ComponentModel.CanonicalABI;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
+using Xunit;
+
+namespace Wacs.ComponentModel.Test
+{
+    /// <summary>
+    /// Pins the contract that PrimitiveStore.StoreXxx helpers
+    /// re-fetch <see cref="MemoryInstance.Data"/> AFTER each
+    /// cabi_realloc invocation. <c>Array.Resize</c> on grow
+    /// reallocates the byte[] field and a captured-before
+    /// reference goes stale — gap 11 from
+    /// <c>wasi-nn/WACS-GAPS.md</c>: rust's
+    /// <c>std::io::Read::read</c> threw
+    /// <see cref="ArgumentOutOfRangeException"/> for any single
+    /// call past ~24 KiB because the lower path was capturing the
+    /// pre-grow byte[] before the cabi_realloc that triggered the
+    /// grow.
+    /// </summary>
+    public class PrimitiveStoreGrowTests
+    {
+        [Fact]
+        public void StoreByteArray_ReallocGrowsMemory_BytesRoundTrip()
+        {
+            // 1-page initial memory; 100 KiB byte[] forces grow.
+            var memType = new MemoryType(1, 10);
+            var mem = new MemoryInstance(memType);
+            Assert.Equal(65536, mem.Data.Length);
+
+            byte[] value = new byte[100_000];
+            for (int i = 0; i < value.Length; i++)
+                value[i] = (byte)(i & 0xFF);
+
+            int next = 32;  // bump start
+            Func<int, int, int, int, int> cabiRealloc =
+                (oldPtr, oldSize, align, newSize) =>
+                {
+                    int aligned = (next + align - 1) & ~(align - 1);
+                    int needed = aligned + newSize;
+                    int curBytes = mem.Data.Length;
+                    if (needed > curBytes)
+                    {
+                        int pages = (needed - curBytes + 65535) / 65536;
+                        Assert.True(mem.Grow(pages));
+                    }
+                    next = needed;
+                    return aligned;
+                };
+
+            // Pre-fix this throws ArgumentOutOfRangeException inside
+            // Buffer.BlockCopy because mem.Data is captured before
+            // cabi_realloc grows it. Post-fix the helper re-fetches
+            // mem.Data after cabi_realloc returns.
+            PrimitiveStore.StoreByteArray(mem, 0, value, cabiRealloc);
+
+            Assert.True(mem.Data.Length >= 100_032,
+                $"expected mem.Data >= 100032, got {mem.Data.Length}");
+
+            int ptr = BinaryPrimitives.ReadInt32LittleEndian(
+                mem.Data.AsSpan(0, 4));
+            int len = BinaryPrimitives.ReadInt32LittleEndian(
+                mem.Data.AsSpan(4, 4));
+            Assert.Equal(32, ptr);
+            Assert.Equal(100_000, len);
+
+            for (int i = 0; i < value.Length; i++)
+                Assert.Equal((byte)(i & 0xFF), mem.Data[ptr + i]);
+        }
+
+        [Fact]
+        public void StoreString_ReallocGrowsMemory_BytesRoundTrip()
+        {
+            var memType = new MemoryType(1, 10);
+            var mem = new MemoryInstance(memType);
+
+            // 50 KiB ASCII string — encoded as 50 KiB UTF-8, fits
+            // in the first page minus retArea slot but ride the
+            // post-realloc fetch path anyway. Pad to push past the
+            // initial 64 KiB memory.
+            string value = new string('A', 80_000);
+
+            int next = 32;
+            Func<int, int, int, int, int> cabiRealloc =
+                (oldPtr, oldSize, align, newSize) =>
+                {
+                    int aligned = (next + align - 1) & ~(align - 1);
+                    int needed = aligned + newSize;
+                    int curBytes = mem.Data.Length;
+                    if (needed > curBytes)
+                    {
+                        int pages = (needed - curBytes + 65535) / 65536;
+                        Assert.True(mem.Grow(pages));
+                    }
+                    next = needed;
+                    return aligned;
+                };
+
+            PrimitiveStore.StoreString(mem, 0, value, cabiRealloc);
+
+            int ptr = BinaryPrimitives.ReadInt32LittleEndian(
+                mem.Data.AsSpan(0, 4));
+            int len = BinaryPrimitives.ReadInt32LittleEndian(
+                mem.Data.AsSpan(4, 4));
+            Assert.Equal(80_000, len);
+            Assert.Equal((byte)'A', mem.Data[ptr]);
+            Assert.Equal((byte)'A', mem.Data[ptr + 79_999]);
+        }
+
+        [Fact]
+        public void StoreByteArrayList_PerElementGrowDuringIter_BytesRoundTrip()
+        {
+            // Multiple sub-arrays — cabi_realloc fires per-element.
+            // First element fits, second triggers grow. The helper's
+            // outer (sub_ptr, sub_len) writes happen after the grow
+            // — must use the fresh mem.Data.
+            var memType = new MemoryType(1, 10);
+            var mem = new MemoryInstance(memType);
+
+            byte[][] value = new byte[][]
+            {
+                new byte[100],
+                new byte[80_000],   // forces grow on second iteration
+                new byte[50],
+            };
+            for (int i = 0; i < value[0].Length; i++) value[0][i] = 0xAA;
+            for (int i = 0; i < value[1].Length; i++) value[1][i] = 0xBB;
+            for (int i = 0; i < value[2].Length; i++) value[2][i] = 0xCC;
+
+            int next = 32;
+            Func<int, int, int, int, int> cabiRealloc =
+                (oldPtr, oldSize, align, newSize) =>
+                {
+                    int aligned = (next + align - 1) & ~(align - 1);
+                    int needed = aligned + newSize;
+                    int curBytes = mem.Data.Length;
+                    if (needed > curBytes)
+                    {
+                        int pages = (needed - curBytes + 65535) / 65536;
+                        Assert.True(mem.Grow(pages));
+                    }
+                    next = needed;
+                    return aligned;
+                };
+
+            PrimitiveStore.StoreByteArrayList(mem, 0, value, cabiRealloc);
+
+            int outerPtr = BinaryPrimitives.ReadInt32LittleEndian(
+                mem.Data.AsSpan(0, 4));
+            int count = BinaryPrimitives.ReadInt32LittleEndian(
+                mem.Data.AsSpan(4, 4));
+            Assert.Equal(3, count);
+
+            for (int i = 0; i < count; i++)
+            {
+                int subPtr = BinaryPrimitives.ReadInt32LittleEndian(
+                    mem.Data.AsSpan(outerPtr + i * 8, 4));
+                int subLen = BinaryPrimitives.ReadInt32LittleEndian(
+                    mem.Data.AsSpan(outerPtr + i * 8 + 4, 4));
+                Assert.Equal(value[i].Length, subLen);
+                Assert.Equal(value[i][0], mem.Data[subPtr]);
+                Assert.Equal(value[i][value[i].Length - 1],
+                    mem.Data[subPtr + subLen - 1]);
+            }
+        }
+    }
+}

--- a/Wacs.ComponentModel/Wacs.ComponentModel.Test/PrimitiveStoreGrowTests.cs
+++ b/Wacs.ComponentModel/Wacs.ComponentModel.Test/PrimitiveStoreGrowTests.cs
@@ -15,17 +15,14 @@ using Xunit;
 namespace Wacs.ComponentModel.Test
 {
     /// <summary>
-    /// Pins the contract that PrimitiveStore.StoreXxx helpers
+    /// Pins the contract that <c>PrimitiveStore.StoreXxx</c> helpers
     /// re-fetch <see cref="MemoryInstance.Data"/> AFTER each
-    /// cabi_realloc invocation. <c>Array.Resize</c> on grow
-    /// reallocates the byte[] field and a captured-before
-    /// reference goes stale — gap 11 from
-    /// <c>wasi-nn/WACS-GAPS.md</c>: rust's
-    /// <c>std::io::Read::read</c> threw
-    /// <see cref="ArgumentOutOfRangeException"/> for any single
-    /// call past ~24 KiB because the lower path was capturing the
-    /// pre-grow byte[] before the cabi_realloc that triggered the
-    /// grow.
+    /// <c>cabi_realloc</c> invocation. <c>Array.Resize</c> on grow
+    /// reallocates the <c>byte[]</c> field and any reference
+    /// captured before the call goes stale — Rust guests calling
+    /// <c>std::io::Read::read</c> with buffers that cross a page
+    /// boundary surface this as <see cref="ArgumentOutOfRangeException"/>
+    /// inside <c>Buffer.BlockCopy</c>.
     /// </summary>
     public class PrimitiveStoreGrowTests
     {

--- a/Wacs.ComponentModel/Wacs.ComponentModel/CanonicalABI/PrimitiveStore.cs
+++ b/Wacs.ComponentModel/Wacs.ComponentModel/CanonicalABI/PrimitiveStore.cs
@@ -86,11 +86,10 @@ namespace Wacs.ComponentModel.CanonicalABI
                     "String returns require the component to "
                     + "export `cabi_realloc`.");
             // cabi_realloc can call memory.grow, which reassigns
-            // MemoryInstance.Data to a fresh, larger byte[] —
-            // closes gap 11 (input-stream.read AOOR for buffers
-            // crossing the page boundary). Read mem.Data AFTER
-            // every cabi_realloc invocation so the writes target
-            // the post-grow array.
+            // MemoryInstance.Data to a fresh, larger byte[].
+            // Reading mem.Data AFTER each cabi_realloc keeps the
+            // BlockCopy / WriteInt32 targets pointing at the live
+            // backing.
             var bytes = Encoding.UTF8.GetBytes(value);
             var ptr = cabiRealloc(0, 0, 1, bytes.Length);
             Buffer.BlockCopy(bytes, 0, mem.Data, ptr, bytes.Length);
@@ -170,9 +169,9 @@ namespace Wacs.ComponentModel.CanonicalABI
                     "byte[] returns require the component to "
                     + "export `cabi_realloc`.");
             var ptr = cabiRealloc(0, 0, 1, value.Length);
-            // Reference mem.Data AFTER cabi_realloc — gap 11: a
-            // memory.grow inside cabi_realloc reassigns mem.Data
-            // to a new (larger) byte[]; the old reference is stale.
+            // Reference mem.Data AFTER cabi_realloc: a memory.grow
+            // inside cabi_realloc reassigns mem.Data to a new
+            // (larger) byte[], and any earlier reference is stale.
             Buffer.BlockCopy(value, 0, mem.Data, ptr, value.Length);
             BinaryPrimitives.WriteInt32LittleEndian(
                 mem.Data.AsSpan(retAreaOffset, 4), ptr);

--- a/Wacs.ComponentModel/Wacs.ComponentModel/CanonicalABI/PrimitiveStore.cs
+++ b/Wacs.ComponentModel/Wacs.ComponentModel/CanonicalABI/PrimitiveStore.cs
@@ -9,6 +9,7 @@ using System;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using System.Text;
+using Wacs.Core.Runtime.Types;
 
 namespace Wacs.ComponentModel.CanonicalABI
 {
@@ -77,25 +78,26 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// encoded with the canon-ABI default UTF-8; UTF-16 /
         /// Latin1+UTF-16 encoders ride incrementally.</para>
         /// </summary>
-        public static void StoreString(byte[] dest, int retAreaOffset,
+        public static void StoreString(MemoryInstance mem, int retAreaOffset,
             string value, Func<int, int, int, int, int> cabiRealloc)
         {
             if (cabiRealloc == null)
                 throw new InvalidOperationException(
                     "String returns require the component to "
                     + "export `cabi_realloc`.");
-            // The dest buffer can be re-bound by cabi_realloc if
-            // the underlying wasm memory grows; re-fetch by lookup
-            // through the same memory we got passed (in WACS today
-            // the byte[] reference is stable per memory instance,
-            // but defensive re-bind is cheap).
+            // cabi_realloc can call memory.grow, which reassigns
+            // MemoryInstance.Data to a fresh, larger byte[] —
+            // closes gap 11 (input-stream.read AOOR for buffers
+            // crossing the page boundary). Read mem.Data AFTER
+            // every cabi_realloc invocation so the writes target
+            // the post-grow array.
             var bytes = Encoding.UTF8.GetBytes(value);
             var ptr = cabiRealloc(0, 0, 1, bytes.Length);
-            Buffer.BlockCopy(bytes, 0, dest, ptr, bytes.Length);
+            Buffer.BlockCopy(bytes, 0, mem.Data, ptr, bytes.Length);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), ptr);
+                mem.Data.AsSpan(retAreaOffset, 4), ptr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), bytes.Length);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), bytes.Length);
         }
 
         /// <summary>
@@ -106,8 +108,9 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// receives (ptr, codeUnitCount) — note <b>length is in
         /// u16 code units, not bytes</b> per CanonicalABI.md.
         /// </summary>
-        public static void StoreStringUtf16(byte[] dest, int retAreaOffset,
-            string value, Func<int, int, int, int, int> cabiRealloc)
+        public static void StoreStringUtf16(MemoryInstance mem,
+            int retAreaOffset, string value,
+            Func<int, int, int, int, int> cabiRealloc)
         {
             if (cabiRealloc == null)
                 throw new InvalidOperationException(
@@ -115,11 +118,11 @@ namespace Wacs.ComponentModel.CanonicalABI
                     + "export `cabi_realloc`.");
             var bytes = Encoding.Unicode.GetBytes(value);
             var ptr = cabiRealloc(0, 0, 2, bytes.Length);
-            Buffer.BlockCopy(bytes, 0, dest, ptr, bytes.Length);
+            Buffer.BlockCopy(bytes, 0, mem.Data, ptr, bytes.Length);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), ptr);
+                mem.Data.AsSpan(retAreaOffset, 4), ptr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), bytes.Length / 2);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), bytes.Length / 2);
         }
 
         /// <summary>
@@ -131,7 +134,7 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// (ptr, taggedCodeUnits) where the tagged value =
         /// codeUnits | <see cref="StringMarshal.Latin1OrUtf16Tag"/>.
         /// </summary>
-        public static void StoreStringLatin1OrUtf16(byte[] dest,
+        public static void StoreStringLatin1OrUtf16(MemoryInstance mem,
             int retAreaOffset, string value,
             Func<int, int, int, int, int> cabiRealloc)
         {
@@ -141,14 +144,14 @@ namespace Wacs.ComponentModel.CanonicalABI
                     + "export `cabi_realloc`.");
             var bytes = Encoding.Unicode.GetBytes(value);
             var ptr = cabiRealloc(0, 0, 2, bytes.Length);
-            Buffer.BlockCopy(bytes, 0, dest, ptr, bytes.Length);
+            Buffer.BlockCopy(bytes, 0, mem.Data, ptr, bytes.Length);
             int codeUnits = bytes.Length / 2;
             uint tagged = (uint)codeUnits
                 | StringMarshal.Latin1OrUtf16Tag;
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), ptr);
+                mem.Data.AsSpan(retAreaOffset, 4), ptr);
             BinaryPrimitives.WriteUInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), tagged);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), tagged);
         }
 
         /// <summary>
@@ -159,7 +162,7 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// Used by direct-linked aggregate-RETURN emit when the
         /// host returns a byte[].
         /// </summary>
-        public static void StoreByteArray(byte[] dest, int retAreaOffset,
+        public static void StoreByteArray(MemoryInstance mem, int retAreaOffset,
             byte[] value, Func<int, int, int, int, int> cabiRealloc)
         {
             if (cabiRealloc == null)
@@ -167,11 +170,14 @@ namespace Wacs.ComponentModel.CanonicalABI
                     "byte[] returns require the component to "
                     + "export `cabi_realloc`.");
             var ptr = cabiRealloc(0, 0, 1, value.Length);
-            Buffer.BlockCopy(value, 0, dest, ptr, value.Length);
+            // Reference mem.Data AFTER cabi_realloc — gap 11: a
+            // memory.grow inside cabi_realloc reassigns mem.Data
+            // to a new (larger) byte[]; the old reference is stale.
+            Buffer.BlockCopy(value, 0, mem.Data, ptr, value.Length);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), ptr);
+                mem.Data.AsSpan(retAreaOffset, 4), ptr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), value.Length);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), value.Length);
         }
 
         /// <summary>
@@ -191,7 +197,7 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// <para>Used by direct-linked aggregate-RETURN emit when the
         /// host returns int[], long[], float[], etc.</para>
         /// </summary>
-        public static void StorePrimitiveArray<T>(byte[] dest,
+        public static void StorePrimitiveArray<T>(MemoryInstance mem,
             int retAreaOffset, T[] value,
             Func<int, int, int, int, int> cabiRealloc)
             where T : unmanaged
@@ -205,11 +211,11 @@ namespace Wacs.ComponentModel.CanonicalABI
             var ptr = cabiRealloc(0, 0, elementSize, byteCount);
             var srcBytes = MemoryMarshal.AsBytes(
                 new ReadOnlySpan<T>(value));
-            srcBytes.CopyTo(dest.AsSpan(ptr, byteCount));
+            srcBytes.CopyTo(mem.Data.AsSpan(ptr, byteCount));
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), ptr);
+                mem.Data.AsSpan(retAreaOffset, 4), ptr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), value.Length);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), value.Length);
         }
 
         /// <summary>
@@ -223,8 +229,9 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// minus the UTF-8 encode step. Used by direct-linked
         /// aggregate-RETURN emit when the host returns byte[][].</para>
         /// </summary>
-        public static void StoreByteArrayList(byte[] dest, int retAreaOffset,
-            byte[][] value, Func<int, int, int, int, int> cabiRealloc)
+        public static void StoreByteArrayList(MemoryInstance mem,
+            int retAreaOffset, byte[][] value,
+            Func<int, int, int, int, int> cabiRealloc)
         {
             if (cabiRealloc == null)
                 throw new InvalidOperationException(
@@ -237,16 +244,16 @@ namespace Wacs.ComponentModel.CanonicalABI
             {
                 var sub = value[i];
                 var subPtr = cabiRealloc(0, 0, 1, sub.Length);
-                Buffer.BlockCopy(sub, 0, dest, subPtr, sub.Length);
+                Buffer.BlockCopy(sub, 0, mem.Data, subPtr, sub.Length);
                 BinaryPrimitives.WriteInt32LittleEndian(
-                    dest.AsSpan(outerPtr + i * 8, 4), subPtr);
+                    mem.Data.AsSpan(outerPtr + i * 8, 4), subPtr);
                 BinaryPrimitives.WriteInt32LittleEndian(
-                    dest.AsSpan(outerPtr + i * 8 + 4, 4), sub.Length);
+                    mem.Data.AsSpan(outerPtr + i * 8 + 4, 4), sub.Length);
             }
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), outerPtr);
+                mem.Data.AsSpan(retAreaOffset, 4), outerPtr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), count);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), count);
         }
 
         /// <summary>
@@ -263,7 +270,7 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// <para>Used by direct-linked aggregate-RETURN emit when
         /// the host returns int[][], long[][], etc.</para>
         /// </summary>
-        public static void StorePrimArrayList<T>(byte[] dest,
+        public static void StorePrimArrayList<T>(MemoryInstance mem,
             int retAreaOffset, T[][] value,
             Func<int, int, int, int, int> cabiRealloc)
             where T : unmanaged
@@ -283,16 +290,16 @@ namespace Wacs.ComponentModel.CanonicalABI
                 var subPtr = cabiRealloc(0, 0, elementSize, subByteCount);
                 var srcBytes = MemoryMarshal.AsBytes(
                     new ReadOnlySpan<T>(sub));
-                srcBytes.CopyTo(dest.AsSpan(subPtr, subByteCount));
+                srcBytes.CopyTo(mem.Data.AsSpan(subPtr, subByteCount));
                 BinaryPrimitives.WriteInt32LittleEndian(
-                    dest.AsSpan(outerPtr + i * 8, 4), subPtr);
+                    mem.Data.AsSpan(outerPtr + i * 8, 4), subPtr);
                 BinaryPrimitives.WriteInt32LittleEndian(
-                    dest.AsSpan(outerPtr + i * 8 + 4, 4), sub.Length);
+                    mem.Data.AsSpan(outerPtr + i * 8 + 4, 4), sub.Length);
             }
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), outerPtr);
+                mem.Data.AsSpan(retAreaOffset, 4), outerPtr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), count);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), count);
         }
 
         /// <summary>
@@ -308,8 +315,9 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// <para>Used by direct-linked aggregate-RETURN emit when the
         /// host returns string[].</para>
         /// </summary>
-        public static void StoreStringList(byte[] dest, int retAreaOffset,
-            string[] value, Func<int, int, int, int, int> cabiRealloc)
+        public static void StoreStringList(MemoryInstance mem,
+            int retAreaOffset, string[] value,
+            Func<int, int, int, int, int> cabiRealloc)
         {
             if (cabiRealloc == null)
                 throw new InvalidOperationException(
@@ -322,17 +330,17 @@ namespace Wacs.ComponentModel.CanonicalABI
             {
                 var bytes = Encoding.UTF8.GetBytes(value[i]);
                 var sPtr = cabiRealloc(0, 0, 1, bytes.Length);
-                Buffer.BlockCopy(bytes, 0, dest, sPtr, bytes.Length);
+                Buffer.BlockCopy(bytes, 0, mem.Data, sPtr, bytes.Length);
                 BinaryPrimitives.WriteInt32LittleEndian(
-                    dest.AsSpan(outerPtr + i * 8, 4), sPtr);
+                    mem.Data.AsSpan(outerPtr + i * 8, 4), sPtr);
                 BinaryPrimitives.WriteInt32LittleEndian(
-                    dest.AsSpan(outerPtr + i * 8 + 4, 4),
+                    mem.Data.AsSpan(outerPtr + i * 8 + 4, 4),
                     bytes.Length);
             }
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), outerPtr);
+                mem.Data.AsSpan(retAreaOffset, 4), outerPtr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), count);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), count);
         }
 
         /// <summary>
@@ -346,7 +354,7 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// inner string-pair array + per-string UTF-8 buffers).
         /// Mirrors realistic shapes like HTTP's list-of-header-lists.</para>
         /// </summary>
-        public static void StoreListOfStringList(byte[] dest,
+        public static void StoreListOfStringList(MemoryInstance mem,
             int retAreaOffset, string[][] value,
             Func<int, int, int, int, int> cabiRealloc)
         {
@@ -359,13 +367,13 @@ namespace Wacs.ComponentModel.CanonicalABI
             int outerPtr = cabiRealloc(0, 0, 4, outerByteCount);
             for (int i = 0; i < count; i++)
             {
-                StoreStringList(dest, outerPtr + i * 8, value[i],
+                StoreStringList(mem, outerPtr + i * 8, value[i],
                     cabiRealloc);
             }
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), outerPtr);
+                mem.Data.AsSpan(retAreaOffset, 4), outerPtr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), count);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), count);
         }
 
         /// <summary>
@@ -375,7 +383,7 @@ namespace Wacs.ComponentModel.CanonicalABI
         /// <see cref="StoreListOfStringList"/> but with raw bytes
         /// instead of UTF-8 strings.
         /// </summary>
-        public static void StoreListOfByteArrayList(byte[] dest,
+        public static void StoreListOfByteArrayList(MemoryInstance mem,
             int retAreaOffset, byte[][][] value,
             Func<int, int, int, int, int> cabiRealloc)
         {
@@ -388,13 +396,13 @@ namespace Wacs.ComponentModel.CanonicalABI
             int outerPtr = cabiRealloc(0, 0, 4, outerByteCount);
             for (int i = 0; i < count; i++)
             {
-                StoreByteArrayList(dest, outerPtr + i * 8, value[i],
+                StoreByteArrayList(mem, outerPtr + i * 8, value[i],
                     cabiRealloc);
             }
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset, 4), outerPtr);
+                mem.Data.AsSpan(retAreaOffset, 4), outerPtr);
             BinaryPrimitives.WriteInt32LittleEndian(
-                dest.AsSpan(retAreaOffset + 4, 4), count);
+                mem.Data.AsSpan(retAreaOffset + 4, 4), count);
         }
 
         // sizeof(T) requires unsafe; cache the per-T size once via

--- a/Wacs.ComponentModel/Wacs.ComponentModel/Wacs.ComponentModel.csproj
+++ b/Wacs.ComponentModel/Wacs.ComponentModel/Wacs.ComponentModel.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.ComponentModel</AssemblyName>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.2.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>

--- a/Wacs.ComponentModel/Wacs.ComponentModel/Wacs.ComponentModel.csproj
+++ b/Wacs.ComponentModel/Wacs.ComponentModel/Wacs.ComponentModel.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.ComponentModel</AssemblyName>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
-        <Version>0.2.1</Version>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
+        <Version>0.3.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>

--- a/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
+++ b/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
@@ -98,6 +98,29 @@ namespace Wacs.Console.Verbs
 
         private static int ExecuteSingleCore(RunOptions opts, string wasmPath)
         {
+            // Phase C.5 / C.4c: a `wacs run --native-memory` invocation
+            // sets the storage mode for both the interpreter
+            // (RuntimeOptions.MemoryStorage on the InstantiateModule
+            // call below) and the transpiler-engine path (the static
+            // ModuleInit.CurrentMemoryStorage flag InitializationHelper
+            // reads when the transpiled module class is constructed).
+            // Reset to ManagedArray on exit so subsequent in-process
+            // calls (test harnesses, library hosts) aren't affected.
+            var prevStorage = ModuleInit.CurrentMemoryStorage;
+            if (opts.NativeMemory)
+                ModuleInit.CurrentMemoryStorage = MemoryStorageMode.NativePointer;
+            try
+            {
+                return ExecuteSingleCoreInner(opts, wasmPath);
+            }
+            finally
+            {
+                ModuleInit.CurrentMemoryStorage = prevStorage;
+            }
+        }
+
+        private static int ExecuteSingleCoreInner(RunOptions opts, string wasmPath)
+        {
             string fileExtension = Path.GetExtension(wasmPath).ToLowerInvariant();
             if (fileExtension != ".wasm" && fileExtension != ".wat")
             {
@@ -209,6 +232,9 @@ namespace Wacs.Console.Verbs
                 {
                     SkipModuleValidation = true,
                     TimeInstantiation = opts.Verbose,
+                    MemoryStorage = opts.NativeMemory
+                        ? MemoryStorageMode.NativePointer
+                        : MemoryStorageMode.ManagedArray,
                 });
             runtime.RegisterModule(moduleName, modInst);
 
@@ -422,7 +448,13 @@ namespace Wacs.Console.Verbs
                     using var fs = new FileStream(inputPath, FileMode.Open,
                         FileAccess.Read);
                     m = BinaryModuleParser.ParseWasm(fs);
-                    inst = runtime.InstantiateModule(m);
+                    inst = runtime.InstantiateModule(m,
+                        new RuntimeOptions
+                        {
+                            MemoryStorage = opts.NativeMemory
+                                ? MemoryStorageMode.NativePointer
+                                : MemoryStorageMode.ManagedArray,
+                        });
                     runtime.RegisterModule(name, inst);
                 }
                 catch (Exception ex)
@@ -497,6 +529,29 @@ namespace Wacs.Console.Verbs
         // ============================================================
 
         private static int ExecuteComponent(RunOptions opts, string componentPath)
+        {
+            // Phase C.5 / C.4c: pin the storage mode for the
+            // duration of the component run. Both the interpreter
+            // component path (Wacs.ComponentModel.Runtime.ComponentInstance
+            // .Instantiate) and the transpiled path
+            // (ExecuteComponentTranspiled → InitializationHelper)
+            // observe ModuleInit.CurrentMemoryStorage at memory-
+            // alloc time. Reset on return so other in-process
+            // callers aren't affected.
+            var prevStorage = ModuleInit.CurrentMemoryStorage;
+            if (opts.NativeMemory)
+                ModuleInit.CurrentMemoryStorage = MemoryStorageMode.NativePointer;
+            try
+            {
+                return ExecuteComponentInner(opts, componentPath);
+            }
+            finally
+            {
+                ModuleInit.CurrentMemoryStorage = prevStorage;
+            }
+        }
+
+        private static int ExecuteComponentInner(RunOptions opts, string componentPath)
         {
             // --wasip2 / --host-package implies the transpiler engine
             // for components — those flags route through the typed

--- a/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
+++ b/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
@@ -98,14 +98,14 @@ namespace Wacs.Console.Verbs
 
         private static int ExecuteSingleCore(RunOptions opts, string wasmPath)
         {
-            // Phase C.5 / C.4c: a `wacs run --native-memory` invocation
-            // sets the storage mode for both the interpreter
-            // (RuntimeOptions.MemoryStorage on the InstantiateModule
-            // call below) and the transpiler-engine path (the static
-            // ModuleInit.CurrentMemoryStorage flag InitializationHelper
-            // reads when the transpiled module class is constructed).
-            // Reset to ManagedArray on exit so subsequent in-process
-            // calls (test harnesses, library hosts) aren't affected.
+            // --native-memory pins the storage mode for both the
+            // interpreter (RuntimeOptions.MemoryStorage) and the
+            // transpiler-engine path (the static
+            // ModuleInit.CurrentMemoryStorage that
+            // InitializationHelper reads when the transpiled module
+            // class is constructed). Restored on exit so subsequent
+            // in-process callers (test harnesses, library hosts)
+            // aren't affected.
             var prevStorage = ModuleInit.CurrentMemoryStorage;
             if (opts.NativeMemory)
                 ModuleInit.CurrentMemoryStorage = MemoryStorageMode.NativePointer;
@@ -530,14 +530,14 @@ namespace Wacs.Console.Verbs
 
         private static int ExecuteComponent(RunOptions opts, string componentPath)
         {
-            // Phase C.5 / C.4c: pin the storage mode for the
-            // duration of the component run. Both the interpreter
-            // component path (Wacs.ComponentModel.Runtime.ComponentInstance
-            // .Instantiate) and the transpiled path
-            // (ExecuteComponentTranspiled → InitializationHelper)
-            // observe ModuleInit.CurrentMemoryStorage at memory-
-            // alloc time. Reset on return so other in-process
-            // callers aren't affected.
+            // Pin the storage mode for the duration of the run.
+            // Both the interpreter component path
+            // (Wacs.ComponentModel.Runtime.ComponentInstance.Instantiate)
+            // and the transpiled path (ExecuteComponentTranspiled →
+            // InitializationHelper) observe
+            // ModuleInit.CurrentMemoryStorage at memory-alloc time.
+            // Restored on return so other in-process callers
+            // aren't affected.
             var prevStorage = ModuleInit.CurrentMemoryStorage;
             if (opts.NativeMemory)
                 ModuleInit.CurrentMemoryStorage = MemoryStorageMode.NativePointer;

--- a/Wacs.Console/Wacs.Console/Verbs/RunOptions.cs
+++ b/Wacs.Console/Wacs.Console/Verbs/RunOptions.cs
@@ -188,14 +188,13 @@ namespace Wacs.Console.Verbs
         public string DataStorage { get; set; } = "compressed";
 
         [Option("native-memory", HelpText =
-            "Allocate wasm linear memory via NativeMemory.AllocZeroed "
-            + "(byte* + nuint length) instead of byte[]. Lifts the "
-            + "~2 GiB Array.MaxLength cap to the wasm32 spec's 4 GiB. "
-            + "Required for guests that allocate >2 GiB of linear "
-            + "memory. Adds a per-MemoryInstance dispatch branch on "
-            + "every memory access — minor perf hit on sub-2 GiB "
-            + "workloads where the default ManagedArray mode is "
-            + "byte-stable. Phase C.5 from gap 12.")]
+            "Back wasm linear memory with native-pointer storage "
+            + "(NativeMemory.AllocZeroed) instead of a managed byte[]. "
+            + "Lifts the ~2 GiB Array.MaxLength cap to the wasm32 "
+            + "spec's 4 GiB; required for memory64 modules and any "
+            + "guest that allocates more than ~2 GiB of linear memory. "
+            + "Adds a per-access mode-dispatch branch — minor perf "
+            + "cost on sub-2 GiB workloads.")]
         public bool NativeMemory { get; set; }
 
         // Trailing argv comes through the dispatcher (Program.cs's

--- a/Wacs.Console/Wacs.Console/Verbs/RunOptions.cs
+++ b/Wacs.Console/Wacs.Console/Verbs/RunOptions.cs
@@ -187,6 +187,17 @@ namespace Wacs.Console.Verbs
             + "compressed | raw | static.")]
         public string DataStorage { get; set; } = "compressed";
 
+        [Option("native-memory", HelpText =
+            "Allocate wasm linear memory via NativeMemory.AllocZeroed "
+            + "(byte* + nuint length) instead of byte[]. Lifts the "
+            + "~2 GiB Array.MaxLength cap to the wasm32 spec's 4 GiB. "
+            + "Required for guests that allocate >2 GiB of linear "
+            + "memory. Adds a per-MemoryInstance dispatch branch on "
+            + "every memory access — minor perf hit on sub-2 GiB "
+            + "workloads where the default ManagedArray mode is "
+            + "byte-stable. Phase C.5 from gap 12.")]
+        public bool NativeMemory { get; set; }
+
         // Trailing argv comes through the dispatcher (Program.cs's
         // direct-run shortcut + dash-dash split). This list is
         // populated programmatically rather than via [Value], to

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.4.1</Version>
-    <AssemblyVersion>1.4.1</AssemblyVersion>
+    <Version>1.4.2</Version>
+    <AssemblyVersion>1.4.2</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.4.2</Version>
-    <AssemblyVersion>1.4.2</AssemblyVersion>
+    <Version>1.5.0</Version>
+    <AssemblyVersion>1.5.0</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Core/Wacs.Core.Test/MemoryInstanceNativeStorageTests.cs
+++ b/Wacs.Core/Wacs.Core.Test/MemoryInstanceNativeStorageTests.cs
@@ -1,0 +1,185 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
+using Wacs.Core.Utilities;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// Pins the contract for <see cref="MemoryStorageMode.NativePointer"/>:
+    /// allocation, indexer + AsSpan parity with the byte[] backing,
+    /// grow preserves live bytes and zero-fills the new pages, and
+    /// Dispose actually releases the native buffer.
+    ///
+    /// <para>Phase A from <c>wasi-nn/WACS-GAPS.md</c> gap 12 — the
+    /// migration from byte[] (2 GiB cap) to native-pointer storage.
+    /// Phase A only adds the storage mode; subsequent phases migrate
+    /// the interpreter and transpiler access sites to consult it.</para>
+    /// </summary>
+    public unsafe class MemoryInstanceNativeStorageTests
+    {
+        [Fact]
+        public void NativePointer_Ctor_AllocatesZeroedPage()
+        {
+            var memType = new MemoryType(1, 10);
+            using var mem = new MemoryInstance(memType,
+                MemoryStorageMode.NativePointer);
+
+            Assert.Equal(MemoryStorageMode.NativePointer, mem.StorageMode);
+            Assert.True(mem.NativeBase != null);
+            Assert.Equal((nuint)65536, mem.NativeSize);
+            Assert.Equal(1, mem.Size);
+            Assert.Equal((nuint)65536, mem.ByteLength);
+
+            // Zero-initialized — every byte should be 0.
+            for (int i = 0; i < 65536; i += 1024)
+                Assert.Equal((byte)0, mem.NativeBase[i]);
+
+            // Sentinel managed array stays empty so accidental
+            // Data[i] reads fail loudly instead of zero-reading.
+            Assert.Empty(mem.Data);
+        }
+
+        [Fact]
+        public void ManagedArray_Ctor_DefaultsByteArray()
+        {
+            var memType = new MemoryType(1, 10);
+            using var mem = new MemoryInstance(memType);  // default mode
+
+            Assert.Equal(MemoryStorageMode.ManagedArray, mem.StorageMode);
+            Assert.Equal(65536, mem.Data.Length);
+            Assert.Equal((nuint)65536, mem.ByteLength);
+            Assert.Equal(1, mem.Size);
+        }
+
+        [Fact]
+        public void NativePointer_AsSpan_ReadWrite_RoundTrips()
+        {
+            var memType = new MemoryType(1, 10);
+            using var mem = new MemoryInstance(memType,
+                MemoryStorageMode.NativePointer);
+
+            var span = mem.AsSpan(100, 4);
+            span[0] = 0xDE;
+            span[1] = 0xAD;
+            span[2] = 0xBE;
+            span[3] = 0xEF;
+
+            // Read via raw pointer to confirm the writes hit native
+            // memory (not some shadow buffer).
+            Assert.Equal(0xDE, mem.NativeBase[100]);
+            Assert.Equal(0xAD, mem.NativeBase[101]);
+            Assert.Equal(0xBE, mem.NativeBase[102]);
+            Assert.Equal(0xEF, mem.NativeBase[103]);
+
+            // AsSpan re-read returns the same bytes.
+            var readback = mem.AsSpan(100, 4);
+            Assert.Equal(0xDE, readback[0]);
+            Assert.Equal(0xEF, readback[3]);
+        }
+
+        [Fact]
+        public void NativePointer_Indexer_RangeSlice_RoundTrips()
+        {
+            var memType = new MemoryType(1, 10);
+            using var mem = new MemoryInstance(memType,
+                MemoryStorageMode.NativePointer);
+
+            var span = mem[200..208];
+            for (int i = 0; i < span.Length; i++) span[i] = (byte)(0xA0 + i);
+
+            for (int i = 0; i < 8; i++)
+                Assert.Equal((byte)(0xA0 + i), mem.NativeBase[200 + i]);
+        }
+
+        [Fact]
+        public void NativePointer_Grow_PreservesLiveBytes_ZeroFillsNew()
+        {
+            var memType = new MemoryType(1, 10);
+            using var mem = new MemoryInstance(memType,
+                MemoryStorageMode.NativePointer);
+
+            // Stamp signature bytes near the end of page 0 + start.
+            mem.AsSpan(0, 4).CopyTo(new byte[] { 1, 2, 3, 4 });
+            mem.NativeBase[0] = 0x11;
+            mem.NativeBase[65535] = 0x22;
+
+            byte* preGrowBase = mem.NativeBase;
+            Assert.True(mem.Grow(2));  // +2 pages → 3 pages
+            Assert.Equal(3, mem.Size);
+            Assert.Equal((nuint)(3 * 65536), mem.NativeSize);
+            // Realloc should have moved the buffer (or at least not
+            // left the same pointer with zeroed signature bytes).
+            Assert.Equal(0x11, mem.NativeBase[0]);
+            Assert.Equal(0x22, mem.NativeBase[65535]);
+
+            // New pages are zero-initialized.
+            Assert.Equal(0, mem.NativeBase[65536]);
+            Assert.Equal(0, mem.NativeBase[3 * 65536 - 1]);
+
+            // The freed buffer should not be aliased to the live
+            // one; if alloc happened to recycle the same address
+            // the test would still pass on byte content but flag
+            // unintended aliasing here is informational.
+            _ = preGrowBase;
+        }
+
+        [Fact]
+        public void NativePointer_Grow_RejectedAtHostMaxPages()
+        {
+            // HostMaxPages = 0x8000 = 32768 pages = 2 GiB. Ask for
+            // one page over the cap; Grow must refuse and leave the
+            // memory unchanged.
+            var memType = new MemoryType(1, Constants.HostMaxPages);
+            using var mem = new MemoryInstance(memType,
+                MemoryStorageMode.NativePointer);
+
+            // numPages = HostMaxPages would put newNumPages at
+            // HostMaxPages + 1 — over the cap.
+            Assert.False(mem.Grow(Constants.HostMaxPages));
+            Assert.Equal(1, mem.Size);
+            Assert.Equal((nuint)65536, mem.NativeSize);
+        }
+
+        [Fact]
+        public void NativePointer_Dispose_FreesAndIsIdempotent()
+        {
+            var memType = new MemoryType(1, 10);
+            var mem = new MemoryInstance(memType,
+                MemoryStorageMode.NativePointer);
+            Assert.True(mem.NativeBase != null);
+
+            mem.Dispose();
+            Assert.True(mem.NativeBase == null);
+            Assert.Equal((nuint)0, mem.NativeSize);
+
+            // Idempotent — second Dispose is a no-op.
+            mem.Dispose();
+            Assert.True(mem.NativeBase == null);
+        }
+
+        [Fact]
+        public void ManagedArray_Dispose_NoOpForGCBacking()
+        {
+            // ManagedArray mode has no native buffer to free; Dispose
+            // is a no-op (the GC reclaims Data when the instance
+            // becomes unreachable). This test pins that contract so
+            // future "always free" refactors don't break ManagedArray.
+            var memType = new MemoryType(1, 10);
+            var mem = new MemoryInstance(memType);
+            int prevDataLen = mem.Data.Length;
+            mem.Dispose();
+            // Data unchanged; the GC will reclaim it later.
+            Assert.Equal(prevDataLen, mem.Data.Length);
+        }
+    }
+}

--- a/Wacs.Core/Wacs.Core.Test/MemoryInstanceNativeStorageTests.cs
+++ b/Wacs.Core/Wacs.Core.Test/MemoryInstanceNativeStorageTests.cs
@@ -19,11 +19,6 @@ namespace Wacs.Core.Test
     /// allocation, indexer + AsSpan parity with the byte[] backing,
     /// grow preserves live bytes and zero-fills the new pages, and
     /// Dispose actually releases the native buffer.
-    ///
-    /// <para>Phase A from <c>wasi-nn/WACS-GAPS.md</c> gap 12 — the
-    /// migration from byte[] (2 GiB cap) to native-pointer storage.
-    /// Phase A only adds the storage mode; subsequent phases migrate
-    /// the interpreter and transpiler access sites to consult it.</para>
     /// </summary>
     public unsafe class MemoryInstanceNativeStorageTests
     {

--- a/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
+++ b/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
@@ -1,0 +1,303 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Text;
+using Xunit;
+
+namespace Wacs.Core.Test
+{
+    /// <summary>
+    /// Pins the contract that an interpreter run with
+    /// <c>RuntimeOptions.MemoryStorage = NativePointer</c> executes
+    /// every routine that lives behind <c>MemoryHandlers.MemSlice</c>
+    /// — load, store, narrow load/store, bulk init/copy/fill,
+    /// memory.size, memory.grow — with byte-identical results to
+    /// the default <c>ManagedArray</c> path.
+    ///
+    /// <para>Phase B from <c>wasi-nn/WACS-GAPS.md</c> gap 12: the
+    /// option threads through <c>WasmRuntimeInstantiation</c> and
+    /// <c>MemSlice</c> dispatches by mode, so a NativePointer-mode
+    /// run of these wasm fixtures is now a real end-to-end exercise
+    /// of the new storage path through the interpreter.</para>
+    /// </summary>
+    public class MemoryNativePointerEndToEndTests
+    {
+        private static (WasmRuntime runtime, ModuleInstance inst)
+            Instantiate(string wat, MemoryStorageMode mode)
+        {
+            var runtime = new WasmRuntime();
+            var module = TextModuleParser.ParseWat(wat);
+            var inst = runtime.InstantiateModule(module,
+                new RuntimeOptions { MemoryStorage = mode });
+            return (runtime, inst);
+        }
+
+        private static long Invoke(WasmRuntime runtime,
+            ModuleInstance inst, string export, params Value[] args)
+        {
+            runtime.RegisterModule("M", inst);
+            var addr = runtime.GetExportedFunction(("M", export));
+            var result = runtime.CreateStackInvoker(addr)(args);
+            return (long)result[0];
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void I32StoreLoad_RoundTrips(MemoryStorageMode mode)
+        {
+            // Store 0xDEADBEEF at offset 64; load it back.
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i32)
+                    i32.const 64
+                    i32.const 0xDEADBEEF
+                    i32.store
+                    i32.const 64
+                    i32.load))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(unchecked((int)0xDEADBEEF),
+                (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void I64StoreLoad_RoundTrips(MemoryStorageMode mode)
+        {
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i64)
+                    i32.const 128
+                    i64.const 0x0123456789ABCDEF
+                    i64.store
+                    i32.const 128
+                    i64.load))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(0x0123456789ABCDEFL,
+                Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void NarrowLoadStore_RoundTrips(MemoryStorageMode mode)
+        {
+            // i32.store8 + i32.load8_u: narrow path through MemSlice.
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i32)
+                    i32.const 256
+                    i32.const 0xAB
+                    i32.store8
+                    i32.const 256
+                    i32.load8_u))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(0xAB, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void MemorySize_ReportsPages(MemoryStorageMode mode)
+        {
+            var src = @"
+                (module
+                  (memory 3)
+                  (func (export ""run"") (result i32)
+                    memory.size))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(3, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void MemoryGrow_GrowsAndPreservesBytes(MemoryStorageMode mode)
+        {
+            // Write a signature byte at offset 0, grow by 2 pages,
+            // verify the byte survived and we can write/read in a
+            // freshly-allocated page.
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i32)
+                    ;; stamp signature
+                    i32.const 0
+                    i32.const 0x42
+                    i32.store8
+                    ;; grow by 2 pages
+                    i32.const 2
+                    memory.grow
+                    drop
+                    ;; verify signature and a byte in new page
+                    i32.const 65536
+                    i32.const 0x99
+                    i32.store8
+                    i32.const 0
+                    i32.load8_u
+                    i32.const 65536
+                    i32.load8_u
+                    i32.add))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(0x42 + 0x99, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void MemoryFill_WritesByteRange(MemoryStorageMode mode)
+        {
+            // Fill 100 bytes at offset 1024 with 0x77, read back the
+            // first and last filled bytes.
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i32)
+                    i32.const 1024
+                    i32.const 0x77
+                    i32.const 100
+                    memory.fill
+                    i32.const 1024
+                    i32.load8_u
+                    i32.const 1123
+                    i32.load8_u
+                    i32.add))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(0x77 + 0x77, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void MemoryCopy_NonOverlapping(MemoryStorageMode mode)
+        {
+            // Stamp a pattern at offset 1024, memory.copy 100 bytes
+            // to offset 4096, read back from the new location.
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i32)
+                    i32.const 1024
+                    i32.const 0xAB
+                    i32.store8
+                    i32.const 1124
+                    i32.const 0xCD
+                    i32.store8
+                    i32.const 4096
+                    i32.const 1024
+                    i32.const 101
+                    memory.copy
+                    i32.const 4096
+                    i32.load8_u
+                    i32.const 4196
+                    i32.load8_u
+                    i32.add))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(0xAB + 0xCD, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void MemoryCopy_OverlappingForward(MemoryStorageMode mode)
+        {
+            // Forward overlap (dst > src): memmove must produce the
+            // same result Span.CopyTo gives. Pattern at 1000..1010,
+            // copy to 1005..1015 (5-byte overlap).
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i32)
+                    ;; 10 bytes 0..9
+                    i32.const 1000 i32.const 0 i32.store8
+                    i32.const 1001 i32.const 1 i32.store8
+                    i32.const 1002 i32.const 2 i32.store8
+                    i32.const 1003 i32.const 3 i32.store8
+                    i32.const 1004 i32.const 4 i32.store8
+                    i32.const 1005 i32.const 5 i32.store8
+                    i32.const 1006 i32.const 6 i32.store8
+                    i32.const 1007 i32.const 7 i32.store8
+                    i32.const 1008 i32.const 8 i32.store8
+                    i32.const 1009 i32.const 9 i32.store8
+                    ;; copy 1000..1010 → 1005..1015 (5-byte overlap)
+                    i32.const 1005
+                    i32.const 1000
+                    i32.const 10
+                    memory.copy
+                    ;; expected at 1005..1014: 0,1,2,3,4,5,6,7,8,9
+                    ;; sum should be 45
+                    i32.const 1005 i32.load8_u
+                    i32.const 1006 i32.load8_u i32.add
+                    i32.const 1007 i32.load8_u i32.add
+                    i32.const 1008 i32.load8_u i32.add
+                    i32.const 1009 i32.load8_u i32.add
+                    i32.const 1010 i32.load8_u i32.add
+                    i32.const 1011 i32.load8_u i32.add
+                    i32.const 1012 i32.load8_u i32.add
+                    i32.const 1013 i32.load8_u i32.add
+                    i32.const 1014 i32.load8_u i32.add))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(45, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void MemoryInit_FromDataSegment(MemoryStorageMode mode)
+        {
+            // Active data segment writes "hello" at offset 64;
+            // memory.init copies 5 more bytes from a passive segment
+            // to offset 256.
+            var src = @"
+                (module
+                  (memory 1)
+                  (data ""hello"")
+                  (data ""world"")
+                  (func (export ""run"") (result i32)
+                    ;; data segment 0 is passive; copy ""hello"" to 0..5
+                    i32.const 0    ;; dst
+                    i32.const 0    ;; src
+                    i32.const 5    ;; n
+                    memory.init 0
+                    ;; data segment 1 is passive; copy ""world"" to 100..105
+                    i32.const 100  ;; dst
+                    i32.const 0    ;; src
+                    i32.const 5    ;; n
+                    memory.init 1
+                    ;; sum: 'h' + 'w' = 0x68 + 0x77 = 0xDF
+                    i32.const 0 i32.load8_u
+                    i32.const 100 i32.load8_u
+                    i32.add))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(0x68 + 0x77, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void OutOfBoundsLoad_Traps(MemoryStorageMode mode)
+        {
+            // 1 page = 65536 bytes. Loading at 65535 with an i32
+            // (4 bytes) crosses the boundary → trap, both modes.
+            var src = @"
+                (module
+                  (memory 1)
+                  (func (export ""run"") (result i32)
+                    i32.const 65535
+                    i32.load))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Throws<TrapException>(() =>
+                Invoke(runtime, inst, "run"));
+        }
+    }
+}

--- a/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
+++ b/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
@@ -285,6 +285,98 @@ namespace Wacs.Core.Test
         [Theory]
         [InlineData(MemoryStorageMode.ManagedArray)]
         [InlineData(MemoryStorageMode.NativePointer)]
+        public void I32AtomicStoreLoad_RoundTrips(MemoryStorageMode mode)
+        {
+            // shared memory required for atomic ops. Aligned 4-byte
+            // store + atomic load round-trip through the new RefAs<T>
+            // helper (Phase C.1).
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""run"") (result i32)
+                    i32.const 16
+                    i32.const 0xCAFEBABE
+                    i32.atomic.store
+                    i32.const 16
+                    i32.atomic.load))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(unchecked((int)0xCAFEBABE),
+                (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void I64AtomicRMW_Add_RoundTrips(MemoryStorageMode mode)
+        {
+            // i64.atomic.rmw.add returns the OLD value; cell ends up
+            // at original + delta. Initial = 100, delta = 23, result
+            // load should return 123.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""run"") (result i64)
+                    i32.const 32
+                    i64.const 100
+                    i64.atomic.store
+                    i32.const 32
+                    i64.const 23
+                    i64.atomic.rmw.add
+                    drop
+                    i32.const 32
+                    i64.atomic.load))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(123L, Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void I32AtomicSubword_Load8_RoundTrips(MemoryStorageMode mode)
+        {
+            // i32.atomic.store8 + i32.atomic.load8_u: subword path
+            // through Volatile.Read/Write on a single byte ref.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""run"") (result i32)
+                    i32.const 8
+                    i32.const 0xA5
+                    i32.atomic.store8
+                    i32.const 8
+                    i32.atomic.load8_u))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(0xA5, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
+        public void I32AtomicCmpxchg_Success(MemoryStorageMode mode)
+        {
+            // Initial 7. cmpxchg(expected=7, new=42) succeeds, returns
+            // old (7). Subsequent load returns 42.
+            var src = @"
+                (module
+                  (memory 1 1 shared)
+                  (func (export ""run"") (result i32)
+                    i32.const 0
+                    i32.const 7
+                    i32.atomic.store
+                    i32.const 0
+                    i32.const 7
+                    i32.const 42
+                    i32.atomic.rmw.cmpxchg
+                    drop
+                    i32.const 0
+                    i32.atomic.load))";
+            var (runtime, inst) = Instantiate(src, mode);
+            Assert.Equal(42, (int)Invoke(runtime, inst, "run"));
+        }
+
+        [Theory]
+        [InlineData(MemoryStorageMode.ManagedArray)]
+        [InlineData(MemoryStorageMode.NativePointer)]
         public void OutOfBoundsLoad_Traps(MemoryStorageMode mode)
         {
             // 1 page = 65536 bytes. Loading at 65535 with an i32

--- a/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
+++ b/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
@@ -21,13 +21,8 @@ namespace Wacs.Core.Test
     /// every routine that lives behind <c>MemoryHandlers.MemSlice</c>
     /// — load, store, narrow load/store, bulk init/copy/fill,
     /// memory.size, memory.grow — with byte-identical results to
-    /// the default <c>ManagedArray</c> path.
-    ///
-    /// <para>Phase B from <c>wasi-nn/WACS-GAPS.md</c> gap 12: the
-    /// option threads through <c>WasmRuntimeInstantiation</c> and
-    /// <c>MemSlice</c> dispatches by mode, so a NativePointer-mode
-    /// run of these wasm fixtures is now a real end-to-end exercise
-    /// of the new storage path through the interpreter.</para>
+    /// the default <c>ManagedArray</c> path. Each [Theory] case
+    /// runs once per mode so any divergence surfaces immediately.
     /// </summary>
     public class MemoryNativePointerEndToEndTests
     {
@@ -291,8 +286,7 @@ namespace Wacs.Core.Test
         public void I32AtomicStoreLoad_RoundTrips(MemoryStorageMode mode)
         {
             // shared memory required for atomic ops. Aligned 4-byte
-            // store + atomic load round-trip through the new RefAs<T>
-            // helper (Phase C.1).
+            // store + atomic load round-trip through MemoryInstance.RefAs<T>.
             var src = @"
                 (module
                   (memory 1 1 shared)
@@ -377,7 +371,7 @@ namespace Wacs.Core.Test
             Assert.Equal(42, (int)Invoke(runtime, inst, "run"));
         }
 
-        // === Phase D: memory64 ===
+        // === memory64 ===
         // memory64 modules use i64 addresses. NativePointer mode is
         // required (ManagedArray's byte[] cap is ~2 GiB). The cap
         // shifts from WasmMaxPages (2^16) to WasmMaxPages64 (2^48).

--- a/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
+++ b/Wacs.Core/Wacs.Core.Test/MemoryNativePointerEndToEndTests.cs
@@ -8,6 +8,9 @@
 using Wacs.Core.Runtime;
 using Wacs.Core.Runtime.Types;
 using Wacs.Core.Text;
+using Wacs.Core.Types;
+using Wacs.Core.Types.Defs;
+using Wacs.Core.Utilities;
 using Xunit;
 
 namespace Wacs.Core.Test
@@ -372,6 +375,71 @@ namespace Wacs.Core.Test
                     i32.atomic.load))";
             var (runtime, inst) = Instantiate(src, mode);
             Assert.Equal(42, (int)Invoke(runtime, inst, "run"));
+        }
+
+        // === Phase D: memory64 ===
+        // memory64 modules use i64 addresses. NativePointer mode is
+        // required (ManagedArray's byte[] cap is ~2 GiB). The cap
+        // shifts from WasmMaxPages (2^16) to WasmMaxPages64 (2^48).
+
+        [Fact]
+        public void Memory64_Pages_AllocationCapsAtWasmMaxPages64()
+        {
+            // memory64 type with explicit max=WasmMaxPages64 should
+            // construct under NativePointer. ManagedArray rejects
+            // anything past HostMaxPages even for memory64 (the
+            // byte[] backing has the hard 2 GiB limit).
+            var memType = new MemoryType(new Limits(
+                AddrType.I64, 1, Constants.WasmMaxPages64));
+            using var mem = new MemoryInstance(memType,
+                MemoryStorageMode.NativePointer);
+            Assert.Equal(MemoryStorageMode.NativePointer, mem.StorageMode);
+            Assert.Equal(AddrType.I64, mem.Type.Limits.AddressType);
+            Assert.Equal(1, mem.Size);
+        }
+
+        [Fact]
+        public void Memory64_StoreLoad_RoundTripsAtHighAddress()
+        {
+            // Grow to 4 pages (256 KiB) and write/read past the
+            // first page boundary. Validates that memory64-mode
+            // bounds-check arithmetic (unsigned) accepts addresses
+            // well within range and stores survive grow.
+            var src = @"
+                (module
+                  (memory i64 1)
+                  (func (export ""run"") (result i64)
+                    ;; Store 0xDEADC0DE_00112233 at offset 100000
+                    ;; (within 1 page after 2-page grow). Then read it.
+                    i64.const 3
+                    memory.grow
+                    drop
+                    i64.const 100000
+                    i64.const 0xDEADC0DE00112233
+                    i64.store
+                    i64.const 100000
+                    i64.load))";
+            var (runtime, inst) = Instantiate(src,
+                MemoryStorageMode.NativePointer);
+            Assert.Equal(unchecked((long)0xDEADC0DE00112233UL),
+                Invoke(runtime, inst, "run"));
+        }
+
+        [Fact]
+        public void Memory64_OutOfBoundsLoad_Traps()
+        {
+            // 1 page = 65536 bytes. Loading at 65535 with i64 (8B)
+            // crosses the boundary → trap.
+            var src = @"
+                (module
+                  (memory i64 1)
+                  (func (export ""run"") (result i64)
+                    i64.const 65535
+                    i64.load))";
+            var (runtime, inst) = Instantiate(src,
+                MemoryStorageMode.NativePointer);
+            Assert.Throws<TrapException>(() =>
+                Invoke(runtime, inst, "run"));
         }
 
         [Theory]

--- a/Wacs.Core/Wacs.Core.Test/Wacs.Core.Test.csproj
+++ b/Wacs.Core/Wacs.Core.Test/Wacs.Core.Test.csproj
@@ -8,6 +8,10 @@
         <Authors>Kelvin Nishikawa</Authors>
         <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
+        <!-- MemoryInstanceNativeStorageTests reads through the
+             public byte* NativeBase pointer to verify writes hit
+             native memory. -->
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicBase.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicBase.cs
@@ -144,7 +144,7 @@ namespace Wacs.Core.Instructions.Atomic
             if (ea < 0)
                 throw new TrapException(
                     $"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthBytes > (long)CachedMem.ByteLength)
+            if ((ulong)ea > (ulong)CachedMem.ByteLength || (ulong)CachedMem.ByteLength - (ulong)ea < (ulong)WidthBytes)
                 throw new TrapException(
                     $"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthBytes} out of bounds ({(long)CachedMem.ByteLength}).");
             if ((ea & (WidthBytes - 1)) != 0)

--- a/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicBase.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicBase.cs
@@ -144,9 +144,9 @@ namespace Wacs.Core.Instructions.Atomic
             if (ea < 0)
                 throw new TrapException(
                     $"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthBytes > CachedMem.Data.Length)
+            if (ea + WidthBytes > (long)CachedMem.ByteLength)
                 throw new TrapException(
-                    $"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthBytes} out of bounds ({CachedMem.Data.Length}).");
+                    $"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthBytes} out of bounds ({(long)CachedMem.ByteLength}).");
             if ((ea & (WidthBytes - 1)) != 0)
                 throw new TrapException(
                     $"Instruction {Op.GetMnemonic()} failed. Unaligned atomic access at {ea} (width {WidthBytes}).");

--- a/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicHandlers.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicHandlers.cs
@@ -47,9 +47,9 @@ namespace Wacs.Core.Instructions.Atomic
         {
             var mem = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)memIdx]];
             long eaLong = (long)addr + (long)offset;
-            if (eaLong < 0 || eaLong + widthBytes > mem.Data.Length)
+            if (eaLong < 0 || eaLong + widthBytes > (long)mem.ByteLength)
                 throw new TrapException(
-                    $"{op}: out of bounds atomic access (ea={eaLong}, width={widthBytes}, size={mem.Data.Length})");
+                    $"{op}: out of bounds atomic access (ea={eaLong}, width={widthBytes}, size={(long)mem.ByteLength})");
             if ((eaLong & (widthBytes - 1)) != 0)
                 throw new TrapException(
                     $"{op}: unaligned atomic access at ea={eaLong} (width={widthBytes})");
@@ -79,14 +79,14 @@ namespace Wacs.Core.Instructions.Atomic
         private static uint I32AtomicLoad8U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.load8_u", out int ea);
-            return System.Threading.Volatile.Read(ref mem.Data[ea]);
+            return System.Threading.Volatile.Read(ref mem.RefAs<byte>(ea));
         }
 
         [OpHandler(AtomCode.I32AtomicLoad16U)]
         private static uint I32AtomicLoad16U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.load16_u", out int ea);
-            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            ref ushort cell = ref mem.RefAs<ushort>(ea);
             return System.Threading.Volatile.Read(ref cell);
         }
 
@@ -94,14 +94,14 @@ namespace Wacs.Core.Instructions.Atomic
         private static ulong I64AtomicLoad8U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.load8_u", out int ea);
-            return System.Threading.Volatile.Read(ref mem.Data[ea]);
+            return System.Threading.Volatile.Read(ref mem.RefAs<byte>(ea));
         }
 
         [OpHandler(AtomCode.I64AtomicLoad16U)]
         private static ulong I64AtomicLoad16U(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.load16_u", out int ea);
-            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            ref ushort cell = ref mem.RefAs<ushort>(ea);
             return System.Threading.Volatile.Read(ref cell);
         }
 
@@ -134,14 +134,14 @@ namespace Wacs.Core.Instructions.Atomic
         private static void I32AtomicStore8(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i32.atomic.store8", out int ea);
-            System.Threading.Volatile.Write(ref mem.Data[ea], (byte)value);
+            System.Threading.Volatile.Write(ref mem.RefAs<byte>(ea), (byte)value);
         }
 
         [OpHandler(AtomCode.I32AtomicStore16)]
         private static void I32AtomicStore16(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, uint value)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i32.atomic.store16", out int ea);
-            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            ref ushort cell = ref mem.RefAs<ushort>(ea);
             System.Threading.Volatile.Write(ref cell, (ushort)value);
         }
 
@@ -149,14 +149,14 @@ namespace Wacs.Core.Instructions.Atomic
         private static void I64AtomicStore8(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 1, "i64.atomic.store8", out int ea);
-            System.Threading.Volatile.Write(ref mem.Data[ea], (byte)value);
+            System.Threading.Volatile.Write(ref mem.RefAs<byte>(ea), (byte)value);
         }
 
         [OpHandler(AtomCode.I64AtomicStore16)]
         private static void I64AtomicStore16(ExecContext ctx, [Imm] uint memIdx, [Imm] ulong offset, uint addr, ulong value)
         {
             var mem = Wacs.Core.Instructions.Atomic.AtomicHandlers.ResolveAtomic(ctx, memIdx, addr, offset, 2, "i64.atomic.store16", out int ea);
-            ref ushort cell = ref System.Runtime.CompilerServices.Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            ref ushort cell = ref mem.RefAs<ushort>(ea);
             System.Threading.Volatile.Write(ref cell, (ushort)value);
         }
 

--- a/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicLoadStore.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Atomic/AtomicLoadStore.cs
@@ -40,7 +40,7 @@ namespace Wacs.Core.Instructions.Atomic
     {
         public InstI32AtomicLoad8U() : base((ByteCode)AtomCode.I32AtomicLoad8U, ValType.I32, 1) {}
         protected override void DoLoad(ExecContext context, int ea) =>
-            context.OpStack.PushU32(Volatile.Read(ref CachedMem.Data[ea]));
+            context.OpStack.PushU32(Volatile.Read(ref CachedMem.RefAs<byte>(ea)));
     }
 
     public sealed class InstI32AtomicLoad16U : InstAtomicLoad
@@ -48,7 +48,7 @@ namespace Wacs.Core.Instructions.Atomic
         public InstI32AtomicLoad16U() : base((ByteCode)AtomCode.I32AtomicLoad16U, ValType.I32, 2) {}
         protected override void DoLoad(ExecContext context, int ea)
         {
-            ref ushort cell = ref Unsafe.As<byte, ushort>(ref CachedMem.Data[ea]);
+            ref ushort cell = ref CachedMem.RefAs<ushort>(ea);
             context.OpStack.PushU32(Volatile.Read(ref cell));
         }
     }
@@ -57,7 +57,7 @@ namespace Wacs.Core.Instructions.Atomic
     {
         public InstI64AtomicLoad8U() : base((ByteCode)AtomCode.I64AtomicLoad8U, ValType.I64, 1) {}
         protected override void DoLoad(ExecContext context, int ea) =>
-            context.OpStack.PushU64(Volatile.Read(ref CachedMem.Data[ea]));
+            context.OpStack.PushU64(Volatile.Read(ref CachedMem.RefAs<byte>(ea)));
     }
 
     public sealed class InstI64AtomicLoad16U : InstAtomicLoad
@@ -65,7 +65,7 @@ namespace Wacs.Core.Instructions.Atomic
         public InstI64AtomicLoad16U() : base((ByteCode)AtomCode.I64AtomicLoad16U, ValType.I64, 2) {}
         protected override void DoLoad(ExecContext context, int ea)
         {
-            ref ushort cell = ref Unsafe.As<byte, ushort>(ref CachedMem.Data[ea]);
+            ref ushort cell = ref CachedMem.RefAs<ushort>(ea);
             context.OpStack.PushU64(Volatile.Read(ref cell));
         }
     }
@@ -104,7 +104,7 @@ namespace Wacs.Core.Instructions.Atomic
     {
         public InstI32AtomicStore8() : base((ByteCode)AtomCode.I32AtomicStore8, 1) {}
         protected override void DoStore(MemoryInstance mem, int ea, int value) =>
-            Volatile.Write(ref mem.Data[ea], (byte)value);
+            Volatile.Write(ref mem.RefAs<byte>(ea), (byte)value);
     }
 
     public sealed class InstI32AtomicStore16 : InstAtomicStore32
@@ -112,7 +112,7 @@ namespace Wacs.Core.Instructions.Atomic
         public InstI32AtomicStore16() : base((ByteCode)AtomCode.I32AtomicStore16, 2) {}
         protected override void DoStore(MemoryInstance mem, int ea, int value)
         {
-            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            ref ushort cell = ref mem.RefAs<ushort>(ea);
             Volatile.Write(ref cell, (ushort)value);
         }
     }
@@ -121,7 +121,7 @@ namespace Wacs.Core.Instructions.Atomic
     {
         public InstI64AtomicStore8() : base((ByteCode)AtomCode.I64AtomicStore8, 1) {}
         protected override void DoStore(MemoryInstance mem, int ea, long value) =>
-            Volatile.Write(ref mem.Data[ea], (byte)value);
+            Volatile.Write(ref mem.RefAs<byte>(ea), (byte)value);
     }
 
     public sealed class InstI64AtomicStore16 : InstAtomicStore64
@@ -129,7 +129,7 @@ namespace Wacs.Core.Instructions.Atomic
         public InstI64AtomicStore16() : base((ByteCode)AtomCode.I64AtomicStore16, 2) {}
         protected override void DoStore(MemoryInstance mem, int ea, long value)
         {
-            ref ushort cell = ref Unsafe.As<byte, ushort>(ref mem.Data[ea]);
+            ref ushort cell = ref mem.RefAs<ushort>(ea);
             Volatile.Write(ref cell, (ushort)value);
         }
     }

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryLoad.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryLoad.cs
@@ -48,9 +48,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
             
@@ -84,9 +82,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
             

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryLoad.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryLoad.cs
@@ -50,9 +50,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
             
             return MemoryMarshal.Read<float>(bs);
         }
@@ -86,9 +86,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
             
             return MemoryMarshal.Read<double>(bs);
         }

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryStore.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryStore.cs
@@ -55,10 +55,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
             
 #if NET8_0_OR_GREATER
             MemoryMarshal.Write(bs, in cF32);
@@ -100,10 +100,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
             
 #if NET8_0_OR_GREATER
             MemoryMarshal.Write(bs, in cF64);

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryStore.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/FMemoryStore.cs
@@ -53,9 +53,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
@@ -98,9 +96,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/I32MemoryLoad.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/I32MemoryLoad.cs
@@ -46,9 +46,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > cachedInstance.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({cachedInstance.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(cachedInstance.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)cachedInstance.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)cachedInstance.ByteLength}).");
+            var bs = cachedInstance.AsSpan((int)ea, WidthTByteSize);
             
             #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<uint>(bs);
@@ -96,10 +96,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             
-            return (sbyte)mem.Data[(int)ea];
+            return (sbyte)mem.AsSpan((int)ea, 1)[0];
         }
     }
     
@@ -130,10 +130,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             
-            return mem.Data[(int)ea];
+            return mem.AsSpan((int)ea, 1)[0];
         }
     }
     
@@ -164,9 +164,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
 
 #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<short>(bs);
@@ -203,9 +203,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
 
 #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<ushort>(bs);

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/I32MemoryLoad.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/I32MemoryLoad.cs
@@ -44,9 +44,7 @@ namespace Wacs.Core.Instructions.Memory
         public uint FetchFromMemory(ExecContext context, long offset)
         {
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)cachedInstance.ByteLength)
+            if ((ulong)ea > (ulong)cachedInstance.ByteLength || (ulong)cachedInstance.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)cachedInstance.ByteLength}).");
             var bs = cachedInstance.AsSpan((int)ea, WidthTByteSize);
             
@@ -94,9 +92,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory {M.M.Value} was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             
             return (sbyte)mem.AsSpan((int)ea, 1)[0];
@@ -128,9 +124,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             
             return mem.AsSpan((int)ea, 1)[0];
@@ -162,9 +156,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
 
@@ -201,9 +193,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
 

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/I64MemoryLoad.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/I64MemoryLoad.cs
@@ -50,9 +50,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<ulong>(bs);
 #else
@@ -88,9 +88,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
             
             int cS8 = (sbyte)bs[0];
             return cS8;
@@ -124,9 +124,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
             
             uint cU8 = bs[0];
             return cU8;
@@ -160,9 +160,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<short>(bs);
 #else
@@ -198,9 +198,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
 
 #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<ushort>(bs);
@@ -237,9 +237,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<int>(bs);
 #else
@@ -275,9 +275,9 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER
             return MemoryMarshal.AsRef<uint>(bs);
 #else

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/I64MemoryLoad.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/I64MemoryLoad.cs
@@ -48,9 +48,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER
@@ -86,9 +84,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
             
@@ -122,9 +118,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
             
@@ -158,9 +152,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER
@@ -196,9 +188,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
 
@@ -235,9 +225,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER
@@ -273,9 +261,7 @@ namespace Wacs.Core.Instructions.Memory
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory 0 was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
 #if NET8_0_OR_GREATER

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/InstI32Store.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/InstI32Store.cs
@@ -53,9 +53,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
@@ -98,9 +96,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             // Single-byte store via mode-aware AsSpan.
             mem.AsSpan((int)ea, 1)[0] = (byte)(0xFF & cU32);
@@ -137,9 +133,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/InstI32Store.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/InstI32Store.cs
@@ -55,11 +55,11 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
-            
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
+
 #if NET8_0_OR_GREATER
             MemoryMarshal.Write(bs, in cU32);
 #else
@@ -100,11 +100,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
-            //13,14,15
-            // Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
-            mem.Data[(int)ea] = (byte)(0xFF & cU32);
+            // Single-byte store via mode-aware AsSpan.
+            mem.AsSpan((int)ea, 1)[0] = (byte)(0xFF & cU32);
         }
     }
     
@@ -140,10 +139,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
             
             ushort cI16 = (ushort)cU32;
 #if NET8_0_OR_GREATER

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/InstI64Store.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/InstI64Store.cs
@@ -55,10 +55,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
             
 #if NET8_0_OR_GREATER
             MemoryMarshal.Write(bs, in cU64);
@@ -100,10 +100,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            mem.Data[(int)ea] = (byte)(0xFF & cU64);
+            mem.AsSpan((int)ea, 1)[0] = (byte)(0xFF & cU64);
         }
     }
     
@@ -139,10 +139,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
             
             ushort cI16 = (ushort)cU64;
 #if NET8_0_OR_GREATER
@@ -185,10 +185,10 @@ namespace Wacs.Core.Instructions.Memory
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
             
             uint cI32 = (uint)cU64;
 #if NET8_0_OR_GREATER

--- a/Wacs.Core/Wacs.Core/Instructions/Memory/InstI64Store.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Memory/InstI64Store.cs
@@ -53,9 +53,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
@@ -98,9 +96,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             mem.AsSpan((int)ea, 1)[0] = (byte)(0xFF & cU64);
@@ -137,9 +133,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
@@ -183,9 +177,7 @@ namespace Wacs.Core.Instructions.Memory
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);

--- a/Wacs.Core/Wacs.Core/Instructions/MemoryBulk.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/MemoryBulk.cs
@@ -220,10 +220,13 @@ namespace Wacs.Core.Instructions
             //15.
             long d = context.OpStack.PopAddr();
 
-            if (s + n > data.Data.Length)
+            // Wrap-safe unsigned bounds for memory64; data segment is
+            // always byte[]-bounded so its check stays in long.
+            if ((ulong)s > (ulong)data.Data.Length
+                || (ulong)data.Data.Length - (ulong)s < (ulong)n)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Data underflow.");
-            
-            if (d + n > (long)mem.ByteLength)
+            if ((ulong)d > (ulong)mem.ByteLength
+                || (ulong)mem.ByteLength - (ulong)d < (ulong)n)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory overflow.");
 
             // Bulk Span.CopyTo (memmove); mode-aware via mem.AsSpan
@@ -369,10 +372,15 @@ namespace Wacs.Core.Instructions
                 $"Instruction {Op.GetMnemonic()} failed. Wrong type on stack.");
             //15.
             long d = context.OpStack.PopAddr();
-            //16.
-            if (s+n > (long)memSrc.ByteLength)
+            //16. Wrap-safe unsigned bounds — memory64 addresses
+            // can sit anywhere in [0, 2^64); the spec wraps in u64
+            // arithmetic but out-of-bounds at the byte level still
+            // traps.
+            if ((ulong)s > (ulong)memSrc.ByteLength
+                || (ulong)memSrc.ByteLength - (ulong)s < (ulong)n)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Source memory overflow.");
-            if (d+n > (long)memDst.ByteLength)
+            if ((ulong)d > (ulong)memDst.ByteLength
+                || (ulong)memDst.ByteLength - (ulong)d < (ulong)n)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Destination memory overflow.");
 
             // Span<byte>.CopyTo dispatches to Buffer.Memmove and
@@ -441,8 +449,9 @@ namespace Wacs.Core.Instructions
                 $"Instruction {Op.GetMnemonic()} failed. Wrong type on stack.");
             //11.
             long d = context.OpStack.PopAddr();
-            //12.
-            if (d + n > (long)mem.ByteLength)
+            //12. Wrap-safe unsigned bounds for memory64.
+            if ((ulong)d > (ulong)mem.ByteLength
+                || (ulong)mem.ByteLength - (ulong)d < (ulong)n)
                 throw new TrapException("Instruction memory.fill failed. Buffer overflow");
 
             // Bulk Span.Fill — mode-aware via mem.AsSpan.

--- a/Wacs.Core/Wacs.Core/Instructions/MemoryBulk.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/MemoryBulk.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.IO;
 using Wacs.Core.OpCodes;
 using Wacs.Core.Runtime;
@@ -222,22 +223,14 @@ namespace Wacs.Core.Instructions
             if (s + n > data.Data.Length)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Data underflow.");
             
-            if (d + n > mem.Data.Length)
+            if (d + n > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory overflow.");
-                
-            //Tail recursive call alternative loop, inline direct memory set
-            while (true)
-            {
-                if (n == 0)
-                    return;
 
-                //Set memory direct
-                mem.Data[(int)d] = (byte)(0xFF & data.Data[s]);
-                
-                d += 1L;
-                s += 1L;
-                n -= 1L;
-            }
+            // Bulk Span.CopyTo (memmove); mode-aware via mem.AsSpan
+            // and zero-cost on byte[] (Span over the array's data).
+            if (n == 0) return;
+            new ReadOnlySpan<byte>(data.Data, (int)s, (int)n)
+                .CopyTo(mem.AsSpan((int)d, (int)n));
         }
 
         public override InstructionBase Parse(BinaryReader reader)
@@ -377,28 +370,15 @@ namespace Wacs.Core.Instructions
             //15.
             long d = context.OpStack.PopAddr();
             //16.
-            if (s+n > memSrc.Data.Length)
+            if (s+n > (long)memSrc.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Source memory overflow.");
-            if (d+n > memDst.Data.Length)
+            if (d+n > (long)memDst.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Destination memory overflow.");
-            
-            //Tail recursive call alternative loop, inline load/store
-            while (true)
-            {
-                if (n == 0)
-                    return;
-                if (d <= s)
-                {
-                    memDst.Data[(int)d] = memSrc.Data[(int)s];
-                    d += 1L;
-                    s += 1L;
-                }
-                else
-                {
-                    memDst.Data[(int)(d+n-1L)] = memSrc.Data[(int)(s+n-1L)];
-                }
-                n -= 1L;
-            }
+
+            // Span<byte>.CopyTo dispatches to Buffer.Memmove and
+            // handles overlap correctly across both modes.
+            if (n == 0) return;
+            memSrc.AsSpan((int)s, (int)n).CopyTo(memDst.AsSpan((int)d, (int)n));
         }
 
         public override InstructionBase Parse(BinaryReader reader)
@@ -462,19 +442,12 @@ namespace Wacs.Core.Instructions
             //11.
             long d = context.OpStack.PopAddr();
             //12.
-            if (d + n > mem.Data.Length)
+            if (d + n > (long)mem.ByteLength)
                 throw new TrapException("Instruction memory.fill failed. Buffer overflow");
-            
-            //Tail recursive call alternative loop, inline store
-            while (true)
-            {
-                if (n == 0)
-                    return;
-                
-                mem.Data[(int)d] = (byte)(0xFF & cU32);
-                d += 1L;
-                n -= 1L;
-            }
+
+            // Bulk Span.Fill — mode-aware via mem.AsSpan.
+            if (n == 0) return;
+            mem.AsSpan((int)d, (int)n).Fill((byte)(0xFF & cU32));
         }
 
         public override InstructionBase Parse(BinaryReader reader)

--- a/Wacs.Core/Wacs.Core/Instructions/MemoryHandlers.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/MemoryHandlers.cs
@@ -41,11 +41,9 @@ namespace Wacs.Core.Instructions
         {
             var mem = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)memIdx]];
             long ea = (long)addr + (long)offset;
-            // ByteLength is mode-agnostic (Data.Length for managed,
-            // NativeSize for native). AsSpan dispatches likewise.
-            // Gap 12 phase B: this is the chokepoint for every
-            // [OpHandler] memory load/store, so a single AsSpan
-            // dispatch flips all 25+ op-handlers to mode-aware.
+            // ByteLength + AsSpan dispatch by StorageMode, so this
+            // single chokepoint covers every [OpHandler] memory
+            // load/store / narrow / size on either backing.
             long len = (long)mem.ByteLength;
             if (ea < 0 || ea + width > len)
                 throw new Wacs.Core.Runtime.Types.TrapException(

--- a/Wacs.Core/Wacs.Core/Instructions/MemoryHandlers.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/MemoryHandlers.cs
@@ -41,10 +41,16 @@ namespace Wacs.Core.Instructions
         {
             var mem = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)memIdx]];
             long ea = (long)addr + (long)offset;
-            if (ea < 0 || ea + width > mem.Data.Length)
+            // ByteLength is mode-agnostic (Data.Length for managed,
+            // NativeSize for native). AsSpan dispatches likewise.
+            // Gap 12 phase B: this is the chokepoint for every
+            // [OpHandler] memory load/store, so a single AsSpan
+            // dispatch flips all 25+ op-handlers to mode-aware.
+            long len = (long)mem.ByteLength;
+            if (ea < 0 || ea + width > len)
                 throw new Wacs.Core.Runtime.Types.TrapException(
-                    $"{op}: out of bounds memory access (ea={ea}, width={width}, size={mem.Data.Length})");
-            return new Span<byte>(mem.Data, (int)ea, width);
+                    $"{op}: out of bounds memory access (ea={ea}, width={width}, size={len})");
+            return mem.AsSpan((int)ea, width);
         }
 
         // ---- Loads ---------------------------------------------------------------------
@@ -190,10 +196,14 @@ namespace Wacs.Core.Instructions
         {
             var mem = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)memIdx]];
             var data = ctx.Store[ctx.Frame.Module.DataAddrs[(DataIdx)dataIdx]];
-            if ((long)s + n > data.Data.Length || (long)d + n > mem.Data.Length)
+            // mem.ByteLength is mode-agnostic; data is always byte[].
+            if ((long)s + n > data.Data.Length || (long)d + n > (long)mem.ByteLength)
                 throw new Wacs.Core.Runtime.Types.TrapException("memory.init: out of bounds memory access");
             if (n == 0) return;
-            Array.Copy(data.Data, (int)s, mem.Data, (int)d, (int)n);
+            // Span<byte>.CopyTo memmoves underneath; handles either
+            // backing for mem (data segment is always byte[]).
+            new ReadOnlySpan<byte>(data.Data, (int)s, (int)n)
+                .CopyTo(mem.AsSpan((int)d, (int)n));
         }
 
         // 0xFC 09 data.drop — invalidate the data segment (subsequent memory.init traps).
@@ -208,11 +218,13 @@ namespace Wacs.Core.Instructions
         {
             var src = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)srcIdx]];
             var dst = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)dstIdx]];
-            if ((long)s + n > src.Data.Length || (long)d + n > dst.Data.Length)
+            if ((long)s + n > (long)src.ByteLength || (long)d + n > (long)dst.ByteLength)
                 throw new Wacs.Core.Runtime.Types.TrapException("memory.copy: out of bounds memory access");
             if (n == 0) return;
-            // Array.Copy handles overlapping regions correctly (memmove semantics).
-            Array.Copy(src.Data, (int)s, dst.Data, (int)d, (int)n);
+            // Span<byte>.CopyTo dispatches to Buffer.Memmove under
+            // the hood, which handles overlap correctly even when
+            // src and dst alias the same backing.
+            src.AsSpan((int)s, (int)n).CopyTo(dst.AsSpan((int)d, (int)n));
         }
 
         // 0xFC 0B memory.fill — mem[d..d+n] = (byte)val for the low 8 bits of val.
@@ -221,10 +233,10 @@ namespace Wacs.Core.Instructions
                                         uint d, uint val, uint n)
         {
             var mem = ctx.Store[ctx.Frame.Module.MemAddrs[(MemIdx)memIdx]];
-            if ((long)d + n > mem.Data.Length)
+            if ((long)d + n > (long)mem.ByteLength)
                 throw new Wacs.Core.Runtime.Types.TrapException("memory.fill: out of bounds memory access");
             if (n == 0) return;
-            new Span<byte>(mem.Data, (int)d, (int)n).Fill((byte)val);
+            mem.AsSpan((int)d, (int)n).Fill((byte)val);
         }
 
         // ---- Size/Grow -----------------------------------------------------------------

--- a/Wacs.Core/Wacs.Core/Instructions/SIMD/VMemory.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/SIMD/VMemory.cs
@@ -53,9 +53,9 @@ namespace Wacs.Core.Instructions.SIMD
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({mem.Data.Length}).");
-            var bs = new ReadOnlySpan<byte>(mem.Data, (int)ea, WidthTByteSize);
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
+            var bs = mem.AsSpan((int)ea, WidthTByteSize);
          
             // return new V128(bs);
 #if NET8_0_OR_GREATER
@@ -98,10 +98,10 @@ namespace Wacs.Core.Instructions.SIMD
             long ea = offset + M.Offset;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > mem.Data.Length)
+            if (ea + WidthTByteSize > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, WidthTByteSize);
+            Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
             
 #if NET8_0_OR_GREATER
             MemoryMarshal.Write(bs, in cV128);
@@ -189,10 +189,10 @@ namespace Wacs.Core.Instructions.SIMD
             int mn = WidthTByteSize * CountN;
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + mn > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{mn} out of bounds ({mem.Data.Length}).");
+            if (ea + mn > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{mn} out of bounds ({(long)mem.ByteLength}).");
             //10.
-            var bs = new ReadOnlySpan<byte>(mem.Data,(int)ea, mn);
+            var bs = mem.AsSpan((int)ea, mn);
             //11,12,13,14
             int m = WidthTByteSize;
             MV128 c = new MV128();
@@ -297,10 +297,10 @@ namespace Wacs.Core.Instructions.SIMD
             //9.
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthN.ByteSize() > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({mem.Data.Length}).");
+            if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({(long)mem.ByteLength}).");
             //10.
-            var bs = mem.Data.AsSpan((int)ea, WidthN.ByteSize());
+            var bs = mem.AsSpan((int)ea, WidthN.ByteSize());
             //11,12,13,14
             switch (WidthN)
             {
@@ -407,10 +407,10 @@ namespace Wacs.Core.Instructions.SIMD
             //9.
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthN.ByteSize() > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({mem.Data.Length}).");
+            if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({(long)mem.ByteLength}).");
             //10.
-            var bs = mem.Data.AsSpan((int)ea, WidthN.ByteSize());
+            var bs = mem.AsSpan((int)ea, WidthN.ByteSize());
             //11,12,13
             switch (WidthN)
             {
@@ -520,10 +520,10 @@ namespace Wacs.Core.Instructions.SIMD
             //11.
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthN.ByteSize() > mem.Data.Length)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({mem.Data.Length}).");
+            if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
+                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({(long)mem.ByteLength}).");
             //12.
-            var bs = mem.Data.AsSpan((int)ea, WidthN.ByteSize());
+            var bs = mem.AsSpan((int)ea, WidthN.ByteSize());
             //13,14,15,16
             switch (WidthN)
             {
@@ -635,11 +635,11 @@ namespace Wacs.Core.Instructions.SIMD
             //11.
             if (ea < 0)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthN.ByteSize() > mem.Data.Length)
+            if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             
             //12,13,14,15
-            Span<byte> bs = mem.Data.AsSpan((int)ea, 16);
+            Span<byte> bs = mem.AsSpan((int)ea, 16);
             switch (WidthN)
             {
                 case BitWidth.S8:

--- a/Wacs.Core/Wacs.Core/Instructions/SIMD/VMemory.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/SIMD/VMemory.cs
@@ -51,9 +51,7 @@ namespace Wacs.Core.Instructions.SIMD
                 $"Instruction {Op.GetMnemonic()} failed. Address for Memory {M.M.Value} was not in the Store.");
             var mem = context.Store[a];
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthTByteSize} out of bounds ({(long)mem.ByteLength}).");
             var bs = mem.AsSpan((int)ea, WidthTByteSize);
          
@@ -96,9 +94,7 @@ namespace Wacs.Core.Instructions.SIMD
             var mem = context.Store[a];
 
             long ea = offset + M.Offset;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + WidthTByteSize > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)WidthTByteSize)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             //13,14,15
             Span<byte> bs = mem.AsSpan((int)ea, WidthTByteSize);
@@ -187,9 +183,7 @@ namespace Wacs.Core.Instructions.SIMD
             long ea = i + M.Offset;
             //9.
             int mn = WidthTByteSize * CountN;
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
-            if (ea + mn > (long)mem.ByteLength)
+            if ((ulong)ea > (ulong)mem.ByteLength || (ulong)mem.ByteLength - (ulong)ea < (ulong)mn)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{mn} out of bounds ({(long)mem.ByteLength}).");
             //10.
             var bs = mem.AsSpan((int)ea, mn);
@@ -295,8 +289,6 @@ namespace Wacs.Core.Instructions.SIMD
             //8.
             long ea = i + M.Offset;
             //9.
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
             if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({(long)mem.ByteLength}).");
             //10.
@@ -405,8 +397,6 @@ namespace Wacs.Core.Instructions.SIMD
             //8.
             long ea = i + M.Offset;
             //9.
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
             if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({(long)mem.ByteLength}).");
             //10.
@@ -518,8 +508,6 @@ namespace Wacs.Core.Instructions.SIMD
             //10.
             long ea = i + M.Offset;
             //11.
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
             if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea}+{WidthN.ByteSize()} out of bounds ({(long)mem.ByteLength}).");
             //12.
@@ -633,8 +621,6 @@ namespace Wacs.Core.Instructions.SIMD
             //10.
             long ea = i + M.Offset;
             //11.
-            if (ea < 0)
-                throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer {ea} out of bounds.");
             if (ea + WidthN.ByteSize() > (long)mem.ByteLength)
                 throw new TrapException($"Instruction {Op.GetMnemonic()} failed. Memory pointer out of bounds.");
             

--- a/Wacs.Core/Wacs.Core/Instructions/Table.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Table.cs
@@ -64,8 +64,13 @@ namespace Wacs.Core.Instructions
                 $"Instruction table.get failed. Wrong type on stack.");
             //7.
             long i = context.OpStack.PopAddr();
-            //8.
-            if (i >= tab.Elements.Count || (i > (long)int.MaxValue))
+            //8. Phase D: unsigned compare. table64 indices ride on
+            // the same OpStack pop path; PopAddr no longer traps on
+            // negative (memory64-compatible). For tables, treat i
+            // as u64 — negative-as-signed maps to a huge ulong that
+            // always fails the bound.
+            if ((ulong)i >= (ulong)tab.Elements.Count
+                || i > (long)int.MaxValue)
             {
                 throw new TrapException("Trap in table.get");
             }
@@ -130,8 +135,8 @@ namespace Wacs.Core.Instructions
                 $"Instruction table.set found incorrect type on top of the Stack");
             //9.
             long i = context.OpStack.PopAddr();
-            //10.
-            if (i >= tab.Elements.Count)
+            //10. Phase D: unsigned compare for table64 indices.
+            if ((ulong)i >= (ulong)tab.Elements.Count)
             {
                 throw new TrapException("table.set index exceeds table size.");
             }

--- a/Wacs.Core/Wacs.Core/Instructions/Table.cs
+++ b/Wacs.Core/Wacs.Core/Instructions/Table.cs
@@ -64,11 +64,9 @@ namespace Wacs.Core.Instructions
                 $"Instruction table.get failed. Wrong type on stack.");
             //7.
             long i = context.OpStack.PopAddr();
-            //8. Phase D: unsigned compare. table64 indices ride on
-            // the same OpStack pop path; PopAddr no longer traps on
-            // negative (memory64-compatible). For tables, treat i
-            // as u64 — negative-as-signed maps to a huge ulong that
-            // always fails the bound.
+            //8. Unsigned bound: table64 indices arrive as u64
+            // bit-patterns through PopAddr; a negative-as-signed i
+            // casts to a huge ulong that always fails the bound.
             if ((ulong)i >= (ulong)tab.Elements.Count
                 || i > (long)int.MaxValue)
             {
@@ -135,7 +133,7 @@ namespace Wacs.Core.Instructions
                 $"Instruction table.set found incorrect type on top of the Stack");
             //9.
             long i = context.OpStack.PopAddr();
-            //10. Phase D: unsigned compare for table64 indices.
+            //10. Unsigned bound for table64 indices.
             if ((ulong)i >= (ulong)tab.Elements.Count)
             {
                 throw new TrapException("table.set index exceeds table size.");

--- a/Wacs.Core/Wacs.Core/Runtime/OpStack.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/OpStack.cs
@@ -147,11 +147,20 @@ namespace Wacs.Core.Runtime
             return _registers[Count].Data.UInt64;
         }
 
+        // Phase D: returns a long whose unsigned reading is the wasm
+        // address. memory32 pops i32 zero-extended into the low 32
+        // bits — fits in long without sign issues. memory64 pops i64
+        // bit-patterns up to 2^64-1; the long carries the bits and
+        // bounds-check sites cast to ulong for unsigned comparison.
+        // The historical `if (addr < 0) trap` is gone: a memory64
+        // address with the high bit set is legitimate, and the
+        // bounds check via ulong + width handles wrap detection
+        // explicitly.
         public long PopAddr()
         {
             --Count;
             var value = _registers[Count];
-            var addr = value.Type switch
+            return value.Type switch
             {
                 ValType.I32 => value.Data.UInt32,
                 ValType.I64 => value.Data.Int64,
@@ -159,9 +168,6 @@ namespace Wacs.Core.Runtime
                 ValType.U64 => (long)value.Data.UInt64,
                 _ => throw new InvalidDataException($"OperandStack contained wrong type {value.Type} expected int")
             };
-            if (addr < 0)
-                throw new TrapException($"Address was negative {addr}");
-            return addr;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Wacs.Core/Wacs.Core/Runtime/OpStack.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/OpStack.cs
@@ -147,15 +147,11 @@ namespace Wacs.Core.Runtime
             return _registers[Count].Data.UInt64;
         }
 
-        // Phase D: returns a long whose unsigned reading is the wasm
-        // address. memory32 pops i32 zero-extended into the low 32
-        // bits — fits in long without sign issues. memory64 pops i64
-        // bit-patterns up to 2^64-1; the long carries the bits and
-        // bounds-check sites cast to ulong for unsigned comparison.
-        // The historical `if (addr < 0) trap` is gone: a memory64
-        // address with the high bit set is legitimate, and the
-        // bounds check via ulong + width handles wrap detection
-        // explicitly.
+        // Returns a long whose unsigned reading is the wasm address.
+        // memory32 pops i32 zero-extended into the low 32 bits;
+        // memory64 pops i64 bit-patterns up to 2^64-1. Bounds-check
+        // sites cast to ulong for unsigned comparison and detect
+        // wrap explicitly.
         public long PopAddr()
         {
             --Count;

--- a/Wacs.Core/Wacs.Core/Runtime/RuntimeOptions.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/RuntimeOptions.cs
@@ -14,10 +14,48 @@
 
 namespace Wacs.Core.Runtime
 {
+    /// <summary>
+    /// Backing storage for <c>MemoryInstance</c> linear memory.
+    /// </summary>
+    /// <remarks>
+    /// Closes the byte[] 2 GiB-cap path from gap 12 of
+    /// <c>wasi-nn/WACS-GAPS.md</c>: <see cref="ManagedArray"/> uses
+    /// the historical <c>byte[]</c> + <c>Array.Resize</c> backing
+    /// (subject to <c>Array.MaxLength ≈ 2^31-1</c>);
+    /// <see cref="NativePointer"/> uses raw native memory allocated
+    /// via <c>NativeMemory.AllocZeroed</c> (.NET 6+) or
+    /// <c>Marshal.AllocHGlobal</c> + zeroing fallback, removing the
+    /// 2 GiB cap and enabling memory64. The runtime defaults to
+    /// <see cref="ManagedArray"/> until the migration phases land.
+    /// </remarks>
+    public enum MemoryStorageMode
+    {
+        /// <summary>Managed <c>byte[]</c> via <c>Array.Resize</c>.
+        /// Hard-capped at ~2 GiB (Array.MaxLength).</summary>
+        ManagedArray = 0,
+
+        /// <summary>Native pointer + <c>nuint</c> length via
+        /// <c>NativeMemory.AllocZeroed</c>. No 2 GiB cap; required
+        /// for memory64. Caller is responsible for disposing the
+        /// owning <c>WasmRuntime</c> / <c>MemoryInstance</c> so the
+        /// native buffer is freed.</summary>
+        NativePointer = 1,
+    }
+
     public class RuntimeOptions
     {
         public bool SkipModuleValidation = false;
         public bool SkipStartFunction = false;
         public bool TimeInstantiation = false;
+
+        /// <summary>
+        /// Backing storage for new <c>MemoryInstance</c> allocations.
+        /// Default <see cref="MemoryStorageMode.ManagedArray"/> keeps
+        /// the existing byte[] path byte-stable for callers that
+        /// haven't opted in. Set to
+        /// <see cref="MemoryStorageMode.NativePointer"/> to allocate
+        /// native memory and lift the 2 GiB cap.
+        /// </summary>
+        public MemoryStorageMode MemoryStorage = MemoryStorageMode.ManagedArray;
     }
 }

--- a/Wacs.Core/Wacs.Core/Runtime/RuntimeOptions.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/RuntimeOptions.cs
@@ -15,18 +15,21 @@
 namespace Wacs.Core.Runtime
 {
     /// <summary>
-    /// Backing storage for <c>MemoryInstance</c> linear memory.
+    /// Backing storage for a <see cref="Wacs.Core.Runtime.Types.MemoryInstance"/>'s
+    /// linear-memory bytes. Selected per runtime via
+    /// <see cref="RuntimeOptions.MemoryStorage"/>.
     /// </summary>
     /// <remarks>
-    /// Closes the byte[] 2 GiB-cap path from gap 12 of
-    /// <c>wasi-nn/WACS-GAPS.md</c>: <see cref="ManagedArray"/> uses
-    /// the historical <c>byte[]</c> + <c>Array.Resize</c> backing
-    /// (subject to <c>Array.MaxLength ≈ 2^31-1</c>);
-    /// <see cref="NativePointer"/> uses raw native memory allocated
-    /// via <c>NativeMemory.AllocZeroed</c> (.NET 6+) or
-    /// <c>Marshal.AllocHGlobal</c> + zeroing fallback, removing the
-    /// 2 GiB cap and enabling memory64. The runtime defaults to
-    /// <see cref="ManagedArray"/> until the migration phases land.
+    /// <see cref="ManagedArray"/> uses a <c>byte[]</c> grown via
+    /// <c>Array.Resize</c>: simple, GC-managed, and capped at
+    /// <c>Array.MaxLength ≈ 2^31-1</c> (~2 GiB).
+    /// <see cref="NativePointer"/> uses native memory allocated via
+    /// <c>NativeMemory.AllocZeroed</c> (.NET 6+) or
+    /// <c>Marshal.AllocHGlobal</c> + zeroing fallback (legacy): no
+    /// 2 GiB cap, supports the wasm32 spec's full 4 GiB, and is
+    /// required for memory64 modules. Native-mode memory must be
+    /// disposed by tearing down the owning <see cref="MemoryInstance"/>
+    /// — finalizer is a backstop only.
     /// </remarks>
     public enum MemoryStorageMode
     {
@@ -34,11 +37,10 @@ namespace Wacs.Core.Runtime
         /// Hard-capped at ~2 GiB (Array.MaxLength).</summary>
         ManagedArray = 0,
 
-        /// <summary>Native pointer + <c>nuint</c> length via
-        /// <c>NativeMemory.AllocZeroed</c>. No 2 GiB cap; required
-        /// for memory64. Caller is responsible for disposing the
-        /// owning <c>WasmRuntime</c> / <c>MemoryInstance</c> so the
-        /// native buffer is freed.</summary>
+        /// <summary>Native pointer + <c>nuint</c> length. No 2 GiB
+        /// cap; required for memory64. Owning
+        /// <see cref="Wacs.Core.Runtime.Types.MemoryInstance"/>
+        /// must be disposed to free the native buffer.</summary>
         NativePointer = 1,
     }
 

--- a/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -315,6 +315,24 @@ namespace Wacs.Core.Runtime.Types
             _growLock?.ExitReadLock();
         }
 
+        /// <summary>
+        /// Mode-dispatched <c>ref T</c> over the byte at offset
+        /// <paramref name="ea"/>. ManagedArray returns
+        /// <c>ref Unsafe.As&lt;byte, T&gt;(ref Data[ea])</c>;
+        /// NativePointer returns <c>ref Unsafe.AsRef&lt;T&gt;(NativeBase + ea)</c>.
+        /// Used by atomic load/store/RMW so the same Interlocked /
+        /// Volatile call sites work on both backings.
+        /// Caller guarantees <paramref name="ea"/> is in-bounds and
+        /// aligned for <typeparamref name="T"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ref T RefAs<T>(int ea) where T : unmanaged
+        {
+            if (StorageMode == MemoryStorageMode.NativePointer)
+                return ref Unsafe.AsRef<T>(NativeBase + ea);
+            return ref Unsafe.As<byte, T>(ref Data[ea]);
+        }
+
         /// <summary>Atomic 32-bit load at byte offset <paramref name="ea"/>.
         /// Caller guarantees <paramref name="ea"/> is in-bounds and 4-byte
         /// aligned.</summary>
@@ -323,7 +341,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 return Volatile.Read(ref cell);
             }
             finally { ExitReadIfShared(); }
@@ -336,7 +354,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 return Interlocked.Read(ref cell);
             }
             finally { ExitReadIfShared(); }
@@ -350,7 +368,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 Interlocked.Exchange(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -361,7 +379,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 Interlocked.Exchange(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -373,7 +391,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 return Interlocked.CompareExchange(ref cell, newValue, expected);
             }
             finally { ExitReadIfShared(); }
@@ -384,7 +402,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 return Interlocked.CompareExchange(ref cell, newValue, expected);
             }
             finally { ExitReadIfShared(); }
@@ -396,7 +414,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 // Interlocked.Add returns the new value; subtract to get original.
                 return Interlocked.Add(ref cell, value) - value;
             }
@@ -408,7 +426,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 return Interlocked.Add(ref cell, value) - value;
             }
             finally { ExitReadIfShared(); }
@@ -420,7 +438,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 return Interlocked.Exchange(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -431,7 +449,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 return Interlocked.Exchange(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -444,7 +462,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 return Interlocked.And(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -455,7 +473,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 return Interlocked.Or(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -466,7 +484,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 return Interlocked.And(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -477,7 +495,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 return Interlocked.Or(ref cell, value);
             }
             finally { ExitReadIfShared(); }
@@ -489,7 +507,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 int old;
                 do { old = Volatile.Read(ref cell); }
                 while (Interlocked.CompareExchange(ref cell, old & value, old) != old);
@@ -503,7 +521,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 int old;
                 do { old = Volatile.Read(ref cell); }
                 while (Interlocked.CompareExchange(ref cell, old | value, old) != old);
@@ -517,7 +535,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 long old;
                 do { old = Interlocked.Read(ref cell); }
                 while (Interlocked.CompareExchange(ref cell, old & value, old) != old);
@@ -531,7 +549,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 long old;
                 do { old = Interlocked.Read(ref cell); }
                 while (Interlocked.CompareExchange(ref cell, old & value, old) != old);
@@ -547,7 +565,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref int cell = ref Unsafe.As<byte, int>(ref Data[ea]);
+                ref int cell = ref RefAs<int>(ea);
                 int old;
                 do { old = Volatile.Read(ref cell); }
                 while (Interlocked.CompareExchange(ref cell, old ^ value, old) != old);
@@ -561,7 +579,7 @@ namespace Wacs.Core.Runtime.Types
             EnterReadIfShared();
             try
             {
-                ref long cell = ref Unsafe.As<byte, long>(ref Data[ea]);
+                ref long cell = ref RefAs<long>(ea);
                 long old;
                 do { old = Interlocked.Read(ref cell); }
                 while (Interlocked.CompareExchange(ref cell, old ^ value, old) != old);

--- a/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -80,7 +80,7 @@ namespace Wacs.Core.Runtime.Types
             Type = type;
             StorageMode = storage;
 
-            if (type.Limits.Minimum > Constants.HostMaxPages)
+            if (type.Limits.Minimum > MaxPagesForMode(storage))
                 throw new InstantiationException($"Cannot allocate memory of size {type.Limits.Minimum}");
 
             long initialSize = type.Limits.Minimum * Constants.PageSize;
@@ -156,7 +156,7 @@ namespace Wacs.Core.Runtime.Types
                 : Data.Length / Constants.PageSize;
             long newNumPages = oldNumPages + numPages;
 
-            if (newNumPages > Constants.HostMaxPages)
+            if (newNumPages > MaxPagesForMode(StorageMode))
                 return false;
 
             if (newNumPages > Type.Limits.Maximum)
@@ -217,6 +217,17 @@ namespace Wacs.Core.Runtime.Types
             }
             Type = new MemoryType(newLimits);
         }
+
+        // Page-count cap, by storage mode. ManagedArray is hard-
+        // capped at HostMaxPages (~2 GiB, the byte[] limit even with
+        // gcAllowVeryLargeObjects). NativePointer lifts the cap to
+        // the wasm32 spec max (WasmMaxPages = 4 GiB) for memory32 —
+        // memory64 widens it further to WasmMaxPages64 (2^48), but
+        // that requires Phase D's i64-address plumbing.
+        private static long MaxPagesForMode(MemoryStorageMode mode)
+            => mode == MemoryStorageMode.NativePointer
+                ? Constants.WasmMaxPages
+                : Constants.HostMaxPages;
 
         // Native buffer allocator. Prefers NativeMemory.AllocZeroed
         // on .NET 6+ (single syscall, page-zeroed by the OS); falls

--- a/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -28,22 +28,14 @@ namespace Wacs.Core.Runtime.Types
 {
     public unsafe class MemoryInstance : IDisposable
     {
-        // Managed-array backing for ManagedArray mode. In
-        // NativePointer mode this stays as Array.Empty<byte>() so
-        // accidental Data[i] reads land on a bounds-checked empty
-        // span (clear AOOR) rather than silently zero-reading. The
-        // byte[] surface is preserved for callers that haven't yet
-        // migrated to NativeBase / AsSpan; Phase B/C will retire
-        // those access sites and Phase D will remove this field.
+        // ManagedArray-mode backing. In NativePointer mode this
+        // stays as Array.Empty<byte>() so accidental Data[i] access
+        // surfaces an AOOR rather than silently zero-reading.
         public byte[] Data;
 
-        // NativePointer-mode storage. Zero in ManagedArray mode.
-        // Native buffer is allocated by NativeMemory.AllocZeroed
-        // (.NET 6+) or Marshal.AllocHGlobal + InitBlock (legacy)
-        // and reallocated by Grow's own copy+free sequence.
-        // NativeSize is the authoritative byte length in this mode
-        // (Data.Length is meaningless when StorageMode ==
-        // NativePointer).
+        // NativePointer-mode storage; zero/null in ManagedArray
+        // mode. NativeSize is authoritative — Data.Length is
+        // meaningless when StorageMode == NativePointer.
         public byte* NativeBase;
         public nuint NativeSize;
 
@@ -67,9 +59,8 @@ namespace Wacs.Core.Runtime.Types
         // off the lock entirely.
         internal ReaderWriterLockSlim? _growLock;
 
-        // Disposed flag: cheap bool check on dispose paths so the
-        // finalizer + explicit Dispose are both idempotent. Native
-        // buffer free happens once.
+        // Idempotency flag: explicit Dispose and the finalizer both
+        // hit DisposeCore; the native-buffer free runs once.
         private bool _disposed;
 
         [SuppressMessage("ReSharper.DPA", "DPA0003: Excessive memory allocations in LOH", MessageId = "type: System.Byte[]; size: 134MB")]
@@ -88,13 +79,10 @@ namespace Wacs.Core.Runtime.Types
             switch (storage)
             {
                 case MemoryStorageMode.NativePointer:
-                    // AllocZeroed on .NET 6+ gives us page-zeroed memory
-                    // (matches byte[]'s default-zero spec). On legacy
-                    // targets fall back to AllocHGlobal + InitBlock.
                     NativeBase = AllocateZeroed((nuint)initialSize);
                     NativeSize = (nuint)initialSize;
-                    // Sentinel empty array so Data[i] callers fail loudly
-                    // (AOOR) instead of silently reading zeros.
+                    // Sentinel empty array so accidental Data[i]
+                    // reads fail loudly instead of zero-reading.
                     Data = Array.Empty<byte>();
                     break;
                 case MemoryStorageMode.ManagedArray:
@@ -110,10 +98,10 @@ namespace Wacs.Core.Runtime.Types
             ? (long)(NativeSize / Constants.PageSize)
             : Data.Length / Constants.PageSize;
 
-        // Authoritative byte length, both modes. Returns nuint (64-
-        // bit on 64-bit hosts) so memory64 callers don't truncate.
-        // Phase B/C migrate access sites to consult this instead of
-        // Data.Length; ManagedArray callers see the same value.
+        /// <summary>
+        /// Authoritative byte length in either mode. <c>nuint</c>
+        /// (host-pointer-sized) so memory64 callers don't truncate.
+        /// </summary>
         public nuint ByteLength => StorageMode == MemoryStorageMode.NativePointer
             ? NativeSize
             : (nuint)Data.Length;
@@ -219,14 +207,12 @@ namespace Wacs.Core.Runtime.Types
             Type = new MemoryType(newLimits);
         }
 
-        // Page-count cap, by storage mode + address type. ManagedArray
-        // is hard-capped at HostMaxPages (~2 GiB, the byte[] limit
-        // even with gcAllowVeryLargeObjects). NativePointer lifts the
-        // cap to the wasm32 spec max (WasmMaxPages = 4 GiB) for
-        // memory32 modules and to WasmMaxPages64 (2^48) for memory64
-        // modules — phase D wires the i64-address plumbing through
-        // PopAddr / bounds-check arithmetic so the high cap is
-        // actually reachable.
+        // Page-count cap, by storage mode + address type.
+        // ManagedArray: hard-capped at HostMaxPages (~2 GiB, the
+        // byte[] limit even with gcAllowVeryLargeObjects).
+        // NativePointer + i32 memory: WasmMaxPages (4 GiB, wasm32
+        // spec max).
+        // NativePointer + i64 memory: WasmMaxPages64 (2^48).
         private long MaxPagesForMode(MemoryStorageMode mode)
         {
             if (mode != MemoryStorageMode.NativePointer)

--- a/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -337,7 +337,7 @@ namespace Wacs.Core.Runtime.Types
         /// aligned for <typeparamref name="T"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ref T RefAs<T>(int ea) where T : unmanaged
+        public ref T RefAs<T>(int ea) where T : unmanaged
         {
             if (StorageMode == MemoryStorageMode.NativePointer)
                 return ref Unsafe.AsRef<T>(NativeBase + ea);

--- a/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -25,9 +25,35 @@ using Wacs.Core.Utilities;
 
 namespace Wacs.Core.Runtime.Types
 {
-    public class MemoryInstance
+    public unsafe class MemoryInstance : IDisposable
     {
+        // Managed-array backing for ManagedArray mode. In
+        // NativePointer mode this stays as Array.Empty<byte>() so
+        // accidental Data[i] reads land on a bounds-checked empty
+        // span (clear AOOR) rather than silently zero-reading. The
+        // byte[] surface is preserved for callers that haven't yet
+        // migrated to NativeBase / AsSpan; Phase B/C will retire
+        // those access sites and Phase D will remove this field.
         public byte[] Data;
+
+        // NativePointer-mode storage. Zero in ManagedArray mode.
+        // Native buffer is allocated by NativeMemory.AllocZeroed
+        // (.NET 6+) or Marshal.AllocHGlobal + InitBlock (legacy)
+        // and reallocated by Grow's own copy+free sequence.
+        // NativeSize is the authoritative byte length in this mode
+        // (Data.Length is meaningless when StorageMode ==
+        // NativePointer).
+        public byte* NativeBase;
+        public nuint NativeSize;
+
+        /// <summary>
+        /// Backing storage selector. <see cref="MemoryStorageMode.ManagedArray"/>
+        /// reads/writes <see cref="Data"/>; <see cref="MemoryStorageMode.NativePointer"/>
+        /// reads/writes <see cref="NativeBase"/> + <see cref="NativeSize"/>.
+        /// Set at construction; immutable for the lifetime of this
+        /// instance (Grow preserves the chosen mode).
+        /// </summary>
+        public MemoryStorageMode StorageMode { get; }
 
         // Lazy-allocated only when the host has opted into concurrent wasm
         // execution (see ConcurrencyPolicyMode.HostDefined) AND the memory
@@ -40,39 +66,102 @@ namespace Wacs.Core.Runtime.Types
         // off the lock entirely.
         internal ReaderWriterLockSlim? _growLock;
 
+        // Disposed flag: cheap bool check on dispose paths so the
+        // finalizer + explicit Dispose are both idempotent. Native
+        // buffer free happens once.
+        private bool _disposed;
+
         [SuppressMessage("ReSharper.DPA", "DPA0003: Excessive memory allocations in LOH", MessageId = "type: System.Byte[]; size: 134MB")]
         public MemoryInstance(MemoryType type)
+            : this(type, MemoryStorageMode.ManagedArray) { }
+
+        public MemoryInstance(MemoryType type, MemoryStorageMode storage)
         {
             Type = type;
+            StorageMode = storage;
 
             if (type.Limits.Minimum > Constants.HostMaxPages)
                 throw new InstantiationException($"Cannot allocate memory of size {type.Limits.Minimum}");
-            
-            long initialSize = (type.Limits.Minimum)* Constants.PageSize;
-            Data = new byte[initialSize];
+
+            long initialSize = type.Limits.Minimum * Constants.PageSize;
+            switch (storage)
+            {
+                case MemoryStorageMode.NativePointer:
+                    // AllocZeroed on .NET 6+ gives us page-zeroed memory
+                    // (matches byte[]'s default-zero spec). On legacy
+                    // targets fall back to AllocHGlobal + InitBlock.
+                    NativeBase = AllocateZeroed((nuint)initialSize);
+                    NativeSize = (nuint)initialSize;
+                    // Sentinel empty array so Data[i] callers fail loudly
+                    // (AOOR) instead of silently reading zeros.
+                    Data = Array.Empty<byte>();
+                    break;
+                case MemoryStorageMode.ManagedArray:
+                default:
+                    Data = new byte[initialSize];
+                    break;
+            }
         }
 
         public MemoryType Type { get; private set; }
 
-        public long Size => Data.Length / Constants.PageSize;
+        public long Size => StorageMode == MemoryStorageMode.NativePointer
+            ? (long)(NativeSize / Constants.PageSize)
+            : Data.Length / Constants.PageSize;
+
+        // Authoritative byte length, both modes. Returns nuint (64-
+        // bit on 64-bit hosts) so memory64 callers don't truncate.
+        // Phase B/C migrate access sites to consult this instead of
+        // Data.Length; ManagedArray callers see the same value.
+        public nuint ByteLength => StorageMode == MemoryStorageMode.NativePointer
+            ? NativeSize
+            : (nuint)Data.Length;
 
         //TODO bounds checking?
-        public Span<byte> this[Range range] => Data.AsSpan(range);
+        public Span<byte> this[Range range]
+        {
+            get
+            {
+                if (StorageMode == MemoryStorageMode.NativePointer)
+                {
+                    var (offset, length) = range.GetOffsetAndLength((int)NativeSize);
+                    return new Span<byte>(NativeBase + offset, length);
+                }
+                return Data.AsSpan(range);
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Span{T}"/> over the storage,
+        /// regardless of mode. Callers must not retain the span past
+        /// the next <see cref="Grow"/> on this instance — grow
+        /// reallocates the backing storage and the span becomes
+        /// stale (matches the contract <c>byte[].AsSpan</c> already
+        /// imposed via Array.Resize).
+        /// </summary>
+        public Span<byte> AsSpan(int offset, int length)
+        {
+            if (StorageMode == MemoryStorageMode.NativePointer)
+                return new Span<byte>(NativeBase + offset, length);
+            return Data.AsSpan(offset, length);
+        }
 
         /// <summary>
         /// @Spec 4.5.3.9. Growing memories
         /// </summary>
         public bool Grow(long numPages)
         {
-            long oldNumPages = Data.Length / Constants.PageSize;
+            long oldNumPages = StorageMode == MemoryStorageMode.NativePointer
+                ? (long)(NativeSize / Constants.PageSize)
+                : Data.Length / Constants.PageSize;
             long newNumPages = oldNumPages + numPages;
 
             if (newNumPages > Constants.HostMaxPages)
                 return false;
-            
+
             if (newNumPages > Type.Limits.Maximum)
                 return false;
-            
+
             var newLimits = new Limits(Type.Limits)
             {
                 Minimum = newNumPages
@@ -88,29 +177,110 @@ namespace Wacs.Core.Runtime.Types
                 return false;
             }
 
-            int len = (int)(newNumPages * Constants.PageSize);
+            long len = newNumPages * Constants.PageSize;
 
             var gl = _growLock;
             if (gl != null)
             {
                 gl.EnterWriteLock();
-                try
-                {
-                    Array.Resize(ref Data, len);
-                    Type = new MemoryType(newLimits);
-                }
-                finally
-                {
-                    gl.ExitWriteLock();
-                }
+                try { GrowStorage(len, newLimits); }
+                finally { gl.ExitWriteLock(); }
             }
             else
             {
-                Array.Resize(ref Data, len);
-                Type = new MemoryType(newLimits);
+                GrowStorage(len, newLimits);
             }
 
             return true;
+        }
+
+        // Mode-specific grow body. ManagedArray uses Array.Resize
+        // (capped at ~2 GiB). NativePointer allocates a new
+        // zero-initialized native buffer, copies the live bytes,
+        // and frees the old buffer — no 2 GiB cap.
+        private void GrowStorage(long newLenBytes, Limits newLimits)
+        {
+            if (StorageMode == MemoryStorageMode.NativePointer)
+            {
+                nuint newSize = (nuint)newLenBytes;
+                byte* newBase = AllocateZeroed(newSize);
+                if (NativeSize > 0)
+                    Buffer.MemoryCopy(NativeBase, newBase,
+                        (long)newSize, (long)NativeSize);
+                FreeNative(NativeBase);
+                NativeBase = newBase;
+                NativeSize = newSize;
+            }
+            else
+            {
+                Array.Resize(ref Data, (int)newLenBytes);
+            }
+            Type = new MemoryType(newLimits);
+        }
+
+        // Native buffer allocator. Prefers NativeMemory.AllocZeroed
+        // on .NET 6+ (single syscall, page-zeroed by the OS); falls
+        // back to AllocHGlobal + InitBlock on legacy targets.
+        private static byte* AllocateZeroed(nuint size)
+        {
+#if NET6_0_OR_GREATER
+            return (byte*)NativeMemory.AllocZeroed(size);
+#else
+            // AllocHGlobal returns uninitialized memory; zero it
+            // explicitly so the byte[] default-zero spec holds.
+            // size cap: AllocHGlobal takes IntPtr (signed) — for
+            // sizes near nuint.MaxValue on 64-bit hosts this would
+            // truncate; netstandard2.1 callers don't need >2 GiB
+            // memories, so the cast is safe in practice.
+            byte* ptr = (byte*)Marshal.AllocHGlobal((IntPtr)(long)size);
+            if (size > 0)
+                Unsafe.InitBlockUnaligned(ptr, 0, (uint)size);
+            return ptr;
+#endif
+        }
+
+        private static void FreeNative(byte* ptr)
+        {
+            if (ptr == null) return;
+#if NET6_0_OR_GREATER
+            NativeMemory.Free(ptr);
+#else
+            Marshal.FreeHGlobal((IntPtr)ptr);
+#endif
+        }
+
+        // Explicit dispose — caller owns the lifetime and is
+        // responsible for releasing native memory when the runtime
+        // is torn down. Finalizer is a backstop for native-mode
+        // leaks; ManagedArray mode skips the finalizer registration.
+        public void Dispose()
+        {
+            DisposeCore();
+            // Fully-qualified — Wacs.Core.Runtime has a sibling
+            // GC sub-namespace that the resolver picks first.
+            System.GC.SuppressFinalize(this);
+        }
+
+        ~MemoryInstance()
+        {
+            DisposeCore();
+        }
+
+        private void DisposeCore()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            if (StorageMode == MemoryStorageMode.NativePointer
+                && NativeBase != null)
+            {
+                FreeNative(NativeBase);
+                NativeBase = null;
+                NativeSize = 0;
+            }
+            // ManagedArray: nothing to free — the GC reclaims Data
+            // when the MemoryInstance becomes unreachable.
+            _growLock?.Dispose();
+            _growLock = null;
         }
 
         /// <summary>

--- a/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/Types/MemoryInstance.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using FluentValidation;
 using Wacs.Core.Runtime.Exceptions;
 using Wacs.Core.Types;
+using Wacs.Core.Types.Defs;
 using Wacs.Core.Utilities;
 
 namespace Wacs.Core.Runtime.Types
@@ -218,16 +219,22 @@ namespace Wacs.Core.Runtime.Types
             Type = new MemoryType(newLimits);
         }
 
-        // Page-count cap, by storage mode. ManagedArray is hard-
-        // capped at HostMaxPages (~2 GiB, the byte[] limit even with
-        // gcAllowVeryLargeObjects). NativePointer lifts the cap to
-        // the wasm32 spec max (WasmMaxPages = 4 GiB) for memory32 —
-        // memory64 widens it further to WasmMaxPages64 (2^48), but
-        // that requires Phase D's i64-address plumbing.
-        private static long MaxPagesForMode(MemoryStorageMode mode)
-            => mode == MemoryStorageMode.NativePointer
-                ? Constants.WasmMaxPages
-                : Constants.HostMaxPages;
+        // Page-count cap, by storage mode + address type. ManagedArray
+        // is hard-capped at HostMaxPages (~2 GiB, the byte[] limit
+        // even with gcAllowVeryLargeObjects). NativePointer lifts the
+        // cap to the wasm32 spec max (WasmMaxPages = 4 GiB) for
+        // memory32 modules and to WasmMaxPages64 (2^48) for memory64
+        // modules — phase D wires the i64-address plumbing through
+        // PopAddr / bounds-check arithmetic so the high cap is
+        // actually reachable.
+        private long MaxPagesForMode(MemoryStorageMode mode)
+        {
+            if (mode != MemoryStorageMode.NativePointer)
+                return Constants.HostMaxPages;
+            return Type.Limits.AddressType == AddrType.I64
+                ? Constants.WasmMaxPages64
+                : Constants.WasmMaxPages;
+        }
 
         // Native buffer allocator. Prefers NativeMemory.AllocZeroed
         // on .NET 6+ (single syscall, page-zeroed by the OS); falls

--- a/Wacs.Core/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/WasmRuntimeInstantiation.cs
@@ -133,7 +133,8 @@ namespace Wacs.Core.Runtime
         /// @Spec 4.5.3.10. Modules Allocation
         /// *We also evaluate globals and elements here, per instantiation
         /// </summary>
-        private ModuleInstance AllocateModule(Module module)
+        private ModuleInstance AllocateModule(Module module,
+            MemoryStorageMode memStorage = MemoryStorageMode.ManagedArray)
         {
             //20. Include Types from module
             var moduleInstance = new ModuleInstance(module);
@@ -248,7 +249,7 @@ namespace Wacs.Core.Runtime
             //10. index ordered memory addresses
             foreach (var mem in module.Memories)
             {
-                moduleInstance.MemAddrs.Add(AllocateMemory(Store, mem));
+                moduleInstance.MemAddrs.Add(AllocateMemory(Store, mem, memStorage));
             }
             //Make the address space permanent
             moduleInstance.MemAddrs.Finalize();
@@ -434,7 +435,7 @@ namespace Wacs.Core.Runtime
                     throw new WasmRuntimeException("OpStack should be empty");
 
                 //2, 3, 4 Checks if imports are satisfied
-                moduleInstance = AllocateModule(module);
+                moduleInstance = AllocateModule(module, options.MemoryStorage);
 
                 //12.
                 var auxFrame = GetExecContext().ReserveFrame(moduleInstance, 0);
@@ -647,9 +648,10 @@ namespace Wacs.Core.Runtime
         /// <summary>
         /// @Spec 4.5.3.4. Memories
         /// </summary>
-        private static MemAddr AllocateMemory(Store store, MemoryType memType)
+        private static MemAddr AllocateMemory(Store store, MemoryType memType,
+            MemoryStorageMode storage = MemoryStorageMode.ManagedArray)
         {
-            var memInst = new MemoryInstance(memType);
+            var memInst = new MemoryInstance(memType, storage);
             var memAddr = store.AddMemory(memInst);
             return memAddr;
         }

--- a/Wacs.Core/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.12.2</AssemblyVersion>
-    <Version>0.12.2</Version>
+    <AssemblyVersion>0.12.3</AssemblyVersion>
+    <Version>0.12.3</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter. v0.12 brings the in-process WAT/WAST parser to full parity with the binary parser — every wast in the WebAssembly spec testsuite (SIMD, GC, relaxed-SIMD, hex-float edge cases) round-trips identically through both pipelines, dropping the wasm-tools / wast2json CI dependency. v0.12.1 tracks the wasm-3.0 spec submodule to tip d7aada5: inclusive memory page-count limit (PRs #105/#106/#108), tail-call to imported host functions (PR #1872), `array.new_data` bounds (PR #1881), malformed memop reserved bits (PRs #1886/#1936), table64 u64 limits (PR #104), `(module definition …)` validate-only support, u32 offset enforcement on memory32, and `;;` line-comment CR termination.</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/Wacs.Core/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core/Wacs.Core.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.12.4</AssemblyVersion>
-    <Version>0.12.4</Version>
+    <AssemblyVersion>0.13.0</AssemblyVersion>
+    <Version>0.13.0</Version>
     <Authors>Kelvin Nishikawa</Authors>
-    <Description>A Pure C# WebAssembly Interpreter. v0.12 brings the in-process WAT/WAST parser to full parity with the binary parser — every wast in the WebAssembly spec testsuite (SIMD, GC, relaxed-SIMD, hex-float edge cases) round-trips identically through both pipelines, dropping the wasm-tools / wast2json CI dependency. v0.12.1 tracks the wasm-3.0 spec submodule to tip d7aada5: inclusive memory page-count limit (PRs #105/#106/#108), tail-call to imported host functions (PR #1872), `array.new_data` bounds (PR #1881), malformed memop reserved bits (PRs #1886/#1936), table64 u64 limits (PR #104), `(module definition …)` validate-only support, u32 offset enforcement on memory32, and `;;` line-comment CR termination.</Description>
+    <Description>A Pure C# WebAssembly Interpreter. v0.13 introduces selectable linear-memory storage: ManagedArray (byte[], default, ~2 GiB) or NativePointer (NativeMemory.AllocZeroed, no 2 GiB cap) via RuntimeOptions.MemoryStorage. NativePointer + (memory i64) lifts the cap to WasmMaxPages64 (2^48), unlocking memory64 modules end-to-end through the interpreter and transpiler. Memory-op bounds checks moved to a wrap-safe unsigned form covering memory32 and memory64. v0.12 brought the in-process WAT/WAST parser to full parity with the binary parser — every wast in the WebAssembly spec testsuite (SIMD, GC, relaxed-SIMD, hex-float edge cases) round-trips identically through both pipelines, dropping the wasm-tools / wast2json CI dependency. v0.12.1 tracks the wasm-3.0 spec submodule to tip d7aada5: inclusive memory page-count limit (PRs #105/#106/#108), tail-call to imported host functions (PR #1872), `array.new_data` bounds (PR #1881), malformed memop reserved bits (PRs #1886/#1936), table64 u64 limits (PR #104), `(module definition …)` validate-only support, u32 offset enforcement on memory32, and `;;` line-comment CR termination.</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Wacs.Core/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.12.3</AssemblyVersion>
-    <Version>0.12.3</Version>
+    <AssemblyVersion>0.12.4</AssemblyVersion>
+    <Version>0.12.4</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter. v0.12 brings the in-process WAT/WAST parser to full parity with the binary parser — every wast in the WebAssembly spec testsuite (SIMD, GC, relaxed-SIMD, hex-float edge cases) round-trips identically through both pipelines, dropping the wasm-tools / wast2json CI dependency. v0.12.1 tracks the wasm-3.0 spec submodule to tip d7aada5: inclusive memory page-count limit (PRs #105/#106/#108), tail-call to imported host functions (PR #1872), `array.new_data` bounds (PR #1881), malformed memop reserved bits (PRs #1886/#1936), table64 u64 limits (PR #104), `(module definition …)` validate-only support, u32 offset enforcement on memory32, and `;;` line-comment CR termination.</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/Wacs.HostBindings/Wacs.HostBindings.Abstractions/Wacs.HostBindings.Abstractions.csproj
+++ b/Wacs.HostBindings/Wacs.HostBindings.Abstractions/Wacs.HostBindings.Abstractions.csproj
@@ -13,8 +13,8 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.HostBindings.Abstractions</AssemblyName>
         <RootNamespace>Wacs.HostBindings</RootNamespace>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
-        <Version>0.2.1</Version>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
+        <Version>0.3.0</Version>
         <RepositoryType>git</RepositoryType>
         <!-- netstandard2.0 so the matching source generator (also
              netstandard2.0 by Roslyn requirement) can reference this

--- a/Wacs.HostBindings/Wacs.HostBindings.Abstractions/Wacs.HostBindings.Abstractions.csproj
+++ b/Wacs.HostBindings/Wacs.HostBindings.Abstractions/Wacs.HostBindings.Abstractions.csproj
@@ -13,14 +13,20 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.HostBindings.Abstractions</AssemblyName>
         <RootNamespace>Wacs.HostBindings</RootNamespace>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.2.1</Version>
         <RepositoryType>git</RepositoryType>
         <!-- netstandard2.0 so the matching source generator (also
              netstandard2.0 by Roslyn requirement) can reference this
              at analyzer-load time without target-framework gymnastics. -->
         <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
+        <!-- WacsHostMemory supports a NativePointer backing
+             (byte* via IntPtr) for >2 GiB linear-memory hosts that
+             use Wacs.Core's MemoryStorageMode.NativePointer. Methods
+             that dereference the pointer are method-level unsafe;
+             this flag enables those blocks. -->
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/Wacs.HostBindings/Wacs.HostBindings.Abstractions/WacsHostMemory.cs
+++ b/Wacs.HostBindings/Wacs.HostBindings.Abstractions/WacsHostMemory.cs
@@ -13,40 +13,88 @@ namespace Wacs.HostBindings
     /// parameter to every <see cref="WacsImportAttribute"/>-annotated
     /// binding method.
     ///
-    /// <para>Wraps the live <see cref="byte"/>[] backing array plus the
-    /// authoritative byte length (which can grow via <c>memory.grow</c>).
-    /// Designed to be passed by value — it's a 16-byte struct; the JIT
-    /// (or NativeAOT) inlines accesses.</para>
+    /// <para>Wraps either a managed <see cref="byte"/>[] backing array
+    /// (the historical path; up to ~2 GiB per <c>Array.MaxLength</c>)
+    /// or a native pointer + length (added in gap-12 phase C.4 to
+    /// support hosts running with
+    /// <c>Wacs.Core.Runtime.MemoryStorageMode.NativePointer</c>; up to
+    /// 4 GiB on wasm32 — and 2^48 once memory64 lands).</para>
     ///
-    /// <para>Bounds-checks every access via the public methods. Bindings
-    /// that need raw <see cref="Span{T}"/> access (e.g. for bulk
-    /// memcpy-style I/O) call <see cref="AsSpan(int, int)"/>, which performs
-    /// a single bounds check per slice.</para>
+    /// <para>The struct is a 24-byte readonly struct passed by value; the
+    /// JIT (or NativeAOT) inlines the mode dispatch to a single branch
+    /// per access. Bounds-checks every access through the public methods.
+    /// Bindings that need raw <see cref="Span{T}"/> access (e.g. for bulk
+    /// memcpy-style I/O) call <see cref="AsSpan(int, int)"/>, which
+    /// performs a single bounds check per slice.</para>
     ///
-    /// <para>The struct does not own the byte[] — it's a view, valid only
-    /// for the duration of the binding call. Don't squirrel it away across
-    /// asynchronous boundaries; the underlying array can be reallocated
-    /// by <c>memory.grow</c> and any cached reference becomes stale.</para>
+    /// <para>The struct does not own the backing storage — it's a view,
+    /// valid only for the duration of the binding call. Don't squirrel
+    /// it away across asynchronous boundaries; the underlying buffer can
+    /// be reallocated by <c>memory.grow</c> and any cached reference
+    /// becomes stale.</para>
     /// </summary>
     public readonly struct WacsHostMemory
     {
-        private readonly byte[] _data;
+        // ManagedArray backing. Null in NativePointer mode.
+        private readonly byte[]? _data;
+
+        // NativePointer backing. IntPtr.Zero in ManagedArray mode.
+        // Stored as IntPtr so the struct stays usable in safe code;
+        // methods that dereference cast to byte* in unsafe blocks.
+        private readonly IntPtr _nativeBase;
+
+        // Authoritative wasm-visible byte length, both modes.
+        // int (not nuint) for back-compat with the public Length API
+        // and because bindings work in int-bounded slices anyway —
+        // a >2 GiB native memory still sliceable in int chunks. The
+        // ctor overload that takes a host's full nuint length
+        // (truncating to int.MaxValue) gives the binding a usable
+        // window without exposing an int → ulong promotion.
         private readonly int _length;
 
         /// <summary>
-        /// Wraps the given backing array. Pass the live <c>byte[]</c> from
-        /// <c>MemoryInstance.Data</c> (or the equivalent in your runtime)
-        /// plus the authoritative wasm-visible byte length (which may be
-        /// less than <c>_data.Length</c> when the runtime over-allocates
-        /// for grow headroom).
+        /// Wraps the given byte[] backing array. The historical
+        /// constructor; used by hosts running with
+        /// <c>MemoryStorageMode.ManagedArray</c>.
         /// </summary>
         public WacsHostMemory(byte[] data, int length)
         {
             _data = data ?? throw new ArgumentNullException(nameof(data));
+            _nativeBase = IntPtr.Zero;
             if ((uint)length > (uint)data.Length)
                 throw new ArgumentOutOfRangeException(nameof(length),
                     "length exceeds backing array length");
             _length = length;
+        }
+
+        /// <summary>
+        /// Wraps a native-pointer backing. Used by hosts running with
+        /// <c>MemoryStorageMode.NativePointer</c> (gap 12 phase C.4).
+        /// <paramref name="nativeBase"/> must point to <paramref name="length"/>
+        /// bytes of valid linear memory; the caller (the runtime)
+        /// guarantees the pointer outlives the binding call. Pass
+        /// <c>IntPtr.Zero</c> only with <c>length == 0</c>.
+        /// </summary>
+        public WacsHostMemory(IntPtr nativeBase, int length)
+        {
+            _data = null;
+            _nativeBase = nativeBase;
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length),
+                    "length must be non-negative");
+            if (length > 0 && nativeBase == IntPtr.Zero)
+                throw new ArgumentNullException(nameof(nativeBase),
+                    "nativeBase must be non-zero for non-empty memory");
+            _length = length;
+        }
+
+        /// <summary>True when this view is backed by native memory
+        /// (<see cref="MemoryStorageMode.NativePointer"/>) rather than
+        /// a managed byte[].</summary>
+        public bool IsNative
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _data == null;
         }
 
         /// <summary>Authoritative wasm-visible byte length.</summary>
@@ -54,31 +102,40 @@ namespace Wacs.HostBindings
 
         /// <summary>Read a single byte. Throws on out-of-range access.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public byte ReadByte(int offset)
+        public unsafe byte ReadByte(int offset)
         {
             CheckRange(offset, 1);
-            return _data[offset];
+            return _data != null
+                ? _data[offset]
+                : ((byte*)_nativeBase)[offset];
         }
 
         /// <summary>Write a single byte. Throws on out-of-range access.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteByte(int offset, byte value)
+        public unsafe void WriteByte(int offset, byte value)
         {
             CheckRange(offset, 1);
-            _data[offset] = value;
+            if (_data != null)
+                _data[offset] = value;
+            else
+                ((byte*)_nativeBase)[offset] = value;
         }
 
         /// <summary>
         /// Slice as a <see cref="Span{Byte}"/> — one bounds check per slice,
         /// then per-element accesses inside the span are unchecked. The
         /// returned span is live; reads see writes from concurrent wasm
-        /// execution if any.
+        /// execution if any. The span is valid only for the duration of
+        /// the binding call; <c>memory.grow</c> can reallocate the
+        /// backing buffer and invalidate it.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<byte> AsSpan(int offset, int length)
+        public unsafe Span<byte> AsSpan(int offset, int length)
         {
             CheckRange(offset, length);
-            return _data.AsSpan(offset, length);
+            return _data != null
+                ? _data.AsSpan(offset, length)
+                : new Span<byte>((byte*)_nativeBase + offset, length);
         }
 
         /// <summary>
@@ -88,37 +145,37 @@ namespace Wacs.HostBindings
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ReadInt32LE(int offset)
         {
-            CheckRange(offset, 4);
-            return _data[offset]
-                 | (_data[offset + 1] << 8)
-                 | (_data[offset + 2] << 16)
-                 | (_data[offset + 3] << 24);
+            var span = AsSpan(offset, 4);
+            return span[0]
+                 | (span[1] << 8)
+                 | (span[2] << 16)
+                 | (span[3] << 24);
         }
 
         /// <summary>Convenience writer for a 4-byte little-endian int.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteInt32LE(int offset, int value)
         {
-            CheckRange(offset, 4);
-            _data[offset]     = (byte)value;
-            _data[offset + 1] = (byte)(value >> 8);
-            _data[offset + 2] = (byte)(value >> 16);
-            _data[offset + 3] = (byte)(value >> 24);
+            var span = AsSpan(offset, 4);
+            span[0] = (byte)value;
+            span[1] = (byte)(value >> 8);
+            span[2] = (byte)(value >> 16);
+            span[3] = (byte)(value >> 24);
         }
 
         /// <summary>Convenience reader for an 8-byte little-endian long.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long ReadInt64LE(int offset)
         {
-            CheckRange(offset, 8);
-            uint lo = (uint)(_data[offset]
-                          | (_data[offset + 1] << 8)
-                          | (_data[offset + 2] << 16)
-                          | (_data[offset + 3] << 24));
-            uint hi = (uint)(_data[offset + 4]
-                          | (_data[offset + 5] << 8)
-                          | (_data[offset + 6] << 16)
-                          | (_data[offset + 7] << 24));
+            var span = AsSpan(offset, 8);
+            uint lo = (uint)(span[0]
+                          | (span[1] << 8)
+                          | (span[2] << 16)
+                          | (span[3] << 24));
+            uint hi = (uint)(span[4]
+                          | (span[5] << 8)
+                          | (span[6] << 16)
+                          | (span[7] << 24));
             return (long)((ulong)hi << 32 | lo);
         }
 
@@ -126,15 +183,15 @@ namespace Wacs.HostBindings
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteInt64LE(int offset, long value)
         {
-            CheckRange(offset, 8);
-            _data[offset]     = (byte)value;
-            _data[offset + 1] = (byte)(value >> 8);
-            _data[offset + 2] = (byte)(value >> 16);
-            _data[offset + 3] = (byte)(value >> 24);
-            _data[offset + 4] = (byte)(value >> 32);
-            _data[offset + 5] = (byte)(value >> 40);
-            _data[offset + 6] = (byte)(value >> 48);
-            _data[offset + 7] = (byte)(value >> 56);
+            var span = AsSpan(offset, 8);
+            span[0] = (byte)value;
+            span[1] = (byte)(value >> 8);
+            span[2] = (byte)(value >> 16);
+            span[3] = (byte)(value >> 24);
+            span[4] = (byte)(value >> 32);
+            span[5] = (byte)(value >> 40);
+            span[6] = (byte)(value >> 48);
+            span[7] = (byte)(value >> 56);
         }
 
         /// <summary>True if [offset, offset+byteCount) lies within the
@@ -154,12 +211,17 @@ namespace Wacs.HostBindings
             if (value == null) throw new ArgumentNullException(nameof(value));
             int byteCount = System.Text.Encoding.UTF8.GetByteCount(value);
             int total = byteCount + (nullTerminate ? 1 : 0);
-            CheckRange(offset, total);
-            // Encoding.UTF8.GetBytes(string, byte[], int) is available on both
-            // netstandard2.0 and net8.0; the (string, Span<byte>) overload is
-            // net5+ only.
-            System.Text.Encoding.UTF8.GetBytes(value, 0, value.Length, _data, offset);
-            if (nullTerminate) _data[offset + byteCount] = 0;
+            var span = AsSpan(offset, total);
+#if NET5_0_OR_GREATER
+            System.Text.Encoding.UTF8.GetBytes(value, span);
+#else
+            // netstandard2.0 fallback — encode to a byte[] first then
+            // copy. The legacy path historically went straight through
+            // _data; native-mode requires the copy regardless.
+            var bytes = System.Text.Encoding.UTF8.GetBytes(value);
+            new ReadOnlySpan<byte>(bytes).CopyTo(span);
+#endif
+            if (nullTerminate) span[byteCount] = 0;
             return total;
         }
 
@@ -168,10 +230,19 @@ namespace Wacs.HostBindings
         /// <paramref name="byteCount"/> bytes (no nul-terminator handling
         /// — pass the explicit length). Throws on out-of-range.
         /// </summary>
-        public string ReadUtf8String(int offset, int byteCount)
+        public unsafe string ReadUtf8String(int offset, int byteCount)
         {
             CheckRange(offset, byteCount);
-            return System.Text.Encoding.UTF8.GetString(_data, offset, byteCount);
+            if (_data != null)
+                return System.Text.Encoding.UTF8.GetString(_data, offset, byteCount);
+#if NET5_0_OR_GREATER
+            return System.Text.Encoding.UTF8.GetString(
+                new ReadOnlySpan<byte>((byte*)_nativeBase + offset, byteCount));
+#else
+            // netstandard2.0 has GetString(byte*, int).
+            return System.Text.Encoding.UTF8.GetString(
+                (byte*)_nativeBase + offset, byteCount);
+#endif
         }
 
         /// <summary>Alias for <see cref="ReadUtf8String(int,int)"/> matching
@@ -208,9 +279,8 @@ namespace Wacs.HostBindings
         public T[] ReadStructs<T>(int offset, int count) where T : unmanaged
         {
             int sz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
-            CheckRange(offset, sz * count);
             var span = System.Runtime.InteropServices.MemoryMarshal.Cast<byte, T>(
-                _data.AsSpan(offset, sz * count));
+                AsSpan(offset, sz * count));
             var arr = new T[count];
             span.CopyTo(arr);
             return arr;
@@ -222,9 +292,8 @@ namespace Wacs.HostBindings
         public T ReadStruct<T>(int offset) where T : unmanaged
         {
             int sz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
-            CheckRange(offset, sz);
             return System.Runtime.InteropServices.MemoryMarshal.Read<T>(
-                _data.AsSpan(offset, sz));
+                AsSpan(offset, sz));
         }
 
         /// <summary>
@@ -233,9 +302,8 @@ namespace Wacs.HostBindings
         public void WriteStruct<T>(int offset, T value) where T : unmanaged
         {
             int sz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
-            CheckRange(offset, sz);
             System.Runtime.InteropServices.MemoryMarshal.Write(
-                _data.AsSpan(offset, sz),
+                AsSpan(offset, sz),
 #if NET8_0_OR_GREATER
                 in value);
 #else
@@ -243,9 +311,16 @@ namespace Wacs.HostBindings
 #endif
         }
 
-        /// <summary>The underlying backing array. Use with care; prefer
-        /// the typed accessors above.</summary>
-        public byte[] Data => _data;
+        /// <summary>
+        /// The underlying byte[] backing array, or
+        /// <see cref="Array.Empty{T}"/> in NativePointer mode where no
+        /// managed buffer exists. Use <see cref="AsSpan(int, int)"/> for
+        /// mode-agnostic access; this getter exists only for legacy
+        /// callers that need a byte[] handle (pinning, marshaling). In
+        /// NativePointer mode legacy callers see an empty array — they
+        /// must migrate to AsSpan to read native memory.
+        /// </summary>
+        public byte[] Data => _data ?? Array.Empty<byte>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckRange(int offset, int byteCount)

--- a/Wacs.HostBindings/Wacs.HostBindings.Abstractions/WacsHostMemory.cs
+++ b/Wacs.HostBindings/Wacs.HostBindings.Abstractions/WacsHostMemory.cs
@@ -14,48 +14,43 @@ namespace Wacs.HostBindings
     /// binding method.
     ///
     /// <para>Wraps either a managed <see cref="byte"/>[] backing array
-    /// (the historical path; up to ~2 GiB per <c>Array.MaxLength</c>)
-    /// or a native pointer + length (added in gap-12 phase C.4 to
-    /// support hosts running with
-    /// <c>Wacs.Core.Runtime.MemoryStorageMode.NativePointer</c>; up to
-    /// 4 GiB on wasm32 — and 2^48 once memory64 lands).</para>
+    /// (~2 GiB cap per <c>Array.MaxLength</c>) or a native pointer +
+    /// length (no 2 GiB cap; up to 4 GiB on wasm32 and 2^48 on
+    /// memory64). Mode is decided at construction; consumers don't
+    /// need to know which backing they got — every accessor
+    /// dispatches automatically.</para>
     ///
-    /// <para>The struct is a 24-byte readonly struct passed by value; the
-    /// JIT (or NativeAOT) inlines the mode dispatch to a single branch
-    /// per access. Bounds-checks every access through the public methods.
-    /// Bindings that need raw <see cref="Span{T}"/> access (e.g. for bulk
-    /// memcpy-style I/O) call <see cref="AsSpan(int, int)"/>, which
-    /// performs a single bounds check per slice.</para>
+    /// <para>24-byte <c>readonly struct</c> passed by value; the JIT
+    /// (or NativeAOT) inlines the mode dispatch to a single branch
+    /// per access. Every access bounds-checks through the public
+    /// methods. Bindings that need raw <see cref="Span{T}"/> access
+    /// (bulk memcpy-style I/O) call <see cref="AsSpan(int, int)"/>,
+    /// which performs a single bounds check per slice.</para>
     ///
     /// <para>The struct does not own the backing storage — it's a view,
     /// valid only for the duration of the binding call. Don't squirrel
-    /// it away across asynchronous boundaries; the underlying buffer can
-    /// be reallocated by <c>memory.grow</c> and any cached reference
-    /// becomes stale.</para>
+    /// it away across asynchronous boundaries; the underlying buffer
+    /// can be reallocated by <c>memory.grow</c> and any cached
+    /// reference becomes stale.</para>
     /// </summary>
     public readonly struct WacsHostMemory
     {
-        // ManagedArray backing. Null in NativePointer mode.
+        // ManagedArray backing; null in NativePointer mode.
         private readonly byte[]? _data;
 
-        // NativePointer backing. IntPtr.Zero in ManagedArray mode.
+        // NativePointer backing; IntPtr.Zero in ManagedArray mode.
         // Stored as IntPtr so the struct stays usable in safe code;
         // methods that dereference cast to byte* in unsafe blocks.
         private readonly IntPtr _nativeBase;
 
-        // Authoritative wasm-visible byte length, both modes.
-        // int (not nuint) for back-compat with the public Length API
-        // and because bindings work in int-bounded slices anyway —
-        // a >2 GiB native memory still sliceable in int chunks. The
-        // ctor overload that takes a host's full nuint length
-        // (truncating to int.MaxValue) gives the binding a usable
-        // window without exposing an int → ulong promotion.
+        // wasm-visible byte length. int (not nuint) — bindings work
+        // in int-bounded slices anyway (a >2 GiB native memory is
+        // still sliceable in int chunks) and the public Length API
+        // is int-typed for back-compat.
         private readonly int _length;
 
         /// <summary>
-        /// Wraps the given byte[] backing array. The historical
-        /// constructor; used by hosts running with
-        /// <c>MemoryStorageMode.ManagedArray</c>.
+        /// Wraps a managed <c>byte[]</c> backing.
         /// </summary>
         public WacsHostMemory(byte[] data, int length)
         {
@@ -68,12 +63,11 @@ namespace Wacs.HostBindings
         }
 
         /// <summary>
-        /// Wraps a native-pointer backing. Used by hosts running with
-        /// <c>MemoryStorageMode.NativePointer</c> (gap 12 phase C.4).
-        /// <paramref name="nativeBase"/> must point to <paramref name="length"/>
-        /// bytes of valid linear memory; the caller (the runtime)
-        /// guarantees the pointer outlives the binding call. Pass
-        /// <c>IntPtr.Zero</c> only with <c>length == 0</c>.
+        /// Wraps a native-pointer backing. <paramref name="nativeBase"/>
+        /// must point to <paramref name="length"/> bytes of valid
+        /// linear memory; the runtime guarantees the pointer outlives
+        /// the binding call. Pass <c>IntPtr.Zero</c> only with
+        /// <c>length == 0</c>.
         /// </summary>
         public WacsHostMemory(IntPtr nativeBase, int length)
         {

--- a/Wacs.HostBindings/Wacs.HostBindings.Test/Wacs.HostBindings.Test.csproj
+++ b/Wacs.HostBindings/Wacs.HostBindings.Test/Wacs.HostBindings.Test.csproj
@@ -4,6 +4,9 @@
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
+    <!-- NativePointer tests use byte* / NativeMemory.AllocZeroed
+         to verify WacsHostMemory's native-backed accessors. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/Wacs.HostBindings/Wacs.HostBindings.Test/WacsHostMemoryTests.cs
+++ b/Wacs.HostBindings/Wacs.HostBindings.Test/WacsHostMemoryTests.cs
@@ -103,6 +103,119 @@ namespace Wacs.HostBindings.Test
             Assert.Throws<ArgumentNullException>(
                 () => new WacsHostMemory(null!, length: 0));
         }
+
+        // === NativePointer-mode coverage (gap 12 phase C.4) ===
+
+        [Fact]
+        public unsafe void NativePointer_ReadWriteByte_RoundTrips()
+        {
+            const int len = 16;
+            var ptr = (byte*)System.Runtime.InteropServices.NativeMemory
+                .AllocZeroed((nuint)len);
+            try
+            {
+                var mem = new WacsHostMemory((IntPtr)ptr, len);
+                Assert.True(mem.IsNative);
+                Assert.Equal(len, mem.Length);
+
+                mem.WriteByte(0, 0xAA);
+                mem.WriteByte(15, 0xBB);
+                Assert.Equal(0xAA, ptr[0]);
+                Assert.Equal(0xBB, ptr[15]);
+                Assert.Equal(0xAA, mem.ReadByte(0));
+                Assert.Equal(0xBB, mem.ReadByte(15));
+
+                Assert.Throws<WacsHostFault>(() => mem.ReadByte(16));
+                Assert.Throws<WacsHostFault>(() => mem.WriteByte(-1, 0));
+            }
+            finally
+            {
+                System.Runtime.InteropServices.NativeMemory.Free(ptr);
+            }
+        }
+
+        [Fact]
+        public unsafe void NativePointer_AsSpan_RoundTrips()
+        {
+            const int len = 32;
+            var ptr = (byte*)System.Runtime.InteropServices.NativeMemory
+                .AllocZeroed((nuint)len);
+            try
+            {
+                var mem = new WacsHostMemory((IntPtr)ptr, len);
+                var span = mem.AsSpan(8, 16);
+                for (int i = 0; i < span.Length; i++) span[i] = (byte)(i + 0xC0);
+
+                // Verify writes hit native memory directly.
+                for (int i = 0; i < 16; i++)
+                    Assert.Equal((byte)(i + 0xC0), ptr[8 + i]);
+            }
+            finally
+            {
+                System.Runtime.InteropServices.NativeMemory.Free(ptr);
+            }
+        }
+
+        [Fact]
+        public unsafe void NativePointer_Int32LERoundTrip()
+        {
+            const int len = 16;
+            var ptr = (byte*)System.Runtime.InteropServices.NativeMemory
+                .AllocZeroed((nuint)len);
+            try
+            {
+                var mem = new WacsHostMemory((IntPtr)ptr, len);
+                mem.WriteInt32LE(4, unchecked((int)0xCAFEBABE));
+                Assert.Equal(0xBE, ptr[4]);
+                Assert.Equal(0xBA, ptr[5]);
+                Assert.Equal(0xFE, ptr[6]);
+                Assert.Equal(0xCA, ptr[7]);
+                Assert.Equal(unchecked((int)0xCAFEBABE), mem.ReadInt32LE(4));
+            }
+            finally
+            {
+                System.Runtime.InteropServices.NativeMemory.Free(ptr);
+            }
+        }
+
+        [Fact]
+        public unsafe void NativePointer_Utf8String_RoundTrips()
+        {
+            const int len = 64;
+            var ptr = (byte*)System.Runtime.InteropServices.NativeMemory
+                .AllocZeroed((nuint)len);
+            try
+            {
+                var mem = new WacsHostMemory((IntPtr)ptr, len);
+                int written = mem.WriteUtf8String(8, "hello", nullTerminate: true);
+                Assert.Equal(6, written);  // 5 bytes + nul
+                Assert.Equal("hello", mem.ReadUtf8String(8, 5));
+                Assert.Equal((byte)'h', ptr[8]);
+                Assert.Equal((byte)0, ptr[13]);
+            }
+            finally
+            {
+                System.Runtime.InteropServices.NativeMemory.Free(ptr);
+            }
+        }
+
+        [Fact]
+        public void NativePointer_ZeroLength_AcceptsZeroPointer()
+        {
+            // Empty memory is a degenerate but valid case (no allocation).
+            var mem = new WacsHostMemory(IntPtr.Zero, 0);
+            Assert.True(mem.IsNative);
+            Assert.Equal(0, mem.Length);
+            Assert.Equal(0, mem.AsSpan(0, 0).Length);
+            Assert.Throws<WacsHostFault>(() => mem.ReadByte(0));
+        }
+
+        [Fact]
+        public void NativePointer_NonZeroLengthRequiresPointer()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new WacsHostMemory(IntPtr.Zero, 8));
+        }
     }
 
     internal static class TestExt

--- a/Wacs.HostBindings/Wacs.HostBindings.Test/WacsHostMemoryTests.cs
+++ b/Wacs.HostBindings/Wacs.HostBindings.Test/WacsHostMemoryTests.cs
@@ -104,7 +104,7 @@ namespace Wacs.HostBindings.Test
                 () => new WacsHostMemory(null!, length: 0));
         }
 
-        // === NativePointer-mode coverage (gap 12 phase C.4) ===
+        // === NativePointer-mode coverage ===
 
         [Fact]
         public unsafe void NativePointer_ReadWriteByte_RoundTrips()

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/DirectLinkedImportEmit.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/DirectLinkedImportEmit.cs
@@ -489,13 +489,16 @@ namespace Wacs.Transpiler.AOT.Component
                     // cabi_realloc to allocate guest buffer(s),
                     // copy bytes, write (ptr, len) pair.
                     //
-                    //   StoreXxx(memory, retArea, value,
+                    //   StoreXxx(memory_instance, retArea, value,
                     //            ctx.CabiRealloc)
+                    // Pass MemoryInstance (not byte[].Data) — gap 11:
+                    // cabi_realloc may call memory.grow which
+                    // reassigns Data to a new array, and the helper
+                    // re-fetches mem.Data after each realloc.
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, MemoriesField);
                     il.Emit(OpCodes.Ldc_I4_0);
                     il.Emit(OpCodes.Ldelem_Ref);
-                    il.Emit(OpCodes.Ldfld, MemoryDataField);
                     il.Emit(OpCodes.Ldloc, temps[retAreaSlot]);
                     il.Emit(OpCodes.Ldloc, returnLocal);
                     il.Emit(OpCodes.Ldarg_0);
@@ -539,13 +542,15 @@ namespace Wacs.Transpiler.AOT.Component
                 {
                     EmitInlineRecordOrTupleStore(il, method.ReturnType,
                         temps[retAreaSlot], 0, returnLocal,
-                        stringEncoding);
+                        stringEncoding,
+                        resolver, resourcesType);
                 }
                 else
                 {
                     EmitInlineRecordOrTupleStore(il, method.ReturnType,
                         temps[retAreaSlot], 0, returnLocal,
-                        stringEncoding);
+                        stringEncoding,
+                        resolver, resourcesType);
                 }
                 // Wasm sig has 0 returns; nothing further on the stack.
             }
@@ -1363,8 +1368,13 @@ namespace Wacs.Transpiler.AOT.Component
             }
             if (IsLikelyRecordType(t))
             {
+                // Resolver-aware: a record field can be a primitive,
+                // string, byte[], own<R> resource handle, OR an
+                // Option<X> with X a recognized aggregate. The last
+                // case covers DescriptorStat's option<datetime>
+                // fields (gap 10).
                 foreach (var p in GetRecordProperties(t))
-                    if (!IsFlatField(p.PropertyType)) return false;
+                    if (!IsFlatField(p.PropertyType, resolver)) return false;
                 return true;
             }
             if (t.IsGenericType)
@@ -1373,7 +1383,7 @@ namespace Wacs.Transpiler.AOT.Component
                 if (IsValueTupleType(def))
                 {
                     foreach (var ta in t.GetGenericArguments())
-                        if (!IsFlatField(ta)) return false;
+                        if (!IsFlatField(ta, resolver)) return false;
                     return true;
                 }
                 // Option<primitive> OR Option<own<R>> OR
@@ -1510,8 +1520,11 @@ namespace Wacs.Transpiler.AOT.Component
         // Max field alignment across a tuple/record. string/byte[]
         // contribute align 4 (i32 ptr); primitives use their own
         // alignment; resource interfaces contribute align 4 (i32
-        // handle) when a resolver is supplied.
-        private static int MaxFieldAlign(Type t)
+        // handle) when a resolver is supplied; Option<X> contributes
+        // MaxAlignOf(X) so adjacent fields after an option pack at
+        // the inner type's alignment.
+        private static int MaxFieldAlign(Type t,
+            HostPackageResolver? resolver = null)
         {
             int maxA = 1;
             if (t.IsGenericType
@@ -1519,7 +1532,7 @@ namespace Wacs.Transpiler.AOT.Component
             {
                 foreach (var ta in t.GetGenericArguments())
                 {
-                    int a = AlignOfFlatField(ta);
+                    int a = AlignOfFlatField(ta, resolver);
                     if (a > maxA) maxA = a;
                 }
             }
@@ -1527,7 +1540,7 @@ namespace Wacs.Transpiler.AOT.Component
             {
                 foreach (var p in GetRecordProperties(t))
                 {
-                    int a = AlignOfFlatField(p.PropertyType);
+                    int a = AlignOfFlatField(p.PropertyType, resolver);
                     if (a > maxA) maxA = a;
                 }
             }
@@ -1573,7 +1586,7 @@ namespace Wacs.Transpiler.AOT.Component
                 for (int i = 0; i < elements.Length; i++)
                 {
                     var et = elements[i];
-                    int fieldAlign = AlignOfFlatField(et);
+                    int fieldAlign = AlignOfFlatField(et, resolver);
                     int fieldOffset = Align(offsetSoFar, fieldAlign);
 
                     // PersistedAssemblyBuilder mis-encodes Ldfld against
@@ -1599,7 +1612,7 @@ namespace Wacs.Transpiler.AOT.Component
             {
                 foreach (var p in GetRecordProperties(type))
                 {
-                    int fieldAlign = AlignOfFlatField(p.PropertyType);
+                    int fieldAlign = AlignOfFlatField(p.PropertyType, resolver);
                     int fieldOffset = Align(offsetSoFar, fieldAlign);
 
                     EmitTupleOrRecordFieldStore(il, p.PropertyType,
@@ -1638,8 +1651,67 @@ namespace Wacs.Transpiler.AOT.Component
             bool isResource = resolver != null
                 && resourcesType != null
                 && resolver.IsResourceInterface(fieldType);
+            bool isOption = fieldType.IsGenericType
+                && fieldType.GetGenericTypeDefinition() == typeof(Option<>);
 
-            // dest_array
+            if (isOption)
+            {
+                // Option<X> field: stash the option value into a
+                // local, compute the field's absolute base address
+                // (parent_base + fieldOffset) into a separate local,
+                // and dispatch to EmitOptionStoreAt with that local
+                // standing in for retArea + a zero baseOffset.
+                // EmitOptionStoreAt handles the disc + value layout
+                // and recurses into Option<Option<X>> /
+                // Option<Result<X,Y>> / Option<record-of-primitives>
+                // shapes the same way it does for top-level returns.
+                var optionLocal = il.DeclareLocal(fieldType);
+                pushFieldValue(il);
+                il.Emit(OpCodes.Stloc, optionLocal);
+
+                var fieldBaseLocal = il.DeclareLocal(typeof(int));
+                pushBaseAddress(il);
+                if (fieldOffset != 0)
+                {
+                    il.Emit(OpCodes.Ldc_I4, fieldOffset);
+                    il.Emit(OpCodes.Add);
+                }
+                il.Emit(OpCodes.Stloc, fieldBaseLocal);
+
+                EmitOptionStoreAt(il, fieldType, optionLocal,
+                    fieldBaseLocal, 0,
+                    resolver, resourcesType, stringEncoding);
+                return;
+            }
+
+            if (isString || isByteArray)
+            {
+                // Variable-length store: pass MemoryInstance (not
+                // mem.Data) — gap 11. cabi_realloc inside the helper
+                // can grow memory; helper re-fetches mem.Data after
+                // each realloc so writes target the post-grow array.
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, MemoriesField);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldelem_Ref);
+                pushBaseAddress(il);
+                if (fieldOffset != 0)
+                {
+                    il.Emit(OpCodes.Ldc_I4, fieldOffset);
+                    il.Emit(OpCodes.Add);
+                }
+                pushFieldValue(il);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, CabiReallocField);
+                il.Emit(OpCodes.Call, isString
+                    ? ResolveStoreStringMethod(stringEncoding)
+                    : StoreByteArrayMethod);
+                return;
+            }
+
+            // Fixed-width store (primitive / resource handle): the
+            // PrimitiveStore.StoreXxx helpers take byte[] dest, no
+            // cabi_realloc, no grow risk.
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, MemoriesField);
             il.Emit(OpCodes.Ldc_I4_0);
@@ -1653,19 +1725,7 @@ namespace Wacs.Transpiler.AOT.Component
                 il.Emit(OpCodes.Add);
             }
 
-            if (isString || isByteArray)
-            {
-                // Push value + cabiRealloc + StoreXxx (variable-length
-                // dispatch — cabi_realloc allocates a guest buffer
-                // and the helper writes (ptr, len) at retArea slot).
-                pushFieldValue(il);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, CabiReallocField);
-                il.Emit(OpCodes.Call, isString
-                    ? ResolveStoreStringMethod(stringEncoding)
-                    : StoreByteArrayMethod);
-            }
-            else if (isResource)
+            if (isResource)
             {
                 // handle = ctx.Resources.AllocateResource(typeof(IRes), value)
                 il.Emit(OpCodes.Ldarg_0);
@@ -1727,7 +1787,7 @@ namespace Wacs.Transpiler.AOT.Component
             Type? resourcesType = null)
         {
             int elemSize = SizeOfRecordOrTuple(elemType, resolver);
-            int elemAlign = MaxFieldAlign(elemType);
+            int elemAlign = MaxFieldAlign(elemType, resolver);
 
             // count = arrayLocal.Length
             var countLocal = il.DeclareLocal(typeof(int));
@@ -1931,35 +1991,24 @@ namespace Wacs.Transpiler.AOT.Component
             else
             {
                 int totalOffset = baseOffset + valueOffset;
-                // Some: write value at retArea+totalOffset
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, MemoriesField);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ldelem_Ref);
-                il.Emit(OpCodes.Ldfld, MemoryDataField);
-                il.Emit(OpCodes.Ldloc, retAreaLocal);
-                if (totalOffset != 0)
-                {
-                    il.Emit(OpCodes.Ldc_I4, totalOffset);
-                    il.Emit(OpCodes.Add);
-                }
-                if (innerIsResource)
-                {
-                    il.Emit(OpCodes.Ldarg_0);
-                    il.Emit(OpCodes.Ldfld, ResourcesField);
-                    il.Emit(OpCodes.Castclass, resourcesType!);
-                    il.Emit(OpCodes.Ldtoken, inner);
-                    il.Emit(OpCodes.Call, GetTypeFromHandleMethod);
-                    il.Emit(OpCodes.Ldloca, optionLocal);
-                    il.Emit(OpCodes.Call, valueGetter);
-                    il.Emit(OpCodes.Callvirt,
-                        ResolveAllocateResourceMethod(resourcesType!));
-                    il.Emit(OpCodes.Call,
-                        ResolveStoreMethod(typeof(int)));
-                }
-                else if (innerIsString || innerIsByteArray
+
+                if (innerIsString || innerIsByteArray
                     || innerIsPrimArray || innerIsStringArray)
                 {
+                    // Variable-length value: pass MemoryInstance —
+                    // gap 11. cabi_realloc inside the helper can
+                    // grow memory; helper re-fetches mem.Data
+                    // post-realloc.
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, MemoriesField);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Ldelem_Ref);
+                    il.Emit(OpCodes.Ldloc, retAreaLocal);
+                    if (totalOffset != 0)
+                    {
+                        il.Emit(OpCodes.Ldc_I4, totalOffset);
+                        il.Emit(OpCodes.Add);
+                    }
                     il.Emit(OpCodes.Ldloca, optionLocal);
                     il.Emit(OpCodes.Call, valueGetter);
                     il.Emit(OpCodes.Ldarg_0);
@@ -1978,9 +2027,38 @@ namespace Wacs.Transpiler.AOT.Component
                 }
                 else
                 {
-                    il.Emit(OpCodes.Ldloca, optionLocal);
-                    il.Emit(OpCodes.Call, valueGetter);
-                    il.Emit(OpCodes.Call, ResolveStoreMethod(inner));
+                    // Fixed-width value: pass byte[] dest.
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, MemoriesField);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Ldelem_Ref);
+                    il.Emit(OpCodes.Ldfld, MemoryDataField);
+                    il.Emit(OpCodes.Ldloc, retAreaLocal);
+                    if (totalOffset != 0)
+                    {
+                        il.Emit(OpCodes.Ldc_I4, totalOffset);
+                        il.Emit(OpCodes.Add);
+                    }
+                    if (innerIsResource)
+                    {
+                        il.Emit(OpCodes.Ldarg_0);
+                        il.Emit(OpCodes.Ldfld, ResourcesField);
+                        il.Emit(OpCodes.Castclass, resourcesType!);
+                        il.Emit(OpCodes.Ldtoken, inner);
+                        il.Emit(OpCodes.Call, GetTypeFromHandleMethod);
+                        il.Emit(OpCodes.Ldloca, optionLocal);
+                        il.Emit(OpCodes.Call, valueGetter);
+                        il.Emit(OpCodes.Callvirt,
+                            ResolveAllocateResourceMethod(resourcesType!));
+                        il.Emit(OpCodes.Call,
+                            ResolveStoreMethod(typeof(int)));
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Ldloca, optionLocal);
+                        il.Emit(OpCodes.Call, valueGetter);
+                        il.Emit(OpCodes.Call, ResolveStoreMethod(inner));
+                    }
                 }
             }
 
@@ -2113,39 +2191,20 @@ namespace Wacs.Transpiler.AOT.Component
                     }
                     else
                     {
-                        // Push: dest_array, dest_offset =
-                        // retArea + payloadAddrOffset
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldfld, MemoriesField);
-                        il.Emit(OpCodes.Ldc_I4_0);
-                        il.Emit(OpCodes.Ldelem_Ref);
-                        il.Emit(OpCodes.Ldfld, MemoryDataField);
-                        il.Emit(OpCodes.Ldloc, retAreaLocal);
-                        if (payloadAddrOffset != 0)
-                        {
-                            il.Emit(OpCodes.Ldc_I4, payloadAddrOffset);
-                            il.Emit(OpCodes.Add);
-                        }
-
-                        if (isResourcePayload)
-                        {
-                            il.Emit(OpCodes.Ldarg_0);
-                            il.Emit(OpCodes.Ldfld, ResourcesField);
-                            il.Emit(OpCodes.Castclass, resourcesType!);
-                            il.Emit(OpCodes.Ldtoken, c.Payload);
-                            il.Emit(OpCodes.Call, GetTypeFromHandleMethod);
-                            il.Emit(OpCodes.Ldloc, variantLocal);
-                            il.Emit(OpCodes.Castclass, c.CaseType);
-                            il.Emit(OpCodes.Callvirt,
-                                valueProp.GetGetMethod()!);
-                            il.Emit(OpCodes.Callvirt,
-                                ResolveAllocateResourceMethod(resourcesType!));
-                            il.Emit(OpCodes.Call,
-                                ResolveStoreMethod(typeof(int)));
-                        }
-                        else if (isStringPayload || isByteArrayPayload
+                        if (isStringPayload || isByteArrayPayload
                             || isPrimArrayPayload || isStringArrayPayload)
                         {
+                            // Variable-length payload: pass MemoryInstance.
+                            il.Emit(OpCodes.Ldarg_0);
+                            il.Emit(OpCodes.Ldfld, MemoriesField);
+                            il.Emit(OpCodes.Ldc_I4_0);
+                            il.Emit(OpCodes.Ldelem_Ref);
+                            il.Emit(OpCodes.Ldloc, retAreaLocal);
+                            if (payloadAddrOffset != 0)
+                            {
+                                il.Emit(OpCodes.Ldc_I4, payloadAddrOffset);
+                                il.Emit(OpCodes.Add);
+                            }
                             il.Emit(OpCodes.Ldloc, variantLocal);
                             il.Emit(OpCodes.Castclass, c.CaseType);
                             il.Emit(OpCodes.Callvirt,
@@ -2166,12 +2225,44 @@ namespace Wacs.Transpiler.AOT.Component
                         }
                         else
                         {
-                            il.Emit(OpCodes.Ldloc, variantLocal);
-                            il.Emit(OpCodes.Castclass, c.CaseType);
-                            il.Emit(OpCodes.Callvirt,
-                                valueProp.GetGetMethod()!);
-                            il.Emit(OpCodes.Call,
-                                ResolveStoreMethod(c.Payload));
+                            // Fixed-width payload: pass byte[] dest.
+                            il.Emit(OpCodes.Ldarg_0);
+                            il.Emit(OpCodes.Ldfld, MemoriesField);
+                            il.Emit(OpCodes.Ldc_I4_0);
+                            il.Emit(OpCodes.Ldelem_Ref);
+                            il.Emit(OpCodes.Ldfld, MemoryDataField);
+                            il.Emit(OpCodes.Ldloc, retAreaLocal);
+                            if (payloadAddrOffset != 0)
+                            {
+                                il.Emit(OpCodes.Ldc_I4, payloadAddrOffset);
+                                il.Emit(OpCodes.Add);
+                            }
+
+                            if (isResourcePayload)
+                            {
+                                il.Emit(OpCodes.Ldarg_0);
+                                il.Emit(OpCodes.Ldfld, ResourcesField);
+                                il.Emit(OpCodes.Castclass, resourcesType!);
+                                il.Emit(OpCodes.Ldtoken, c.Payload);
+                                il.Emit(OpCodes.Call, GetTypeFromHandleMethod);
+                                il.Emit(OpCodes.Ldloc, variantLocal);
+                                il.Emit(OpCodes.Castclass, c.CaseType);
+                                il.Emit(OpCodes.Callvirt,
+                                    valueProp.GetGetMethod()!);
+                                il.Emit(OpCodes.Callvirt,
+                                    ResolveAllocateResourceMethod(resourcesType!));
+                                il.Emit(OpCodes.Call,
+                                    ResolveStoreMethod(typeof(int)));
+                            }
+                            else
+                            {
+                                il.Emit(OpCodes.Ldloc, variantLocal);
+                                il.Emit(OpCodes.Castclass, c.CaseType);
+                                il.Emit(OpCodes.Callvirt,
+                                    valueProp.GetGetMethod()!);
+                                il.Emit(OpCodes.Call,
+                                    ResolveStoreMethod(c.Payload));
+                            }
                         }
                     }
                 }
@@ -2259,7 +2350,12 @@ namespace Wacs.Transpiler.AOT.Component
         {
             if (IsStorablePrimitive(t)) return AlignOfPrimitive(t);
             if (IsTupleOfPrimitives(t) || IsRecordOfPrimitives(t))
-                return MaxFieldAlign(t);
+                return MaxFieldAlign(t, resolver);
+            // Tuple/record-with-flat-fields (incl. Option fields):
+            // align is the max of recursive MaxAlignOf across fields.
+            if (IsTupleOfFlatFields(t, resolver)
+                || IsRecordOfFlatFields(t, resolver))
+                return MaxFieldAlign(t, resolver);
             if (t.IsGenericType)
             {
                 var def = t.GetGenericTypeDefinition();
@@ -2532,7 +2628,7 @@ namespace Wacs.Transpiler.AOT.Component
             {
                 foreach (var et in type.GetGenericArguments())
                 {
-                    int fa = AlignOfFlatField(et);
+                    int fa = AlignOfFlatField(et, resolver);
                     offsetSoFar = Align(offsetSoFar, fa)
                         + SizeOfFlatField(et, resolver);
                 }
@@ -2541,14 +2637,14 @@ namespace Wacs.Transpiler.AOT.Component
             {
                 foreach (var p in GetRecordProperties(type))
                 {
-                    int fa = AlignOfFlatField(p.PropertyType);
+                    int fa = AlignOfFlatField(p.PropertyType, resolver);
                     offsetSoFar = Align(offsetSoFar, fa)
                         + SizeOfFlatField(p.PropertyType, resolver);
                 }
             }
             // canon-ABI: pad the total to the type's alignment so
             // arrays of this type pack contiguously.
-            int maxA = MaxFieldAlign(type);
+            int maxA = MaxFieldAlign(type, resolver);
             return Align(offsetSoFar, maxA);
         }
 
@@ -2569,7 +2665,13 @@ namespace Wacs.Transpiler.AOT.Component
         {
             if (IsStorablePrimitive(t)) return SizeOfPrimitive(t);
             if (IsTupleOfPrimitives(t) || IsRecordOfPrimitives(t))
-                return SizeOfRecordOrTuple(t);
+                return SizeOfRecordOrTuple(t, resolver);
+            // Tuple/record-with-flat-fields (incl. Option-typed
+            // fields): walk fields via SizeOfRecordOrTuple, which
+            // dispatches per-field through SizeOfFlatField.
+            if (IsTupleOfFlatFields(t, resolver)
+                || IsRecordOfFlatFields(t, resolver))
+                return SizeOfRecordOrTuple(t, resolver);
             if (resolver != null
                 && resolver.IsResourceInterface(t))
                 return 4;
@@ -2659,7 +2761,13 @@ namespace Wacs.Transpiler.AOT.Component
                 return true;
             if (allowVariableLength
                 && (IsTupleOfPrimitives(t)
-                    || IsRecordOfPrimitives(t)))
+                    || IsRecordOfPrimitives(t)
+                    // Records / tuples whose fields include Option<X>
+                    // or own<R> resource handles. Closes gap 10 for
+                    // Result<DescriptorStat, ErrorCode> — the OK arm
+                    // is a record with three option<datetime> fields.
+                    || IsTupleOfFlatFields(t, resolver)
+                    || IsRecordOfFlatFields(t, resolver)))
                 return true;
             if (allowVariableLength
                 && t.IsArray && t.GetArrayRank() == 1)
@@ -2771,7 +2879,9 @@ namespace Wacs.Transpiler.AOT.Component
                 && armType.GetArrayRank() == 1
                 && armType.GetElementType() == typeof(string);
             bool isAggregate = IsTupleOfPrimitives(armType)
-                || IsRecordOfPrimitives(armType);
+                || IsRecordOfPrimitives(armType)
+                || IsTupleOfFlatFields(armType, resolver)
+                || IsRecordOfFlatFields(armType, resolver);
             bool isNestedOption = armType.IsGenericType
                 && armType.GetGenericTypeDefinition() == typeof(Option<>);
             bool isNestedResult = armType.IsGenericType
@@ -2803,7 +2913,9 @@ namespace Wacs.Transpiler.AOT.Component
             }
 
             // Aggregate arms write field-by-field with their own
-            // memory pushes — bypass the common pre-push.
+            // memory pushes — bypass the common pre-push. Resolver
+            // and resourcesType are forwarded so flat-fields-with-
+            // resources / option fields dispatch correctly.
             if (isAggregate)
             {
                 var armLocal = il.DeclareLocal(armType);
@@ -2811,11 +2923,43 @@ namespace Wacs.Transpiler.AOT.Component
                 il.Emit(OpCodes.Call, armGetter);
                 il.Emit(OpCodes.Stloc, armLocal);
                 EmitInlineRecordOrTupleStore(il, armType, retAreaLocal,
-                    valueOffset, armLocal, stringEncoding);
+                    valueOffset, armLocal, stringEncoding,
+                    resolver, resourcesType);
                 return;
             }
 
-            // Push: dest_array, dest_offset
+            if (isString || isByteArray
+                || isPrimArray || isStringArray)
+            {
+                // Variable-length arm: pass MemoryInstance — gap 11.
+                // The helper re-fetches mem.Data after cabi_realloc
+                // (which may grow memory).
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, MemoriesField);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldelem_Ref);
+                il.Emit(OpCodes.Ldloc, retAreaLocal);
+                if (valueOffset != 0)
+                {
+                    il.Emit(OpCodes.Ldc_I4, valueOffset);
+                    il.Emit(OpCodes.Add);
+                }
+                il.Emit(OpCodes.Ldloca, returnLocal);
+                il.Emit(OpCodes.Call, armGetter);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, CabiReallocField);
+                MethodInfo storeMethod;
+                if (isString) storeMethod = ResolveStoreStringMethod(stringEncoding);
+                else if (isByteArray) storeMethod = StoreByteArrayMethod;
+                else if (isStringArray) storeMethod = StoreStringListMethod;
+                else storeMethod = ResolveStorePrimitiveArrayMethod(
+                    armType.GetElementType()!);
+                il.Emit(OpCodes.Call, storeMethod);
+                return;
+            }
+
+            // Fixed-width arm (resource handle / primitive): pass
+            // byte[] dest. No cabi_realloc, no grow risk.
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, MemoriesField);
             il.Emit(OpCodes.Ldc_I4_0);
@@ -2827,7 +2971,6 @@ namespace Wacs.Transpiler.AOT.Component
                 il.Emit(OpCodes.Ldc_I4, valueOffset);
                 il.Emit(OpCodes.Add);
             }
-
             if (isResource)
             {
                 // Allocate handle for the arm's instance, store i32.
@@ -2841,25 +2984,6 @@ namespace Wacs.Transpiler.AOT.Component
                 il.Emit(OpCodes.Callvirt,
                     ResolveAllocateResourceMethod(resourcesType!));
                 il.Emit(OpCodes.Call, ResolveStoreMethod(typeof(int)));
-            }
-            else if (isString || isByteArray
-                || isPrimArray || isStringArray)
-            {
-                // Stack: [memory_data, retArea+valueOffset]
-                // StoreXxx takes (byte[] dest, int retAreaOffset,
-                //   T value, Func realloc) — push value +
-                // cabi_realloc + call.
-                il.Emit(OpCodes.Ldloca, returnLocal);
-                il.Emit(OpCodes.Call, armGetter);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, CabiReallocField);
-                MethodInfo storeMethod;
-                if (isString) storeMethod = ResolveStoreStringMethod(stringEncoding);
-                else if (isByteArray) storeMethod = StoreByteArrayMethod;
-                else if (isStringArray) storeMethod = StoreStringListMethod;
-                else storeMethod = ResolveStorePrimitiveArrayMethod(
-                    armType.GetElementType()!);
-                il.Emit(OpCodes.Call, storeMethod);
             }
             else
             {
@@ -2923,6 +3047,16 @@ namespace Wacs.Transpiler.AOT.Component
             if (resolver != null && resolver.IsResourceInterface(t)
                 && resolver.PreferredResourcesType != null)
                 return true;
+            // Option<X> as a record/tuple field — wire form is u8
+            // disc + value at Align(1, MaxAlignOf(X)). Inner X must
+            // itself be a recognized aggregate. Closes gap 10:
+            // DescriptorStat's three option<datetime> fields ride
+            // this branch, with EmitOptionStoreAt handling the
+            // per-field write at the field's base offset.
+            if (t.IsGenericType
+                && t.GetGenericTypeDefinition() == typeof(Option<>)
+                && IsAggregateReturnSupported(t, resolver))
+                return true;
             return false;
         }
 
@@ -2938,14 +3072,31 @@ namespace Wacs.Transpiler.AOT.Component
             return 4;
         }
 
+        // Resolver-aware overload. Option<X> aligns to MaxAlignOf(X)
+        // — Option<datetime> aligns to 8 because Datetime's u64 field
+        // does. Other shapes match the non-resolver overload.
+        private static int AlignOfFlatField(Type t,
+            HostPackageResolver? resolver)
+        {
+            if (IsStorablePrimitive(t)) return AlignOfPrimitive(t);
+            if (t.IsGenericType
+                && t.GetGenericTypeDefinition() == typeof(Option<>))
+                return MaxAlignOf(t, resolver);
+            return 4;
+        }
+
         // Size for a flat field. string/byte[] = 8 (ptr + len);
-        // resource interface = 4 (i32 handle).
+        // resource interface = 4 (i32 handle); Option<X> dispatches
+        // to the recursive SizeOf for the full disc + value layout.
         private static int SizeOfFlatField(Type t,
             HostPackageResolver? resolver = null)
         {
             if (IsStorablePrimitive(t)) return SizeOfPrimitive(t);
             if (resolver != null && resolver.IsResourceInterface(t))
                 return 4;
+            if (t.IsGenericType
+                && t.GetGenericTypeDefinition() == typeof(Option<>))
+                return SizeOf(t, resolver);
             return 8;  // string / byte[] (ptr + len pair)
         }
 

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/DirectLinkedImportEmit.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/DirectLinkedImportEmit.cs
@@ -491,10 +491,11 @@ namespace Wacs.Transpiler.AOT.Component
                     //
                     //   StoreXxx(memory_instance, retArea, value,
                     //            ctx.CabiRealloc)
-                    // Pass MemoryInstance (not byte[].Data) — gap 11:
-                    // cabi_realloc may call memory.grow which
-                    // reassigns Data to a new array, and the helper
-                    // re-fetches mem.Data after each realloc.
+                    // Pass MemoryInstance (not byte[].Data) so the
+                    // helper re-fetches mem.Data after each
+                    // cabi_realloc — that call may grow memory and
+                    // reassign Data, leaving any captured reference
+                    // stale.
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, MemoriesField);
                     il.Emit(OpCodes.Ldc_I4_0);
@@ -1371,8 +1372,9 @@ namespace Wacs.Transpiler.AOT.Component
                 // Resolver-aware: a record field can be a primitive,
                 // string, byte[], own<R> resource handle, OR an
                 // Option<X> with X a recognized aggregate. The last
-                // case covers DescriptorStat's option<datetime>
-                // fields (gap 10).
+                // case is what carries shapes like
+                // wasi:filesystem/types.descriptor-stat (record with
+                // option<datetime> fields).
                 foreach (var p in GetRecordProperties(t))
                     if (!IsFlatField(p.PropertyType, resolver)) return false;
                 return true;
@@ -1687,9 +1689,9 @@ namespace Wacs.Transpiler.AOT.Component
             if (isString || isByteArray)
             {
                 // Variable-length store: pass MemoryInstance (not
-                // mem.Data) — gap 11. cabi_realloc inside the helper
-                // can grow memory; helper re-fetches mem.Data after
-                // each realloc so writes target the post-grow array.
+                // mem.Data) so the helper re-fetches mem.Data after
+                // its internal cabi_realloc — that call may grow
+                // memory and stale-out any captured byte[] reference.
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldfld, MemoriesField);
                 il.Emit(OpCodes.Ldc_I4_0);
@@ -1995,10 +1997,9 @@ namespace Wacs.Transpiler.AOT.Component
                 if (innerIsString || innerIsByteArray
                     || innerIsPrimArray || innerIsStringArray)
                 {
-                    // Variable-length value: pass MemoryInstance —
-                    // gap 11. cabi_realloc inside the helper can
-                    // grow memory; helper re-fetches mem.Data
-                    // post-realloc.
+                    // Variable-length value: pass MemoryInstance so
+                    // the helper re-fetches mem.Data post-cabi_realloc
+                    // (the alloc may have grown linear memory).
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, MemoriesField);
                     il.Emit(OpCodes.Ldc_I4_0);
@@ -2763,9 +2764,9 @@ namespace Wacs.Transpiler.AOT.Component
                 && (IsTupleOfPrimitives(t)
                     || IsRecordOfPrimitives(t)
                     // Records / tuples whose fields include Option<X>
-                    // or own<R> resource handles. Closes gap 10 for
-                    // Result<DescriptorStat, ErrorCode> — the OK arm
-                    // is a record with three option<datetime> fields.
+                    // or own<R> resource handles — covers shapes
+                    // like Result<descriptor-stat, error-code>'s OK
+                    // arm (record with option<datetime> fields).
                     || IsTupleOfFlatFields(t, resolver)
                     || IsRecordOfFlatFields(t, resolver)))
                 return true;
@@ -2931,9 +2932,9 @@ namespace Wacs.Transpiler.AOT.Component
             if (isString || isByteArray
                 || isPrimArray || isStringArray)
             {
-                // Variable-length arm: pass MemoryInstance — gap 11.
-                // The helper re-fetches mem.Data after cabi_realloc
-                // (which may grow memory).
+                // Variable-length arm: pass MemoryInstance so the
+                // helper re-fetches mem.Data after its internal
+                // cabi_realloc (which may grow memory).
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldfld, MemoriesField);
                 il.Emit(OpCodes.Ldc_I4_0);
@@ -3049,10 +3050,10 @@ namespace Wacs.Transpiler.AOT.Component
                 return true;
             // Option<X> as a record/tuple field — wire form is u8
             // disc + value at Align(1, MaxAlignOf(X)). Inner X must
-            // itself be a recognized aggregate. Closes gap 10:
-            // DescriptorStat's three option<datetime> fields ride
-            // this branch, with EmitOptionStoreAt handling the
-            // per-field write at the field's base offset.
+            // itself be a recognized aggregate. Lets records like
+            // wasi:filesystem/types.descriptor-stat (with three
+            // option<datetime> fields) flow through
+            // EmitOptionStoreAt at the field's base offset.
             if (t.IsGenericType
                 && t.GetGenericTypeDefinition() == typeof(Option<>)
                 && IsAggregateReturnSupported(t, resolver))

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Emitters/BulkEmitter.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Emitters/BulkEmitter.cs
@@ -206,31 +206,33 @@ namespace Wacs.Transpiler.AOT.Emitters
         public static void MemoryCopy(ThinContext ctx, int dstMemIdx, int srcMemIdx,
             int dst, int src, int len)
         {
-            var dstMem = ctx.Memories[dstMemIdx].Data;
-            var srcMem = ctx.Memories[srcMemIdx].Data;
+            var dstMem = ctx.Memories[dstMemIdx];
+            var srcMem = ctx.Memories[srcMemIdx];
             // WASM spec: bounds check applies even when len == 0
-            if ((long)(uint)src + (long)(uint)len > srcMem.Length ||
-                (long)(uint)dst + (long)(uint)len > dstMem.Length)
+            if ((long)(uint)src + (long)(uint)len > (long)srcMem.ByteLength ||
+                (long)(uint)dst + (long)(uint)len > (long)dstMem.ByteLength)
                 throw new TrapException("out of bounds memory access");
             if (len == 0) return;
-            Buffer.BlockCopy(srcMem, src, dstMem, dst, len);
+            // Span<byte>.CopyTo dispatches to Buffer.Memmove and
+            // handles overlap correctly across both modes.
+            srcMem.AsSpan(src, len).CopyTo(dstMem.AsSpan(dst, len));
         }
 
         public static void MemoryFill(ThinContext ctx, int memIdx,
             int dst, int val, int len)
         {
-            var mem = ctx.Memories[memIdx].Data;
+            var mem = ctx.Memories[memIdx];
             // WASM spec: bounds check applies even when len == 0
-            if ((long)(uint)dst + (long)(uint)len > mem.Length)
+            if ((long)(uint)dst + (long)(uint)len > (long)mem.ByteLength)
                 throw new TrapException("out of bounds memory access");
             if (len == 0) return;
-            Array.Fill(mem, (byte)val, dst, len);
+            mem.AsSpan(dst, len).Fill((byte)val);
         }
 
         public static void MemoryInit(ThinContext ctx, int memIdx, int dataIdx,
             int dst, int src, int len)
         {
-            var mem = ctx.Memories[memIdx].Data;
+            var mem = ctx.Memories[memIdx];
             byte[] segData;
 
             if (ctx.Store != null && ctx.Module != null)
@@ -248,10 +250,10 @@ namespace Wacs.Transpiler.AOT.Emitters
 
             // WASM spec: bounds check applies even when len == 0
             if ((long)(uint)src + (long)(uint)len > segData.Length ||
-                (long)(uint)dst + (long)(uint)len > mem.Length)
+                (long)(uint)dst + (long)(uint)len > (long)mem.ByteLength)
                 throw new TrapException("out of bounds memory access");
             if (len == 0) return;
-            Buffer.BlockCopy(segData, src, mem, dst, len);
+            new ReadOnlySpan<byte>(segData, src, len).CopyTo(mem.AsSpan(dst, len));
         }
 
         public static void DataDrop(ThinContext ctx, int dataIdx)

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Emitters/MemoryEmitter.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Emitters/MemoryEmitter.cs
@@ -40,6 +40,11 @@ namespace Wacs.Transpiler.AOT.Emitters
     {
         private static readonly FieldInfo MemoriesField =
             typeof(ThinContext).GetField(nameof(ThinContext.Memories))!;
+        internal static readonly MethodInfo MemorySizeGetter =
+            typeof(Wacs.Core.Runtime.Types.MemoryInstance).GetProperty(
+                nameof(Wacs.Core.Runtime.Types.MemoryInstance.Size))!
+                .GetGetMethod()!;
+
         internal static readonly FieldInfo MemoryDataField =
             typeof(Wacs.Core.Runtime.Types.MemoryInstance).GetField(
                 nameof(Wacs.Core.Runtime.Types.MemoryInstance.Data))!;
@@ -149,7 +154,7 @@ namespace Wacs.Transpiler.AOT.Emitters
         private static void EmitLoad(ILGenerator il, InstMemoryLoad inst, string helperName)
         {
             // Stack: [address (i32)]
-            // We need: MemoryHelpers.LoadXxx(byte[] mem, int address, long offset)
+            // We need: MemoryHelpers.LoadXxx(MemoryInstance mem, int address, long offset)
 
             var addrLocal = il.DeclareLocal(typeof(int));
             il.Emit(OpCodes.Stloc, addrLocal);      // save address
@@ -158,7 +163,6 @@ namespace Wacs.Transpiler.AOT.Emitters
             il.Emit(OpCodes.Ldfld, MemoriesField);   // MemoryInstance[]
             il.Emit(OpCodes.Ldc_I4, inst.MemIndex);  // memIdx
             il.Emit(OpCodes.Ldelem_Ref);              // MemoryInstance
-            il.Emit(OpCodes.Ldfld, MemoryDataField);  // byte[] Data
 
             il.Emit(OpCodes.Ldloc, addrLocal);        // address
             il.Emit(OpCodes.Ldc_I8, inst.MemOffset);  // offset
@@ -170,7 +174,7 @@ namespace Wacs.Transpiler.AOT.Emitters
 
         /// <summary>
         /// Emit a memory store: stack has [address, value], result is [].
-        /// call MemoryHelpers.StoreXxx(byte[] mem, int address, long offset, value)
+        /// call MemoryHelpers.StoreXxx(MemoryInstance mem, int address, long offset, value)
         /// </summary>
         private static void EmitStore(ILGenerator il, InstMemoryStore inst, string helperName)
         {
@@ -190,7 +194,6 @@ namespace Wacs.Transpiler.AOT.Emitters
             il.Emit(OpCodes.Ldfld, MemoriesField);     // MemoryInstance[]
             il.Emit(OpCodes.Ldc_I4, inst.MemIndex);    // memIdx
             il.Emit(OpCodes.Ldelem_Ref);                // MemoryInstance
-            il.Emit(OpCodes.Ldfld, MemoryDataField);    // byte[] Data
 
             il.Emit(OpCodes.Ldloc, addrLocal);          // address
             il.Emit(OpCodes.Ldc_I8, inst.MemOffset);    // offset
@@ -201,16 +204,14 @@ namespace Wacs.Transpiler.AOT.Emitters
 
         private static void EmitMemorySize(ILGenerator il, InstMemorySize inst)
         {
-            // Push ctx.Memories[memIdx].Data.Length / PageSize
+            // Push ctx.Memories[memIdx].Size — mode-aware via the
+            // Size property (which dispatches by StorageMode).
             il.Emit(OpCodes.Ldarg_0);                  // ThinContext
             il.Emit(OpCodes.Ldfld, MemoriesField);     // MemoryInstance[]
             il.Emit(OpCodes.Ldc_I4, inst.MemIndex);    // memIdx
             il.Emit(OpCodes.Ldelem_Ref);                // MemoryInstance
-            il.Emit(OpCodes.Ldfld, MemoryDataField);    // byte[] Data
-            il.Emit(OpCodes.Ldlen);                     // length (native int)
-            il.Emit(OpCodes.Conv_I4);
-            il.Emit(OpCodes.Ldc_I4, 65536);             // PageSize
-            il.Emit(OpCodes.Div);
+            il.Emit(OpCodes.Call, MemorySizeGetter);    // long pages
+            il.Emit(OpCodes.Conv_I4);                   // i32 pages
         }
 
         private static void EmitMemoryGrow(ILGenerator il, InstMemoryGrow inst)
@@ -238,181 +239,177 @@ namespace Wacs.Transpiler.AOT.Emitters
     public static class MemoryHelpers
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void BoundsCheck(byte[] mem, long ea, int width)
+        private static void BoundsCheck(MemoryInstance mem, long ea, int width)
         {
-            if (ea < 0 || ea + width > mem.Length)
+            if (ea < 0 || ea + width > (long)mem.ByteLength)
                 throw new TrapException("out of bounds memory access");
         }
 
         // === i32 loads ===
-        public static int LoadI32(byte[] mem, int addr, long offset)
+        public static int LoadI32(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            return Unsafe.ReadUnaligned<int>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<int>(ref mem.RefAs<byte>((int)ea));
         }
 
-        public static int LoadI32_8S(byte[] mem, int addr, long offset)
+        public static int LoadI32_8S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            return (sbyte)mem[(int)ea];
+            return (sbyte)mem.AsSpan((int)ea, 1)[0];
         }
 
-        public static int LoadI32_8U(byte[] mem, int addr, long offset)
+        public static int LoadI32_8U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            return mem[(int)ea];
+            return mem.AsSpan((int)ea, 1)[0];
         }
 
-        public static int LoadI32_16S(byte[] mem, int addr, long offset)
+        public static int LoadI32_16S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            return Unsafe.ReadUnaligned<short>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<short>(ref mem.RefAs<byte>((int)ea));
         }
 
-        public static int LoadI32_16U(byte[] mem, int addr, long offset)
+        public static int LoadI32_16U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            return Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<ushort>(ref mem.RefAs<byte>((int)ea));
         }
 
         // === i64 loads ===
-        public static long LoadI64(byte[] mem, int addr, long offset)
+        public static long LoadI64(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
-            return Unsafe.ReadUnaligned<long>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<long>(ref mem.RefAs<byte>((int)ea));
         }
 
-        public static long LoadI64_8S(byte[] mem, int addr, long offset)
+        public static long LoadI64_8S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            return (sbyte)mem[(int)ea];
+            return (sbyte)mem.AsSpan((int)ea, 1)[0];
         }
 
-        public static long LoadI64_8U(byte[] mem, int addr, long offset)
+        public static long LoadI64_8U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            return mem[(int)ea];
+            return mem.AsSpan((int)ea, 1)[0];
         }
 
-        public static long LoadI64_16S(byte[] mem, int addr, long offset)
+        public static long LoadI64_16S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            return Unsafe.ReadUnaligned<short>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<short>(ref mem.RefAs<byte>((int)ea));
         }
 
-        public static long LoadI64_16U(byte[] mem, int addr, long offset)
+        public static long LoadI64_16U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            return Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<ushort>(ref mem.RefAs<byte>((int)ea));
         }
 
-        public static long LoadI64_32S(byte[] mem, int addr, long offset)
+        public static long LoadI64_32S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            int raw = Unsafe.ReadUnaligned<int>(ref mem[(int)ea]);
-            System.IO.File.AppendAllText("/tmp/mem_trace.log",$"  L32S mem={mem.GetHashCode()} ea={ea} bytes=[{mem[(int)ea]:X2},{mem[(int)ea+1]:X2},{mem[(int)ea+2]:X2},{mem[(int)ea+3]:X2}] raw=0x{raw:X8}={raw}\n");
-            return raw;
+            return Unsafe.ReadUnaligned<int>(ref mem.RefAs<byte>((int)ea));
         }
 
-        public static long LoadI64_32U(byte[] mem, int addr, long offset)
+        public static long LoadI64_32U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            return (uint)Unsafe.ReadUnaligned<int>(ref mem[(int)ea]);
+            return (uint)Unsafe.ReadUnaligned<int>(ref mem.RefAs<byte>((int)ea));
         }
 
         // === float loads ===
-        public static float LoadF32(byte[] mem, int addr, long offset)
+        public static float LoadF32(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            return Unsafe.ReadUnaligned<float>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<float>(ref mem.RefAs<byte>((int)ea));
         }
 
-        public static double LoadF64(byte[] mem, int addr, long offset)
+        public static double LoadF64(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
-            return Unsafe.ReadUnaligned<double>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<double>(ref mem.RefAs<byte>((int)ea));
         }
 
         // === i32 stores ===
-        public static void StoreI32(byte[] mem, int addr, long offset, int value)
+        public static void StoreI32(MemoryInstance mem, int addr, long offset, int value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), value);
         }
 
-        public static void StoreI32_8(byte[] mem, int addr, long offset, int value)
+        public static void StoreI32_8(MemoryInstance mem, int addr, long offset, int value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            mem[(int)ea] = (byte)value;
-            if (ea < 4)
-                System.IO.File.AppendAllText("/tmp/mem_trace.log",$"  S8 mem={mem.GetHashCode()} ea={ea} val=0x{value:X8} byte=0x{(byte)value:X2} mem[0..3]=[{mem[0]:X2},{mem[1]:X2},{mem[2]:X2},{mem[3]:X2}]\n");
+            mem.AsSpan((int)ea, 1)[0] = (byte)value;
         }
 
-        public static void StoreI32_16(byte[] mem, int addr, long offset, int value)
+        public static void StoreI32_16(MemoryInstance mem, int addr, long offset, int value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], (short)value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), (short)value);
         }
 
         // === i64 stores ===
-        public static void StoreI64(byte[] mem, int addr, long offset, long value)
+        public static void StoreI64(MemoryInstance mem, int addr, long offset, long value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), value);
         }
 
-        public static void StoreI64_8(byte[] mem, int addr, long offset, long value)
+        public static void StoreI64_8(MemoryInstance mem, int addr, long offset, long value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            mem[(int)ea] = (byte)value;
+            mem.AsSpan((int)ea, 1)[0] = (byte)value;
         }
 
-        public static void StoreI64_16(byte[] mem, int addr, long offset, long value)
+        public static void StoreI64_16(MemoryInstance mem, int addr, long offset, long value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], (short)value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), (short)value);
         }
 
-        public static void StoreI64_32(byte[] mem, int addr, long offset, long value)
+        public static void StoreI64_32(MemoryInstance mem, int addr, long offset, long value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], (int)value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), (int)value);
         }
 
         // === float stores ===
-        public static void StoreF32(byte[] mem, int addr, long offset, float value)
+        public static void StoreF32(MemoryInstance mem, int addr, long offset, float value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), value);
         }
 
-        public static void StoreF64(byte[] mem, int addr, long offset, double value)
+        public static void StoreF64(MemoryInstance mem, int addr, long offset, double value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), value);
         }
 
         // ================================================================
@@ -420,207 +417,207 @@ namespace Wacs.Transpiler.AOT.Emitters
         // ================================================================
 
         // v128.load: load 16 bytes
-        public static V128 LoadV128(byte[] mem, int addr, long offset)
+        public static V128 LoadV128(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 16);
-            return Unsafe.ReadUnaligned<V128>(ref mem[(int)ea]);
+            return Unsafe.ReadUnaligned<V128>(ref mem.RefAs<byte>((int)ea));
         }
 
         // v128.store: store 16 bytes
-        public static void StoreV128(byte[] mem, int addr, long offset, V128 value)
+        public static void StoreV128(MemoryInstance mem, int addr, long offset, V128 value)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 16);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], value);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), value);
         }
 
         // v128.load8x8_s: load 8 bytes, sign-extend each to i16
-        public static V128 LoadV128_8x8S(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_8x8S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
             return new V128(
-                (short)(sbyte)mem[(int)ea], (short)(sbyte)mem[(int)ea+1],
-                (short)(sbyte)mem[(int)ea+2], (short)(sbyte)mem[(int)ea+3],
-                (short)(sbyte)mem[(int)ea+4], (short)(sbyte)mem[(int)ea+5],
-                (short)(sbyte)mem[(int)ea+6], (short)(sbyte)mem[(int)ea+7]);
+                (short)(sbyte)mem.AsSpan((int)ea, 1)[0], (short)(sbyte)mem.AsSpan((int)ea+1, 1)[0],
+                (short)(sbyte)mem.AsSpan((int)ea+2, 1)[0], (short)(sbyte)mem.AsSpan((int)ea+3, 1)[0],
+                (short)(sbyte)mem.AsSpan((int)ea+4, 1)[0], (short)(sbyte)mem.AsSpan((int)ea+5, 1)[0],
+                (short)(sbyte)mem.AsSpan((int)ea+6, 1)[0], (short)(sbyte)mem.AsSpan((int)ea+7, 1)[0]);
         }
 
         // v128.load8x8_u: load 8 bytes, zero-extend each to i16
-        public static V128 LoadV128_8x8U(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_8x8U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
             return new V128(
-                (short)mem[(int)ea], (short)mem[(int)ea+1],
-                (short)mem[(int)ea+2], (short)mem[(int)ea+3],
-                (short)mem[(int)ea+4], (short)mem[(int)ea+5],
-                (short)mem[(int)ea+6], (short)mem[(int)ea+7]);
+                (short)mem.AsSpan((int)ea, 1)[0], (short)mem.AsSpan((int)ea+1, 1)[0],
+                (short)mem.AsSpan((int)ea+2, 1)[0], (short)mem.AsSpan((int)ea+3, 1)[0],
+                (short)mem.AsSpan((int)ea+4, 1)[0], (short)mem.AsSpan((int)ea+5, 1)[0],
+                (short)mem.AsSpan((int)ea+6, 1)[0], (short)mem.AsSpan((int)ea+7, 1)[0]);
         }
 
         // v128.load16x4_s: load 8 bytes as 4 i16, sign-extend to i32
-        public static V128 LoadV128_16x4S(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_16x4S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
             return new V128(
-                (int)Unsafe.ReadUnaligned<short>(ref mem[(int)ea]),
-                (int)Unsafe.ReadUnaligned<short>(ref mem[(int)ea+2]),
-                (int)Unsafe.ReadUnaligned<short>(ref mem[(int)ea+4]),
-                (int)Unsafe.ReadUnaligned<short>(ref mem[(int)ea+6]));
+                (int)Unsafe.ReadUnaligned<short>(ref mem.RefAs<byte>((int)ea)),
+                (int)Unsafe.ReadUnaligned<short>(ref mem.AsSpan((int)ea+2, 1)[0]),
+                (int)Unsafe.ReadUnaligned<short>(ref mem.AsSpan((int)ea+4, 1)[0]),
+                (int)Unsafe.ReadUnaligned<short>(ref mem.AsSpan((int)ea+6, 1)[0]));
         }
 
         // v128.load16x4_u
-        public static V128 LoadV128_16x4U(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_16x4U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
             return new V128(
-                (int)Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea]),
-                (int)Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea+2]),
-                (int)Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea+4]),
-                (int)Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea+6]));
+                (int)Unsafe.ReadUnaligned<ushort>(ref mem.RefAs<byte>((int)ea)),
+                (int)Unsafe.ReadUnaligned<ushort>(ref mem.AsSpan((int)ea+2, 1)[0]),
+                (int)Unsafe.ReadUnaligned<ushort>(ref mem.AsSpan((int)ea+4, 1)[0]),
+                (int)Unsafe.ReadUnaligned<ushort>(ref mem.AsSpan((int)ea+6, 1)[0]));
         }
 
         // v128.load32x2_s: load 8 bytes as 2 i32, sign-extend to i64
-        public static V128 LoadV128_32x2S(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_32x2S(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
             return new V128(
-                (long)Unsafe.ReadUnaligned<int>(ref mem[(int)ea]),
-                (long)Unsafe.ReadUnaligned<int>(ref mem[(int)ea+4]));
+                (long)Unsafe.ReadUnaligned<int>(ref mem.RefAs<byte>((int)ea)),
+                (long)Unsafe.ReadUnaligned<int>(ref mem.AsSpan((int)ea+4, 1)[0]));
         }
 
         // v128.load32x2_u
-        public static V128 LoadV128_32x2U(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_32x2U(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
             return new V128(
-                (long)(uint)Unsafe.ReadUnaligned<int>(ref mem[(int)ea]),
-                (long)(uint)Unsafe.ReadUnaligned<int>(ref mem[(int)ea+4]));
+                (long)(uint)Unsafe.ReadUnaligned<int>(ref mem.RefAs<byte>((int)ea)),
+                (long)(uint)Unsafe.ReadUnaligned<int>(ref mem.AsSpan((int)ea+4, 1)[0]));
         }
 
         // v128.load8_splat
-        public static V128 LoadV128_8Splat(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_8Splat(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            byte v = mem[(int)ea];
+            byte v = mem.AsSpan((int)ea, 1)[0];
             return new V128(v,v,v,v,v,v,v,v,v,v,v,v,v,v,v,v);
         }
 
         // v128.load16_splat
-        public static V128 LoadV128_16Splat(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_16Splat(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            ushort v = Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea]);
+            ushort v = Unsafe.ReadUnaligned<ushort>(ref mem.RefAs<byte>((int)ea));
             return new V128(v,v,v,v,v,v,v,v);
         }
 
         // v128.load32_splat
-        public static V128 LoadV128_32Splat(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_32Splat(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            uint v = Unsafe.ReadUnaligned<uint>(ref mem[(int)ea]);
+            uint v = Unsafe.ReadUnaligned<uint>(ref mem.RefAs<byte>((int)ea));
             return new V128(v,v,v,v);
         }
 
         // v128.load64_splat
-        public static V128 LoadV128_64Splat(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_64Splat(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
-            ulong v = Unsafe.ReadUnaligned<ulong>(ref mem[(int)ea]);
+            ulong v = Unsafe.ReadUnaligned<ulong>(ref mem.RefAs<byte>((int)ea));
             return new V128(v,v);
         }
 
         // v128.load32_zero: load 4 bytes into lane 0, rest zero
-        public static V128 LoadV128_32Zero(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_32Zero(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            uint v = Unsafe.ReadUnaligned<uint>(ref mem[(int)ea]);
+            uint v = Unsafe.ReadUnaligned<uint>(ref mem.RefAs<byte>((int)ea));
             return new V128(v, 0u, 0u, 0u);
         }
 
         // v128.load64_zero: load 8 bytes into lane 0, rest zero
-        public static V128 LoadV128_64Zero(byte[] mem, int addr, long offset)
+        public static V128 LoadV128_64Zero(MemoryInstance mem, int addr, long offset)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
-            ulong v = Unsafe.ReadUnaligned<ulong>(ref mem[(int)ea]);
+            ulong v = Unsafe.ReadUnaligned<ulong>(ref mem.RefAs<byte>((int)ea));
             return new V128(v, 0UL);
         }
 
         // v128.loadN_lane: load N bits from memory into a lane of existing v128
-        public static V128 LoadV128_8Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static V128 LoadV128_8Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
             MV128 result = vec;
-            result[(byte)lane] = mem[(int)ea];
+            result[(byte)lane] = mem.AsSpan((int)ea, 1)[0];
             return result;
         }
 
-        public static V128 LoadV128_16Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static V128 LoadV128_16Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
             MV128 result = vec;
-            result[(ushort)lane] = Unsafe.ReadUnaligned<ushort>(ref mem[(int)ea]);
+            result[(ushort)lane] = Unsafe.ReadUnaligned<ushort>(ref mem.RefAs<byte>((int)ea));
             return result;
         }
 
-        public static V128 LoadV128_32Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static V128 LoadV128_32Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
             MV128 result = vec;
-            result[(uint)lane] = Unsafe.ReadUnaligned<uint>(ref mem[(int)ea]);
+            result[(uint)lane] = Unsafe.ReadUnaligned<uint>(ref mem.RefAs<byte>((int)ea));
             return result;
         }
 
-        public static V128 LoadV128_64Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static V128 LoadV128_64Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
             MV128 result = vec;
-            result[(ulong)lane] = Unsafe.ReadUnaligned<ulong>(ref mem[(int)ea]);
+            result[(ulong)lane] = Unsafe.ReadUnaligned<ulong>(ref mem.RefAs<byte>((int)ea));
             return result;
         }
 
         // v128.storeN_lane: store a lane to memory
-        public static void StoreV128_8Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static void StoreV128_8Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 1);
-            mem[(int)ea] = vec[(byte)lane];
+            mem.AsSpan((int)ea, 1)[0] = vec[(byte)lane];
         }
 
-        public static void StoreV128_16Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static void StoreV128_16Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 2);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], vec[(ushort)lane]);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), vec[(ushort)lane]);
         }
 
-        public static void StoreV128_32Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static void StoreV128_32Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 4);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], vec[(uint)lane]);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), vec[(uint)lane]);
         }
 
-        public static void StoreV128_64Lane(byte[] mem, int addr, long offset, V128 vec, byte lane)
+        public static void StoreV128_64Lane(MemoryInstance mem, int addr, long offset, V128 vec, byte lane)
         {
             long ea = (uint)addr + offset;
             BoundsCheck(mem, ea, 8);
-            Unsafe.WriteUnaligned(ref mem[(int)ea], vec[(ulong)lane]);
+            Unsafe.WriteUnaligned(ref mem.RefAs<byte>((int)ea), vec[(ulong)lane]);
         }
 
         // === memory.grow ===

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Emitters/SimdEmitter.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Emitters/SimdEmitter.cs
@@ -701,7 +701,6 @@ namespace Wacs.Transpiler.AOT.Emitters
             il.Emit(OpCodes.Ldfld, MemoriesField);
             il.Emit(OpCodes.Ldc_I4, memIndex);
             il.Emit(OpCodes.Ldelem_Ref);              // MemoryInstance
-            il.Emit(OpCodes.Ldfld, MemoryDataField);  // byte[] Data
             il.Emit(OpCodes.Ldloc, addrLocal);
             il.Emit(OpCodes.Ldc_I8, memOffset);
             il.Emit(OpCodes.Call, typeof(MemoryHelpers).GetMethod(helperName,
@@ -734,7 +733,6 @@ namespace Wacs.Transpiler.AOT.Emitters
             il.Emit(OpCodes.Ldfld, MemoriesField);
             il.Emit(OpCodes.Ldc_I4, laneInst.MemIndex);
             il.Emit(OpCodes.Ldelem_Ref);              // MemoryInstance
-            il.Emit(OpCodes.Ldfld, MemoryDataField);  // byte[] Data
             il.Emit(OpCodes.Ldloc, addrLocal);
             il.Emit(OpCodes.Ldc_I8, laneInst.MemOffset);
             il.Emit(OpCodes.Ldloc, vecLocal);
@@ -760,7 +758,6 @@ namespace Wacs.Transpiler.AOT.Emitters
             il.Emit(OpCodes.Ldfld, MemoriesField);
             il.Emit(OpCodes.Ldc_I4, storeInst.MemIndex);
             il.Emit(OpCodes.Ldelem_Ref);              // MemoryInstance
-            il.Emit(OpCodes.Ldfld, MemoryDataField);  // byte[] Data
             il.Emit(OpCodes.Ldloc, addrLocal);
             il.Emit(OpCodes.Ldc_I8, storeInst.MemOffset);
             il.Emit(OpCodes.Ldloc, vecLocal);
@@ -792,7 +789,6 @@ namespace Wacs.Transpiler.AOT.Emitters
             il.Emit(OpCodes.Ldfld, MemoriesField);
             il.Emit(OpCodes.Ldc_I4, laneInst.MemIndex);
             il.Emit(OpCodes.Ldelem_Ref);              // MemoryInstance
-            il.Emit(OpCodes.Ldfld, MemoryDataField);  // byte[] Data
             il.Emit(OpCodes.Ldloc, addrLocal);
             il.Emit(OpCodes.Ldc_I8, laneInst.MemOffset);
             il.Emit(OpCodes.Ldloc, vecLocal);

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
@@ -479,14 +479,20 @@ namespace Wacs.Transpiler.AOT
             // handled by InitializeFromData before reaching Core). Kept as
             // a parameter so the call sites document their intent.
 
-            // 1. Allocate memories (as MemoryInstance for shared growth)
+            // 1. Allocate memories (as MemoryInstance for shared growth).
+            // Phase C.4c: respect ModuleInit.CurrentMemoryStorage so
+            // a `wacs run --native-memory` invocation actually
+            // allocates native-pointer-backed memories at the
+            // transpiled module ctor (default ManagedArray stays
+            // byte-stable for AOT modules with no opt-in).
             var memories = new MemoryInstance[data.Memories.Length];
+            var storage = ModuleInit.CurrentMemoryStorage;
             for (int i = 0; i < data.Memories.Length; i++)
             {
                 var (min, max) = data.Memories[i];
                 var memType = new MemoryType(minimum: (uint)min,
                     maximum: max.HasValue ? (uint?)max.Value : null);
-                memories[i] = new MemoryInstance(memType);
+                memories[i] = new MemoryInstance(memType, storage);
             }
 
             // 2. Allocate tables (default values evaluated after globals in step 3b)

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/InitializationHelper.cs
@@ -479,12 +479,10 @@ namespace Wacs.Transpiler.AOT
             // handled by InitializeFromData before reaching Core). Kept as
             // a parameter so the call sites document their intent.
 
-            // 1. Allocate memories (as MemoryInstance for shared growth).
-            // Phase C.4c: respect ModuleInit.CurrentMemoryStorage so
-            // a `wacs run --native-memory` invocation actually
-            // allocates native-pointer-backed memories at the
-            // transpiled module ctor (default ManagedArray stays
-            // byte-stable for AOT modules with no opt-in).
+            // 1. Allocate memories (as MemoryInstance for shared
+            // growth). The host pins ModuleInit.CurrentMemoryStorage
+            // before construction to opt into NativePointer storage;
+            // ManagedArray is the default.
             var memories = new MemoryInstance[data.Memories.Length];
             var storage = ModuleInit.CurrentMemoryStorage;
             for (int i = 0; i < data.Memories.Length; i++)

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/ModuleInit.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/ModuleInit.cs
@@ -33,22 +33,18 @@ namespace Wacs.Transpiler.AOT
         /// <summary>
         /// Storage backing for memories the next transpiled module
         /// instance allocates via <see cref="InitializationHelper"/>.
-        /// Set by the host (e.g. <c>wacs run --native-memory</c> from
-        /// <see cref="RunHandler"/>) before constructing the
-        /// transpiled module class; read inside
-        /// <see cref="InitializationHelper.InitializeCore"/>'s memory
-        /// allocation loop. Defaults to <see cref="MemoryStorageMode.ManagedArray"/>
-        /// so transpiled-and-saved AOT modules built without explicit
-        /// opt-in stay byte-stable.
-        ///
-        /// <para>Phase C.4c from <c>wasi-nn/WACS-GAPS.md</c> gap 12 —
-        /// the static-flag approach is intentionally simple: a single
-        /// transpile/dispatch sequence is single-threaded, and the
-        /// flag is set just before module construction and not
-        /// inspected afterwards. AsyncLocal&lt;T&gt; would be needed if
-        /// concurrent transpiled-module construction with mixed modes
-        /// became a real use case (it isn't today).</para>
+        /// Set by the host before constructing the transpiled module
+        /// class; read inside the helper's memory allocation loop.
+        /// Defaults to <see cref="MemoryStorageMode.ManagedArray"/>.
         /// </summary>
+        /// <remarks>
+        /// Static-flag dispatch is intentionally simple: a single
+        /// transpile-and-dispatch sequence is single-threaded, the
+        /// flag is set just before module construction and not
+        /// inspected afterwards. <c>AsyncLocal&lt;T&gt;</c> would be
+        /// the right tool if concurrent transpiled-module construction
+        /// with mixed modes ever became a use case.
+        /// </remarks>
         public static MemoryStorageMode CurrentMemoryStorage = MemoryStorageMode.ManagedArray;
 
         /// <summary>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/ModuleInit.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/ModuleInit.cs
@@ -31,6 +31,27 @@ namespace Wacs.Transpiler.AOT
         private static readonly object _lock = new();
 
         /// <summary>
+        /// Storage backing for memories the next transpiled module
+        /// instance allocates via <see cref="InitializationHelper"/>.
+        /// Set by the host (e.g. <c>wacs run --native-memory</c> from
+        /// <see cref="RunHandler"/>) before constructing the
+        /// transpiled module class; read inside
+        /// <see cref="InitializationHelper.InitializeCore"/>'s memory
+        /// allocation loop. Defaults to <see cref="MemoryStorageMode.ManagedArray"/>
+        /// so transpiled-and-saved AOT modules built without explicit
+        /// opt-in stay byte-stable.
+        ///
+        /// <para>Phase C.4c from <c>wasi-nn/WACS-GAPS.md</c> gap 12 —
+        /// the static-flag approach is intentionally simple: a single
+        /// transpile/dispatch sequence is single-threaded, and the
+        /// flag is set just before module construction and not
+        /// inspected afterwards. AsyncLocal&lt;T&gt; would be needed if
+        /// concurrent transpiled-module construction with mixed modes
+        /// became a real use case (it isn't today).</para>
+        /// </summary>
+        public static MemoryStorageMode CurrentMemoryStorage = MemoryStorageMode.ManagedArray;
+
+        /// <summary>
         /// Register a data segment's bytes at transpile time.
         /// </summary>
         public static int RegisterDataSegment(byte[] data)

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -15,8 +15,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.7.4</Version>
-        <AssemblyVersion>0.7.4</AssemblyVersion>
+        <Version>0.7.5</Version>
+        <AssemblyVersion>0.7.5</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.7.2 fixes a re-instantiation bug where Module classes with active data segments would come up zeroed on the second `Activator.CreateInstance` because spec §4.5.4 segment-drop emptied the process-wide ModuleInit registry. Module ctors now restore from `ModuleInitData.SavedDataSegments` before each CopyDataSegment so every fresh instance sees its memory initialized. v0.7 retires Lokad.ILPack for PersistedAssemblyBuilder (.NET 9), moves WASM data segments + the codec blob to RVA-mapped initialized data (62.5% smaller than the prior base64-in-#US path, true zero-copy from PE pages to ModuleInitData via UnmanagedMemoryStream), and introduces EmissionTarget.Auto as the new default — promotes to AotLinked when the module fits a conservative envelope (compute / memory / globals / tables + active+passive segments / multi-memory / local tags / imported functions), falling back to Standard otherwise. ~50% first-trial cold-start cut on promoted modules. ImportDispatcher now throws on missing handlers by default (lenient: true opts out). v0.6 consumed the Branch Hinting proposal's metadata.code.branch_hint custom section. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -15,8 +15,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.7.5</Version>
-        <AssemblyVersion>0.7.5</AssemblyVersion>
+        <Version>0.8.0</Version>
+        <AssemblyVersion>0.8.0</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.7.2 fixes a re-instantiation bug where Module classes with active data segments would come up zeroed on the second `Activator.CreateInstance` because spec §4.5.4 segment-drop emptied the process-wide ModuleInit registry. Module ctors now restore from `ModuleInitData.SavedDataSegments` before each CopyDataSegment so every fresh instance sees its memory initialized. v0.7 retires Lokad.ILPack for PersistedAssemblyBuilder (.NET 9), moves WASM data segments + the codec blob to RVA-mapped initialized data (62.5% smaller than the prior base64-in-#US path, true zero-copy from PE pages to ModuleInitData via UnmanagedMemoryStream), and introduces EmissionTarget.Auto as the new default — promotes to AotLinked when the module fits a conservative envelope (compute / memory / globals / tables + active+passive segments / multi-memory / local tags / imported functions), falling back to Standard otherwise. ~50% first-trial cold-start cut on promoted modules. ImportDispatcher now throws on missing handlers by default (lenient: true opts out). v0.6 consumed the Branch Hinting proposal's metadata.code.branch_hint custom section. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -15,8 +15,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.7.3</Version>
-        <AssemblyVersion>0.7.3</AssemblyVersion>
+        <Version>0.7.4</Version>
+        <AssemblyVersion>0.7.4</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.7.2 fixes a re-instantiation bug where Module classes with active data segments would come up zeroed on the second `Activator.CreateInstance` because spec §4.5.4 segment-drop emptied the process-wide ModuleInit registry. Module ctors now restore from `ModuleInitData.SavedDataSegments` before each CopyDataSegment so every fresh instance sees its memory initialized. v0.7 retires Lokad.ILPack for PersistedAssemblyBuilder (.NET 9), moves WASM data segments + the codec blob to RVA-mapped initialized data (62.5% smaller than the prior base64-in-#US path, true zero-copy from PE pages to ModuleInitData via UnmanagedMemoryStream), and introduces EmissionTarget.Auto as the new default — promotes to AotLinked when the module fits a conservative envelope (compute / memory / globals / tables + active+passive segments / multi-memory / local tags / imported functions), falling back to Standard otherwise. ~50% first-trial cold-start cut on promoted modules. ImportDispatcher now throws on missing handlers by default (lenient: true opts out). v0.6 consumed the Branch Hinting proposal's metadata.code.branch_hint custom section. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>

--- a/Wacs.Transpiler/Wacs.Transpiler.Test/DirectLinkedWasiE2ETests.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Test/DirectLinkedWasiE2ETests.cs
@@ -431,9 +431,7 @@ namespace Wacs.Transpiler.Test
             // emit lifts the list correctly: per-element
             // AllocateResource for the own&lt;descriptor&gt; field plus
             // cabi_realloc + UTF-8 encode for the string field, all
-            // packed into the 12-byte stride the wasm probes. Closes
-            // gap 9 from wasi-nn/WACS-GAPS.md (preopens not reaching
-            // the guest under the transpiler engine).
+            // packed into the 12-byte stride the wasm probes.
 
             InitRegistry.Reset();
             ModuleInit.Reset();
@@ -562,16 +560,13 @@ namespace Wacs.Transpiler.Test
             // wasi:filesystem/types.[method]descriptor.stat returns
             // result<descriptor-stat, error-code>. descriptor-stat is
             // a record { type: descriptor-type, link-count: u64,
-            // size: u64, three option<datetime> timestamps } — the
-            // shape gap 10 calls out as silently falling back to the
-            // IImports default-zero stub before this fix.
-            //
-            // This test wires a stub IDescriptor whose Stat() returns
-            // a known Size, transpiles the fsstat fixture, and reads
-            // back retArea+24 (the size field within the OK arm). A
-            // returned 0 would mean direct-link emit fell back; the
-            // expected value proves the record-with-option-fields
-            // emit lifted the result correctly.
+            // size: u64, three option<datetime> timestamps }. Wires
+            // a stub IDescriptor whose Stat() returns a known Size,
+            // transpiles the fsstat fixture, reads retArea+24 (the
+            // size field within the OK arm). A returned 0 would mean
+            // direct-link emit fell back to the IImports default-zero
+            // stub; the expected value proves record-with-option-
+            // fields emit lifted the result correctly.
             InitRegistry.Reset();
             ModuleInit.Reset();
             MultiReturnMethodRegistry.Reset();
@@ -855,7 +850,7 @@ namespace Wacs.Transpiler.Test
 
         // Stub IDescriptor whose Stat() returns a hand-shaped
         // DescriptorStat with a known Size and all-None timestamps.
-        // Every other method throws — gap 10's repro only exercises
+        // Every other method throws — this fixture only exercises
         // Stat().
         private sealed class StatStubDescriptor
             : Wacs.WASI.Preview2.Filesystem.IDescriptor

--- a/Wacs.Transpiler/Wacs.Transpiler.Test/DirectLinkedWasiE2ETests.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Test/DirectLinkedWasiE2ETests.cs
@@ -556,6 +556,476 @@ namespace Wacs.Transpiler.Test
             Assert.Equal(3, (int)raw!);
         }
 
+        [Fact]
+        public void E2E_DescriptorStat_RecordWithOptionFields()
+        {
+            // wasi:filesystem/types.[method]descriptor.stat returns
+            // result<descriptor-stat, error-code>. descriptor-stat is
+            // a record { type: descriptor-type, link-count: u64,
+            // size: u64, three option<datetime> timestamps } — the
+            // shape gap 10 calls out as silently falling back to the
+            // IImports default-zero stub before this fix.
+            //
+            // This test wires a stub IDescriptor whose Stat() returns
+            // a known Size, transpiles the fsstat fixture, and reads
+            // back retArea+24 (the size field within the OK arm). A
+            // returned 0 would mean direct-link emit fell back; the
+            // expected value proves the record-with-option-fields
+            // emit lifted the result correctly.
+            InitRegistry.Reset();
+            ModuleInit.Reset();
+            MultiReturnMethodRegistry.Reset();
+
+            var runtime = new WasmRuntime();
+            // Trap-stub the import so InstantiateModule's import
+            // resolution succeeds. Direct-link IL bypasses this —
+            // it fires only if the path falls back to IImports.
+            runtime.BindHostFunction<Action<int, int>>(
+                ("wasi:filesystem/types@0.2.8",
+                    "[method]descriptor.stat"),
+                (_, __) => throw new InvalidOperationException(
+                    "stub descriptor.stat must not be invoked when "
+                    + "direct linking is in effect"));
+
+            var fixturePath = FindFixturePath(
+                "wasi-fs-stat-component", "fsstat.component.wasm");
+            // Some fixtures only ship the wat alongside; fall back
+            // to assembling the wat module if no precompiled wasm
+            // is on disk.
+            // Hand-rolled fixture wasm so the test isn't gated on
+            // wat assembly tooling. Imports descriptor.stat with
+            // signature (i32, i32) → () and exports ask-stat-size +
+            // ask-stat-mtime-disc, both reading from retArea.
+            byte[] fixtureBytes = BuildFsStatFixtureWasm();
+            using var ms = new MemoryStream(fixtureBytes);
+            var coreModule = BinaryModuleParser
+                .ParseWasm(ms);
+            var moduleInst = runtime.InstantiateModule(coreModule);
+
+            var hostAsm = typeof(Wacs.WASI.Preview2.Filesystem
+                .IDescriptor).Assembly;
+            var resolver = HostPackageResolver.FromAssemblies(
+                new[] { hostAsm });
+            // descriptor.stat MUST resolve through the bundle path.
+            Assert.True(resolver.TryResolve(
+                "wasi:filesystem/types@0.2.8",
+                "[method]descriptor.stat", out _));
+
+            // Independent predicate check — the resolver-aware
+            // recognition of Result<DescriptorStat, ErrorCode>.
+            // Pre-fix this returned false, falling through to the
+            // IImports stub.
+            var isAggSupportedMethod = typeof(DirectLinkedImportEmit)
+                .GetMethod("IsAggregateReturnSupported",
+                    System.Reflection.BindingFlags.NonPublic
+                    | System.Reflection.BindingFlags.Static);
+            if (isAggSupportedMethod != null)
+            {
+                var resultType = typeof(Wacs.ComponentModel.Runtime
+                    .Result<Wacs.WASI.Preview2.Filesystem.DescriptorStat,
+                        Wacs.WASI.Preview2.Filesystem.ErrorCode>);
+                Assert.True((bool)isAggSupportedMethod.Invoke(null,
+                    new object?[] { resultType, resolver })!);
+            }
+
+            var options = new TranspilerOptions
+            {
+                Resolver = resolver,
+                HostPackages = new[] { hostAsm },
+            };
+            var transpiler = new ModuleTranspiler(
+                "Wacs.Test.DescriptorStatE2E", options);
+            var result = transpiler.Transpile(moduleInst, runtime,
+                "FsStatModule");
+            Assert.True(options.ResolverImportBindings!.Count >= 1);
+
+            var importsProxy = ImportDispatcher.Create(
+                result.ImportsInterface!,
+                new Dictionary<string, Func<object?[], object?>>
+                {
+                    [InterfaceGenerator.SanitizeName(
+                        "wasi:filesystem/types@0.2.8_[method]descriptor.stat")]
+                        = _ => throw new InvalidOperationException(
+                            "IImports stub for descriptor.stat must "
+                            + "not be invoked"),
+                });
+
+            var bundle = new WasiPreview2Bundle(
+                environment: new StubEnv(),
+                exit: new StubExit(),
+                stdin: new StubStdin(),
+                stdout: new StubStdout(),
+                stderr: new StubStderr(),
+                terminalStdin: new StubTermStdin(),
+                terminalStdout: new StubTermStdout(),
+                terminalStderr: new StubTermStderr(),
+                monotonicClock: new StubMonotonic(),
+                wallClock: new StubWall(),
+                timezone: new StubTimezone(),
+                random: new StubRandom(),
+                insecure: new StubInsecure(),
+                insecureSeed: new StubInsecureSeed(),
+                poll: new StubPoll(),
+                preopens: new StubPreopens(),
+                filesystemErrorCode: new StubFsErr(),
+                instanceNetwork: new StubInstNet(),
+                tcpCreateSocket: new StubTcp(),
+                udpCreateSocket: new StubUdp(),
+                ipNameLookup: new StubDns(),
+                outgoingHandler: new StubHttpHandler());
+
+            var resources = new WasiPreview2Resources(
+                new Wacs.WASI.Preview2.HostBinding.ResourceContext());
+
+            // Allocate the stub descriptor BEFORE module construction
+            // so the handle is stable. Stat() returns OK with a known
+            // Size + None timestamps so retArea+24 (size) and
+            // retArea+56 (mtime option disc) both have predictable
+            // values for the assertions.
+            const ulong ExpectedSize = 0x0000_DEAD_C0DE_F00DUL;
+            var stubDescriptor = new StatStubDescriptor(ExpectedSize);
+            int handle = resources.AllocateResource(
+                typeof(Wacs.WASI.Preview2.Filesystem.IDescriptor),
+                stubDescriptor);
+
+            var instance = Activator.CreateInstance(result.ModuleClass!,
+                new object[] { importsProxy, bundle, resources })!;
+
+            var sizeMethod = result.ExportsInterface!.GetMethod(
+                InterfaceGenerator.SanitizeName("ask-stat-size"))!;
+            object? rawSize = sizeMethod.Invoke(instance,
+                new object[] { handle });
+
+            // ulong (low 64 bits of the size field) returned by the
+            // wasm export through i64.load offset=24. Pre-fix this
+            // would be 0 (silent IImports fallback); post-fix it
+            // matches what the stub Stat() set.
+            Assert.IsType<long>(rawSize);
+            Assert.Equal(ExpectedSize, unchecked((ulong)(long)rawSize!));
+
+            var discMethod = result.ExportsInterface!.GetMethod(
+                InterfaceGenerator.SanitizeName("ask-stat-mtime-disc"));
+            if (discMethod != null)
+            {
+                // mtime was None → option disc at retArea+56 must be 0.
+                object? rawDisc = discMethod.Invoke(instance,
+                    new object[] { handle });
+                Assert.Equal(0, (int)rawDisc!);
+            }
+        }
+
+        // Minimal fallback wasm equivalent to fsstat.wat — assembled
+        // here so the test runs even if the .component.wasm has not
+        // been built into the fixture tree. Imports
+        // [method]descriptor.stat (i32, i32) → (); exports
+        // ask-stat-size (i32) → i64 reading i64 at retArea+24.
+        private static byte[] BuildFsStatFixtureWasm()
+        {
+            // wat:
+            //   (module
+            //     (import "wasi:filesystem/types@0.2.8"
+            //       "[method]descriptor.stat" (func $stat (param i32 i32)))
+            //     (memory (export "memory") 1)
+            //     (func (export "ask-stat-size") (param i32) (result i64)
+            //       (local i32)
+            //       i32.const 8
+            //       local.set 1
+            //       local.get 0
+            //       local.get 1
+            //       call $stat
+            //       local.get 1
+            //       i64.load offset=24)
+            //     (func (export "ask-stat-mtime-disc") (param i32) (result i32)
+            //       (local i32)
+            //       i32.const 8
+            //       local.set 1
+            //       local.get 0
+            //       local.get 1
+            //       call $stat
+            //       local.get 1
+            //       i32.load8_u offset=56))
+            //
+            // Hand-rolled binary: we only need the byte sequence, and
+            // assembling via Wat would pull in extra deps.
+            var stream = new MemoryStream();
+            var w = new BinaryWriter(stream);
+            // magic + version
+            w.Write((byte)0x00); w.Write((byte)0x61); w.Write((byte)0x73); w.Write((byte)0x6D);
+            w.Write((byte)0x01); w.Write((byte)0x00); w.Write((byte)0x00); w.Write((byte)0x00);
+            // type section: 3 types
+            //   0: (i32, i32) → ()    [stat]
+            //   1: (i32) → i64        [ask-stat-size]
+            //   2: (i32) → i32        [ask-stat-mtime-disc]
+            byte[] typeSec = new byte[]
+            {
+                0x03,
+                0x60, 0x02, 0x7F, 0x7F, 0x00,
+                0x60, 0x01, 0x7F, 0x01, 0x7E,
+                0x60, 0x01, 0x7F, 0x01, 0x7F,
+            };
+            w.Write((byte)0x01); WriteLeb(w, (uint)typeSec.Length); w.Write(typeSec);
+            // import section: 1 import
+            //   "wasi:filesystem/types@0.2.8" (28) . "[method]descriptor.stat" (23) : type 0
+            string imodule = "wasi:filesystem/types@0.2.8";
+            string iname = "[method]descriptor.stat";
+            var imodB = System.Text.Encoding.UTF8.GetBytes(imodule);
+            var inmB = System.Text.Encoding.UTF8.GetBytes(iname);
+            var iSec = new MemoryStream();
+            var iw = new BinaryWriter(iSec);
+            iw.Write((byte)0x01); // 1 import
+            WriteLeb(iw, (uint)imodB.Length); iw.Write(imodB);
+            WriteLeb(iw, (uint)inmB.Length); iw.Write(inmB);
+            iw.Write((byte)0x00); iw.Write((byte)0x00); // func, type 0
+            w.Write((byte)0x02);
+            WriteLeb(w, (uint)iSec.Length); w.Write(iSec.ToArray());
+            // function section: 2 local funcs (types 1 and 2)
+            w.Write((byte)0x03);
+            WriteLeb(w, 3u);
+            w.Write((byte)0x02); w.Write((byte)0x01); w.Write((byte)0x02);
+            // memory section: 1 memory, min=1
+            w.Write((byte)0x05);
+            WriteLeb(w, 3u);
+            w.Write((byte)0x01); w.Write((byte)0x00); w.Write((byte)0x01);
+            // export section: memory + 2 funcs
+            //   "memory" (6) → memory 0
+            //   "ask-stat-size" (13) → func 1 (after 1 import)
+            //   "ask-stat-mtime-disc" (19) → func 2
+            var eSec = new MemoryStream();
+            var ew = new BinaryWriter(eSec);
+            ew.Write((byte)0x03);
+            string e0 = "memory";
+            var e0B = System.Text.Encoding.UTF8.GetBytes(e0);
+            WriteLeb(ew, (uint)e0B.Length); ew.Write(e0B);
+            ew.Write((byte)0x02); WriteLeb(ew, 0u);
+            string e1 = "ask-stat-size";
+            var e1B = System.Text.Encoding.UTF8.GetBytes(e1);
+            WriteLeb(ew, (uint)e1B.Length); ew.Write(e1B);
+            ew.Write((byte)0x00); WriteLeb(ew, 1u);
+            string e2 = "ask-stat-mtime-disc";
+            var e2B = System.Text.Encoding.UTF8.GetBytes(e2);
+            WriteLeb(ew, (uint)e2B.Length); ew.Write(e2B);
+            ew.Write((byte)0x00); WriteLeb(ew, 2u);
+            w.Write((byte)0x07);
+            WriteLeb(w, (uint)eSec.Length); w.Write(eSec.ToArray());
+            // code section: 2 bodies
+            //   ask-stat-size body:
+            //     locals: 1 i32
+            //     i32.const 8 ; local.set 1
+            //     local.get 0 ; local.get 1 ; call 0
+            //     local.get 1 ; i64.load offset=24, align=3
+            //     end
+            byte[] body1 = new byte[]
+            {
+                0x01, 0x01, 0x7F,                        // 1 local of i32
+                0x41, 0x08, 0x21, 0x01,                  // i32.const 8 ; local.set 1
+                0x20, 0x00, 0x20, 0x01, 0x10, 0x00,      // local.get 0 ; local.get 1 ; call 0
+                0x20, 0x01, 0x29, 0x03, 0x18,            // local.get 1 ; i64.load align=3 offset=24
+                0x0B,
+            };
+            byte[] body2 = new byte[]
+            {
+                0x01, 0x01, 0x7F,                        // 1 local of i32
+                0x41, 0x08, 0x21, 0x01,                  // i32.const 8 ; local.set 1
+                0x20, 0x00, 0x20, 0x01, 0x10, 0x00,      // local.get 0 ; local.get 1 ; call 0
+                0x20, 0x01, 0x2D, 0x00, 0x38,            // local.get 1 ; i32.load8_u align=0 offset=56
+                0x0B,
+            };
+            var cSec = new MemoryStream();
+            var cw = new BinaryWriter(cSec);
+            cw.Write((byte)0x02);
+            WriteLeb(cw, (uint)body1.Length); cw.Write(body1);
+            WriteLeb(cw, (uint)body2.Length); cw.Write(body2);
+            w.Write((byte)0x0A);
+            WriteLeb(w, (uint)cSec.Length); cw.Flush();
+            w.Write(cSec.ToArray());
+
+            return stream.ToArray();
+        }
+
+        private static void WriteLeb(BinaryWriter w, uint value)
+        {
+            while (true)
+            {
+                byte b = (byte)(value & 0x7F);
+                value >>= 7;
+                if (value == 0) { w.Write(b); return; }
+                w.Write((byte)(b | 0x80));
+            }
+        }
+
+        // Stub IDescriptor whose Stat() returns a hand-shaped
+        // DescriptorStat with a known Size and all-None timestamps.
+        // Every other method throws — gap 10's repro only exercises
+        // Stat().
+        private sealed class StatStubDescriptor
+            : Wacs.WASI.Preview2.Filesystem.IDescriptor
+        {
+            private readonly ulong _size;
+            public StatStubDescriptor(ulong size) { _size = size; }
+
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.DescriptorStat,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode> Stat()
+                => Wacs.ComponentModel.Runtime.Result<
+                    Wacs.WASI.Preview2.Filesystem.DescriptorStat,
+                    Wacs.WASI.Preview2.Filesystem.ErrorCode>.FromOk(
+                    new Wacs.WASI.Preview2.Filesystem.DescriptorStat
+                    {
+                        Type = Wacs.WASI.Preview2.Filesystem
+                            .DescriptorType.RegularFile,
+                        LinkCount = 1,
+                        Size = _size,
+                        DataAccessTimestamp = Wacs.ComponentModel
+                            .Runtime.Option<Wacs.WASI.Preview2.Clocks
+                                .Datetime>.None,
+                        DataModificationTimestamp = Wacs.ComponentModel
+                            .Runtime.Option<Wacs.WASI.Preview2.Clocks
+                                .Datetime>.None,
+                        StatusChangeTimestamp = Wacs.ComponentModel
+                            .Runtime.Option<Wacs.WASI.Preview2.Clocks
+                                .Datetime>.None,
+                    });
+
+            // Every other method on IDescriptor — irrelevant to the
+            // gap-10 path, throw so a stray dispatch is loud.
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Io.IInputStream,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                ReadViaStream(ulong offset)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Io.IOutputStream,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                WriteViaStream(ulong offset)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Io.IOutputStream,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                AppendViaStream()
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                Advise(ulong offset, ulong length,
+                    Wacs.WASI.Preview2.Filesystem.Advice advice)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode> SyncData()
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.DescriptorFlags,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode> GetFlags()
+                => throw new NotImplementedException();
+            public new Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.DescriptorType,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode> GetType()
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode> SetSize(ulong size)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode> SetTimes(
+                Wacs.WASI.Preview2.Filesystem.NewTimestamp ats,
+                Wacs.WASI.Preview2.Filesystem.NewTimestamp mts)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                (byte[], bool),
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                Read(ulong length, ulong offset)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<ulong,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                Write(byte[] buffer, ulong offset)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.IDirectoryEntryStream,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                ReadDirectory()
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode> Sync()
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                CreateDirectoryAt(string path)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.DescriptorStat,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                StatAt(Wacs.WASI.Preview2.Filesystem.PathFlags pf,
+                    string path)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                SetTimesAt(Wacs.WASI.Preview2.Filesystem.PathFlags pf,
+                    string path,
+                    Wacs.WASI.Preview2.Filesystem.NewTimestamp ats,
+                    Wacs.WASI.Preview2.Filesystem.NewTimestamp mts)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                LinkAt(Wacs.WASI.Preview2.Filesystem.PathFlags pf,
+                    string oldPath,
+                    Wacs.WASI.Preview2.Filesystem.IDescriptor newDesc,
+                    string newPath)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.IDescriptor,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                OpenAt(Wacs.WASI.Preview2.Filesystem.PathFlags pf,
+                    string path,
+                    Wacs.WASI.Preview2.Filesystem.OpenFlags of,
+                    Wacs.WASI.Preview2.Filesystem.DescriptorFlags df)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<string,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                ReadlinkAt(string path)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                RemoveDirectoryAt(string path)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                RenameAt(string oldPath,
+                    Wacs.WASI.Preview2.Filesystem.IDescriptor newDesc,
+                    string newPath)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                SymlinkAt(string oldPath, string newPath)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.ComponentModel.Runtime.Unit,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                UnlinkFileAt(string path)
+                => throw new NotImplementedException();
+            public bool IsSameObject(
+                Wacs.WASI.Preview2.Filesystem.IDescriptor other)
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.MetadataHashValue,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                MetadataHash()
+                => throw new NotImplementedException();
+            public Wacs.ComponentModel.Runtime.Result<
+                Wacs.WASI.Preview2.Filesystem.MetadataHashValue,
+                Wacs.WASI.Preview2.Filesystem.ErrorCode>
+                MetadataHashAt(Wacs.WASI.Preview2.Filesystem.PathFlags pf,
+                    string path)
+                => throw new NotImplementedException();
+        }
+
         private static string FindFixturePath(string fixtureDir,
             string fileName)
         {

--- a/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Clock.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Clock.cs
@@ -141,9 +141,18 @@ namespace Wacs.WASI.Preview1
         // The ExecContext path is interpreter-side only; AOT-side
         // callers construct WacsHostMemory directly from their host's
         // byte-buffer view.
-        internal static WacsHostMemory WacsHost(ExecContext ctx)
+        // Gap 12 phase C.4: dispatch by storage mode — NativePointer
+        // memories use the IntPtr ctor so the binding sees native
+        // bytes; ManagedArray uses the historical byte[] ctor.
+        internal static unsafe WacsHostMemory WacsHost(ExecContext ctx)
         {
             var m = ctx.DefaultMemory;
+            if (m.StorageMode == Wacs.Core.Runtime.MemoryStorageMode.NativePointer)
+            {
+                int len = (int)System.Math.Min(
+                    (ulong)m.NativeSize, (ulong)int.MaxValue);
+                return new WacsHostMemory((System.IntPtr)m.NativeBase, len);
+            }
             return new WacsHostMemory(m.Data, m.Data.Length);
         }
 

--- a/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Clock.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Clock.cs
@@ -137,13 +137,12 @@ namespace Wacs.WASI.Preview1
         // Helpers
         // ============================================================
 
-        // Wrap a runtime ExecContext's default memory in WacsHostMemory.
-        // The ExecContext path is interpreter-side only; AOT-side
-        // callers construct WacsHostMemory directly from their host's
-        // byte-buffer view.
-        // Gap 12 phase C.4: dispatch by storage mode — NativePointer
-        // memories use the IntPtr ctor so the binding sees native
-        // bytes; ManagedArray uses the historical byte[] ctor.
+        // Wrap a runtime ExecContext's default memory in
+        // WacsHostMemory. The ExecContext path is interpreter-side
+        // only; AOT-side callers construct WacsHostMemory directly
+        // from their host's byte-buffer view. Dispatches on the
+        // memory's storage mode so native-backed memories pass
+        // through the byte* ctor.
         internal static unsafe WacsHostMemory WacsHost(ExecContext ctx)
         {
             var m = ctx.DefaultMemory;

--- a/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Wacs.WASI.Preview1.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Wacs.WASI.Preview1.csproj
@@ -13,12 +13,16 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview1</AssemblyName>
         <RootNamespace>Wacs.WASI.Preview1</RootNamespace>
-        <AssemblyVersion>0.12.0</AssemblyVersion>
+        <AssemblyVersion>0.12.1</AssemblyVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.12.0</Version>
+        <Version>0.12.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>
+        <!-- Clock.WacsHost branches by MemoryInstance.StorageMode and
+             constructs WacsHostMemory from a byte* in NativePointer
+             mode; needs an unsafe block at that one site. -->
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Wacs.WASI.Preview1.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview1/Wacs.WASI.Preview1/Wacs.WASI.Preview1.csproj
@@ -13,9 +13,9 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview1</AssemblyName>
         <RootNamespace>Wacs.WASI.Preview1</RootNamespace>
-        <AssemblyVersion>0.12.1</AssemblyVersion>
+        <AssemblyVersion>0.13.0</AssemblyVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.12.1</Version>
+        <Version>0.13.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/ErrorCodeEncoderTests.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/ErrorCodeEncoderTests.cs
@@ -25,11 +25,12 @@ namespace Wacs.WASI.Preview2.Test
     /// shared backing buffer.</summary>
     public class ErrorCodeEncoderTests
     {
-        // Bump-pointer allocator simulating cabi_realloc. Phase
-        // C.4b: backs onto a real MemoryInstance so the encoder's
-        // mode-aware AsSpan dispatches correctly. Tests construct
-        // a 1-page (64 KiB) memory and use the first `_size` bytes
-        // — single-byte assertions go through Memory.AsSpan(N, 1)[0].
+        // Bump-pointer allocator simulating cabi_realloc. Backs onto
+        // a real MemoryInstance so the encoder's mode-aware AsSpan
+        // dispatches correctly. Tests construct a 1-page (64 KiB)
+        // memory and use the first `_size` bytes — the indexer +
+        // Span helper hide the AsSpan(N, 1)[0] boilerplate at each
+        // assertion site.
         private sealed class BumpAllocator
         {
             public readonly MemoryInstance Memory;

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/ErrorCodeEncoderTests.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.Test/ErrorCodeEncoderTests.cs
@@ -9,6 +9,8 @@ using System;
 using System.Buffers.Binary;
 using System.Text;
 using Wacs.ComponentModel.Runtime;
+using Wacs.Core.Runtime.Types;
+using Wacs.Core.Types;
 using Wacs.WASI.Preview2.Http;
 using Xunit;
 
@@ -23,15 +25,20 @@ namespace Wacs.WASI.Preview2.Test
     /// shared backing buffer.</summary>
     public class ErrorCodeEncoderTests
     {
-        // Bump-pointer allocator simulating cabi_realloc.
+        // Bump-pointer allocator simulating cabi_realloc. Phase
+        // C.4b: backs onto a real MemoryInstance so the encoder's
+        // mode-aware AsSpan dispatches correctly. Tests construct
+        // a 1-page (64 KiB) memory and use the first `_size` bytes
+        // — single-byte assertions go through Memory.AsSpan(N, 1)[0].
         private sealed class BumpAllocator
         {
-            public readonly byte[] Memory;
+            public readonly MemoryInstance Memory;
             private int _next;
 
             public BumpAllocator(int size, int initialCursor)
             {
-                Memory = new byte[size];
+                _ = size;  // tests stay within one page
+                Memory = new MemoryInstance(new MemoryType(1, 10));
                 _next = initialCursor;
             }
 
@@ -41,6 +48,16 @@ namespace Wacs.WASI.Preview2.Test
                 _next = aligned + size;
                 return aligned;
             }
+
+            // Convenience byte accessor for assertions: avoids the
+            // .AsSpan(N, 1)[0] boilerplate at every test site.
+            public byte this[int idx]
+            {
+                get => Memory.AsSpan(idx, 1)[0];
+                set => Memory.AsSpan(idx, 1)[0] = value;
+            }
+            public Span<byte> Span(int offset, int length)
+                => Memory.AsSpan(offset, length);
         }
 
         [Fact]
@@ -50,17 +67,17 @@ namespace Wacs.WASI.Preview2.Test
             ErrorCodeEncoder.Write(alloc.Memory, 0,
                 new ErrorCode.ErrorCodeConnectionRefused(),
                 alloc.Allocate);
-            Assert.Equal(6, alloc.Memory[0]);
+            Assert.Equal(6, alloc[0]);
             for (int i = 1; i < 32; i++)
-                Assert.Equal(0, alloc.Memory[i]);
+                Assert.Equal(0, alloc[i]);
 
-            for (int i = 32; i < 64; i++) alloc.Memory[i] = 0xAA;
+            for (int i = 32; i < 64; i++) alloc[i] = 0xAA;
             ErrorCodeEncoder.Write(alloc.Memory, 32,
                 new ErrorCode.ErrorCodeLoopDetected(),
                 alloc.Allocate);
-            Assert.Equal(36, alloc.Memory[32]);
+            Assert.Equal(36, alloc[32]);
             for (int i = 33; i < 64; i++)
-                Assert.Equal(0, alloc.Memory[i]);
+                Assert.Equal(0, alloc[i]);
         }
 
         [Fact]
@@ -71,19 +88,19 @@ namespace Wacs.WASI.Preview2.Test
                 new ErrorCode.ErrorCodeHTTPRequestBodySize(
                     Option<ulong>.Some(0x0123456789ABCDEFUL)),
                 alloc.Allocate);
-            Assert.Equal(17, alloc.Memory[0]);
-            Assert.Equal(1, alloc.Memory[8]);
+            Assert.Equal(17, alloc[0]);
+            Assert.Equal(1, alloc[8]);
             ulong v = BinaryPrimitives.ReadUInt64LittleEndian(
-                alloc.Memory.AsSpan(16, 8));
+                alloc.Span(16, 8));
             Assert.Equal(0x0123456789ABCDEFUL, v);
 
-            for (int i = 0; i < 32; i++) alloc.Memory[i] = 0xAA;
+            for (int i = 0; i < 32; i++) alloc[i] = 0xAA;
             ErrorCodeEncoder.Write(alloc.Memory, 0,
                 new ErrorCode.ErrorCodeHTTPRequestBodySize(
                     Option<ulong>.None),
                 alloc.Allocate);
-            Assert.Equal(17, alloc.Memory[0]);
-            Assert.Equal(0, alloc.Memory[8]);
+            Assert.Equal(17, alloc[0]);
+            Assert.Equal(0, alloc[8]);
         }
 
         [Fact]
@@ -94,10 +111,10 @@ namespace Wacs.WASI.Preview2.Test
                 new ErrorCode.ErrorCodeHTTPRequestHeaderSectionSize(
                     Option<uint>.Some(4096u)),
                 alloc.Allocate);
-            Assert.Equal(21, alloc.Memory[0]);
-            Assert.Equal(1, alloc.Memory[8]);
+            Assert.Equal(21, alloc[0]);
+            Assert.Equal(1, alloc[8]);
             uint v = BinaryPrimitives.ReadUInt32LittleEndian(
-                alloc.Memory.AsSpan(12, 4));
+                alloc.Span(12, 4));
             Assert.Equal(4096u, v);
         }
 
@@ -110,16 +127,16 @@ namespace Wacs.WASI.Preview2.Test
                 new ErrorCode.ErrorCodeInternalError(
                     Option<string>.Some(msg)),
                 alloc.Allocate);
-            Assert.Equal(38, alloc.Memory[0]);
-            Assert.Equal(1, alloc.Memory[8]);
+            Assert.Equal(38, alloc[0]);
+            Assert.Equal(1, alloc[8]);
             int ptr = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(12, 4));
+                alloc.Span(12, 4));
             int len = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(16, 4));
+                alloc.Span(16, 4));
             Assert.True(ptr >= 64);
             Assert.Equal(msg.Length, len);
             Assert.Equal(msg, Encoding.UTF8.GetString(
-                alloc.Memory, ptr, len));
+                alloc.Span(ptr, len)));
         }
 
         [Fact]
@@ -133,17 +150,17 @@ namespace Wacs.WASI.Preview2.Test
             ErrorCodeEncoder.Write(alloc.Memory, 0,
                 new ErrorCode.ErrorCodeDNSError(payload),
                 alloc.Allocate);
-            Assert.Equal(1, alloc.Memory[0]);
-            Assert.Equal(1, alloc.Memory[8]);
+            Assert.Equal(1, alloc[0]);
+            Assert.Equal(1, alloc[8]);
             int ptr = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(12, 4));
+                alloc.Span(12, 4));
             int len = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(16, 4));
+                alloc.Span(16, 4));
             Assert.Equal("SERVFAIL",
-                Encoding.UTF8.GetString(alloc.Memory, ptr, len));
-            Assert.Equal(1, alloc.Memory[20]);
+                Encoding.UTF8.GetString(alloc.Span(ptr, len)));
+            Assert.Equal(1, alloc[20]);
             ushort info = BinaryPrimitives.ReadUInt16LittleEndian(
-                alloc.Memory.AsSpan(22, 2));
+                alloc.Span(22, 2));
             Assert.Equal(2, info);
         }
 
@@ -158,18 +175,18 @@ namespace Wacs.WASI.Preview2.Test
             ErrorCodeEncoder.Write(alloc.Memory, 0,
                 new ErrorCode.ErrorCodeTLSAlertReceived(payload),
                 alloc.Allocate);
-            Assert.Equal(14, alloc.Memory[0]);
-            Assert.Equal(1, alloc.Memory[8]);
-            Assert.Equal(51, alloc.Memory[9]);
-            Assert.Equal(0, alloc.Memory[10]);
-            Assert.Equal(0, alloc.Memory[11]);
-            Assert.Equal(1, alloc.Memory[12]);
+            Assert.Equal(14, alloc[0]);
+            Assert.Equal(1, alloc[8]);
+            Assert.Equal(51, alloc[9]);
+            Assert.Equal(0, alloc[10]);
+            Assert.Equal(0, alloc[11]);
+            Assert.Equal(1, alloc[12]);
             int ptr = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(16, 4));
+                alloc.Span(16, 4));
             int len = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(20, 4));
+                alloc.Span(20, 4));
             Assert.Equal("decrypt error",
-                Encoding.UTF8.GetString(alloc.Memory, ptr, len));
+                Encoding.UTF8.GetString(alloc.Span(ptr, len)));
         }
 
         [Fact]
@@ -184,27 +201,27 @@ namespace Wacs.WASI.Preview2.Test
                 new ErrorCode.ErrorCodeHTTPRequestHeaderSize(
                     Option<FieldSizePayload>.Some(payload)),
                 alloc.Allocate);
-            Assert.Equal(22, alloc.Memory[0]);
-            Assert.Equal(1, alloc.Memory[8]);
-            Assert.Equal(1, alloc.Memory[12]);
+            Assert.Equal(22, alloc[0]);
+            Assert.Equal(1, alloc[8]);
+            Assert.Equal(1, alloc[12]);
             int ptr = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(16, 4));
+                alloc.Span(16, 4));
             int len = BinaryPrimitives.ReadInt32LittleEndian(
-                alloc.Memory.AsSpan(20, 4));
+                alloc.Span(20, 4));
             Assert.Equal("Authorization",
-                Encoding.UTF8.GetString(alloc.Memory, ptr, len));
-            Assert.Equal(1, alloc.Memory[24]);
+                Encoding.UTF8.GetString(alloc.Span(ptr, len)));
+            Assert.Equal(1, alloc[24]);
             uint sz = BinaryPrimitives.ReadUInt32LittleEndian(
-                alloc.Memory.AsSpan(28, 4));
+                alloc.Span(28, 4));
             Assert.Equal(8192u, sz);
 
-            for (int i = 0; i < 32; i++) alloc.Memory[i] = 0xAA;
+            for (int i = 0; i < 32; i++) alloc[i] = 0xAA;
             ErrorCodeEncoder.Write(alloc.Memory, 0,
                 new ErrorCode.ErrorCodeHTTPRequestHeaderSize(
                     Option<FieldSizePayload>.None),
                 alloc.Allocate);
-            Assert.Equal(22, alloc.Memory[0]);
-            Assert.Equal(0, alloc.Memory[8]);
+            Assert.Equal(22, alloc[0]);
+            Assert.Equal(0, alloc[8]);
         }
 
         [Fact]
@@ -215,8 +232,8 @@ namespace Wacs.WASI.Preview2.Test
                 new ErrorCode.ErrorCodeHTTPResponseTransferCoding(
                     Option<string>.None),
                 alloc.Allocate);
-            Assert.Equal(31, alloc.Memory[0]);
-            Assert.Equal(0, alloc.Memory[8]);
+            Assert.Equal(31, alloc[0]);
+            Assert.Equal(0, alloc[8]);
         }
 
         [Fact]

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Cli/CliBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Cli/CliBindings.cs
@@ -134,7 +134,7 @@ namespace Wacs.WASI.Preview2.Cli
                     var cwd = impl.InitialCwd();
                     string? value = cwd.TryGetValue(out var v) ? v : null;
                     MemoryWriter.WriteOptionString(
-                        ctx.Memory, retArea, value, alloc);
+                        ctx.Memory(), retArea, value, alloc);
                 });
         }
 
@@ -257,13 +257,13 @@ namespace Wacs.WASI.Preview2.Cli
             var mem = ctx.Memory();
             if (value == null)
             {
-                mem[retArea] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
                 return;
             }
-            mem[retArea] = 1;
-            mem[retArea + 1] = 0;
-            mem[retArea + 2] = 0;
-            mem[retArea + 3] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            mem.AsSpan(retArea + 1, 1)[0] = 0;
+            mem.AsSpan(retArea + 2, 1)[0] = 0;
+            mem.AsSpan(retArea + 3, 1)[0] = 0;
             MemoryWriter.WriteI32LE(mem, retArea + 4,
                 table.Allocate(value));
         }
@@ -282,7 +282,7 @@ namespace Wacs.WASI.Preview2.Cli
             for (int i = 0; i < count; i++)
             {
                 var (ptr, len) = MemoryWriter.WriteUtf8StringAllocated(
-                    ctx.Memory, values[i], alloc);
+                    ctx.Memory(), values[i], alloc);
                 var mem = ctx.Memory();
                 MemoryWriter.WriteI32LE(mem, arrayPtr + i * 8, ptr);
                 MemoryWriter.WriteI32LE(mem, arrayPtr + i * 8 + 4, len);
@@ -304,9 +304,9 @@ namespace Wacs.WASI.Preview2.Cli
             for (int i = 0; i < count; i++)
             {
                 var (kPtr, kLen) = MemoryWriter
-                    .WriteUtf8StringAllocated(ctx.Memory, pairs[i].Item1, alloc);
+                    .WriteUtf8StringAllocated(ctx.Memory(), pairs[i].Item1, alloc);
                 var (vPtr, vLen) = MemoryWriter
-                    .WriteUtf8StringAllocated(ctx.Memory, pairs[i].Item2, alloc);
+                    .WriteUtf8StringAllocated(ctx.Memory(), pairs[i].Item2, alloc);
                 var mem = ctx.Memory();
                 MemoryWriter.WriteI32LE(mem, arrayPtr + i * 16, kPtr);
                 MemoryWriter.WriteI32LE(mem, arrayPtr + i * 16 + 4, kLen);

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Clocks/ClockBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Clocks/ClockBindings.cs
@@ -141,17 +141,17 @@ namespace Wacs.WASI.Preview2.Clocks
                     });
                     var (namePtr, nameLen) = MemoryWriter
                         .WriteUtf8StringAllocated(
-                            ctx.Memory, disp.Name ?? "", alloc);
+                            ctx.Memory(), disp.Name ?? "", alloc);
                     var mem = ctx.Memory();
                     MemoryWriter.WriteI32LE(mem, retArea,
                         disp.UtcOffset);
                     MemoryWriter.WriteI32LE(mem, retArea + 4, namePtr);
                     MemoryWriter.WriteI32LE(mem, retArea + 8, nameLen);
-                    mem[retArea + 12] = disp.InDaylightSavingTime
+                    mem.AsSpan(retArea + 12, 1)[0] = disp.InDaylightSavingTime
                         ? (byte)1 : (byte)0;
-                    mem[retArea + 13] = 0;
-                    mem[retArea + 14] = 0;
-                    mem[retArea + 15] = 0;
+                    mem.AsSpan(retArea + 13, 1)[0] = 0;
+                    mem.AsSpan(retArea + 14, 1)[0] = 0;
+                    mem.AsSpan(retArea + 15, 1)[0] = 0;
                 });
         }
 

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Descriptor.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Descriptor.cs
@@ -83,7 +83,7 @@ namespace Wacs.WASI.Preview2.Filesystem
             runtime.BindHostFunction<Action<ExecContext, int, long, long, int>>(
                 (Ns, "[method]descriptor.read"),
                 (ctx, handle, length, offset, retArea) =>
-                    WriteResultBytesEofTuple(ctx.Memory, retArea,
+                    WriteResultBytesEofTuple(ctx.Memory(), retArea,
                         ((Descriptor)descriptors.Get(handle))
                             .Read((ulong)length, (ulong)offset),
                         alloc));
@@ -231,7 +231,7 @@ namespace Wacs.WASI.Preview2.Filesystem
             runtime.BindHostFunction<Action<ExecContext, int, int, int, int>>(
                 (Ns, "[method]descriptor.readlink-at"),
                 (ctx, handle, ptr, len, retArea) =>
-                    WriteResultString(ctx.Memory, retArea,
+                    WriteResultString(ctx.Memory(), retArea,
                         ((Descriptor)descriptors.Get(handle))
                             .ReadlinkAt(ctx.ReadUtf8String(ptr, len)),
                         alloc));

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Directory.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Directory.cs
@@ -53,30 +53,30 @@ namespace Wacs.WASI.Preview2.Filesystem
                         return;
                     }
                     // Outer Ok disc.
-                    mem[retArea] = 0;
-                    mem[retArea + 1] = 0;
-                    mem[retArea + 2] = 0;
-                    mem[retArea + 3] = 0;
+                    mem.AsSpan(retArea, 1)[0] = 0;
+                    mem.AsSpan(retArea + 1, 1)[0] = 0;
+                    mem.AsSpan(retArea + 2, 1)[0] = 0;
+                    mem.AsSpan(retArea + 3, 1)[0] = 0;
                     if (!r.Ok.HasValue)
                     {
                         // option None — disc=0, rest zero.
-                        for (int i = 4; i < 20; i++) mem[retArea + i] = 0;
+                        for (int i = 4; i < 20; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
                         return;
                     }
                     var entry = r.Ok.Value;
                     // option Some at offset 4.
-                    mem[retArea + 4] = 1;
-                    mem[retArea + 5] = 0;
-                    mem[retArea + 6] = 0;
-                    mem[retArea + 7] = 0;
-                    mem[retArea + 8] = (byte)entry.Type;
-                    mem[retArea + 9] = 0;
-                    mem[retArea + 10] = 0;
-                    mem[retArea + 11] = 0;
+                    mem.AsSpan(retArea + 4, 1)[0] = 1;
+                    mem.AsSpan(retArea + 5, 1)[0] = 0;
+                    mem.AsSpan(retArea + 6, 1)[0] = 0;
+                    mem.AsSpan(retArea + 7, 1)[0] = 0;
+                    mem.AsSpan(retArea + 8, 1)[0] = (byte)entry.Type;
+                    mem.AsSpan(retArea + 9, 1)[0] = 0;
+                    mem.AsSpan(retArea + 10, 1)[0] = 0;
+                    mem.AsSpan(retArea + 11, 1)[0] = 0;
                     // alloc may invalidate `mem` if the guest's
                     // cabi_realloc grows memory; re-fetch.
                     var (ptr, len) = MemoryWriter.WriteUtf8StringAllocated(
-                        ctx.Memory, entry.Name, alloc);
+                        ctx.Memory(), entry.Name, alloc);
                     mem = ctx.Memory();
                     MemoryWriter.WriteI32LE(mem, retArea + 12, ptr);
                     MemoryWriter.WriteI32LE(mem, retArea + 16, len);

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.ErrorCode.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.ErrorCode.cs
@@ -36,12 +36,12 @@ namespace Wacs.WASI.Preview2.Filesystem
                     var mem = ctx.Memory();
                     if (!code.HasValue)
                     {
-                        mem[retArea] = 0;
-                        mem[retArea + 1] = 0;
+                        mem.AsSpan(retArea, 1)[0] = 0;
+                        mem.AsSpan(retArea + 1, 1)[0] = 0;
                         return;
                     }
-                    mem[retArea] = 1;
-                    mem[retArea + 1] = (byte)(int)code.Value;
+                    mem.AsSpan(retArea, 1)[0] = 1;
+                    mem.AsSpan(retArea + 1, 1)[0] = (byte)(int)code.Value;
                 });
         }
     }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Preopens.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.Preopens.cs
@@ -49,7 +49,7 @@ namespace Wacs.WASI.Preview2.Filesystem
                             (Descriptor)entries[i].Item1);
                         var (sPtr, sLen) = MemoryWriter
                             .WriteUtf8StringAllocated(
-                                ctx.Memory, entries[i].Item2, alloc);
+                                ctx.Memory(), entries[i].Item2, alloc);
                         var mem = ctx.Memory();
                         MemoryWriter.WriteI32LE(
                             mem, arrayPtr + i * 12, handle);

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.cs
@@ -12,6 +12,8 @@ using Wacs.WASI.Preview2.Clocks;
 using Wacs.WASI.Preview2.HostBinding;
 using Wacs.WASI.Preview2.HostBinding.CanonicalAbi;
 
+using Wacs.Core.Runtime.Types;
+
 namespace Wacs.WASI.Preview2.Filesystem
 {
     /// <summary>
@@ -83,22 +85,22 @@ namespace Wacs.WASI.Preview2.Filesystem
 
         // Encode the Err side: outer disc=1 at retArea+0,
         // ErrorCode byte at retArea+1, zero through retArea+totalSize.
-        private static void WriteErrCode(byte[] mem, int retArea,
+        private static void WriteErrCode(MemoryInstance mem, int retArea,
             int totalSize, ErrorCode code)
         {
-            mem[retArea] = 1;
-            mem[retArea + 1] = (byte)code;
-            for (int i = 2; i < totalSize; i++) mem[retArea + i] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            mem.AsSpan(retArea + 1, 1)[0] = (byte)code;
+            for (int i = 2; i < totalSize; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
         }
 
         // result<_, error-code>: 2 bytes (1 disc + 1 byte).
-        private static void WriteResultUnit(byte[] mem, int retArea,
+        private static void WriteResultUnit(MemoryInstance mem, int retArea,
             Result<Unit, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
                 return;
             }
             WriteErrCode(mem, retArea, 2, r.Err);
@@ -106,13 +108,13 @@ namespace Wacs.WASI.Preview2.Filesystem
 
         // result<descriptor-type, error-code>: 2 bytes — 8-case
         // enum widens to u8.
-        private static void WriteResultDescriptorType(byte[] mem,
+        private static void WriteResultDescriptorType(MemoryInstance mem,
             int retArea, Result<DescriptorType, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = (byte)(int)r.Ok;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = (byte)(int)r.Ok;
                 return;
             }
             WriteErrCode(mem, retArea, 2, r.Err);
@@ -120,26 +122,26 @@ namespace Wacs.WASI.Preview2.Filesystem
 
         // result<descriptor-flags, error-code>: 2 bytes —
         // 6-flag bitset packed into a u8.
-        private static void WriteResultDescriptorFlags(byte[] mem,
+        private static void WriteResultDescriptorFlags(MemoryInstance mem,
             int retArea, Result<DescriptorFlags, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = (byte)(uint)r.Ok;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = (byte)(uint)r.Ok;
                 return;
             }
             WriteErrCode(mem, retArea, 2, r.Err);
         }
 
         // result<u64, error-code>: 16 bytes (1 disc + 7 pad + 8 u64).
-        private static void WriteResultU64(byte[] mem, int retArea,
+        private static void WriteResultU64(MemoryInstance mem, int retArea,
             Result<ulong, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
                 MemoryWriter.WriteU64LE(mem, retArea + 8, r.Ok);
                 return;
             }
@@ -151,15 +153,15 @@ namespace Wacs.WASI.Preview2.Filesystem
         // handle has already been allocated via the appropriate
         // resource table (the bindings own resource-table allocation;
         // the encoder just writes the handle bits).
-        private static void WriteResultHandle(byte[] mem, int retArea,
+        private static void WriteResultHandle(MemoryInstance mem, int retArea,
             Result<int, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 MemoryWriter.WriteI32LE(mem, retArea + 4, r.Ok);
                 return;
             }
@@ -169,32 +171,29 @@ namespace Wacs.WASI.Preview2.Filesystem
         // result<string, error-code>: 12 bytes (1 disc + 3 pad +
         // ptr@+4 + len@+8). Takes a getMemory delegate since
         // alloc may grow memory.
-        private static void WriteResultString(Func<byte[]> getMemory,
+        private static void WriteResultString(MemoryInstance mem,
             int retArea, Result<string, ErrorCode> r, Realloc alloc)
         {
             if (r.IsOk)
             {
-                var mem = getMemory();
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 var (ptr, len) = MemoryWriter.WriteUtf8StringAllocated(
-                    getMemory, r.Ok, alloc);
-                mem = getMemory();
+                    mem, r.Ok, alloc);
                 MemoryWriter.WriteI32LE(mem, retArea + 4, ptr);
                 MemoryWriter.WriteI32LE(mem, retArea + 8, len);
                 return;
             }
-            WriteErrCode(getMemory(), retArea, 12, r.Err);
+            WriteErrCode(mem, retArea, 12, r.Err);
         }
 
         // result<(list<u8>, bool), error-code>: 16 bytes.
         // outer disc=0 + 3 pad + (list ptr@+4 + list len@+8 +
-        // bool@+12 + 3 tail pad).
-        // Takes a getMemory delegate because alloc.Allocate may
-        // grow the underlying byte[] mid-call.
-        private static void WriteResultBytesEofTuple(Func<byte[]> getMemory,
+        // bool@+12 + 3 tail pad). MemoryInstance dispatches mode-
+        // aware AsSpan post-cabi_realloc; gap 11 / phase C.4b.
+        private static void WriteResultBytesEofTuple(MemoryInstance mem,
             int retArea, Result<(byte[], bool), ErrorCode> r, Realloc alloc)
         {
             if (r.IsOk)
@@ -202,33 +201,35 @@ namespace Wacs.WASI.Preview2.Filesystem
                 var (data, eof) = r.Ok;
                 int ptr = data.Length == 0 ? 0
                     : alloc.Allocate(1, data.Length);
-                var mem = getMemory();
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                // Re-read mem via AsSpan AFTER cabi_realloc — it
+                // may have grown the linear-memory backing.
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 if (data.Length > 0)
-                    Array.Copy(data, 0, mem, ptr, data.Length);
+                    new ReadOnlySpan<byte>(data)
+                        .CopyTo(mem.AsSpan(ptr, data.Length));
                 MemoryWriter.WriteI32LE(mem, retArea + 4, ptr);
                 MemoryWriter.WriteI32LE(mem, retArea + 8, data.Length);
-                mem[retArea + 12] = eof ? (byte)1 : (byte)0;
-                mem[retArea + 13] = 0;
-                mem[retArea + 14] = 0;
-                mem[retArea + 15] = 0;
+                mem.AsSpan(retArea + 12, 1)[0] = eof ? (byte)1 : (byte)0;
+                mem.AsSpan(retArea + 13, 1)[0] = 0;
+                mem.AsSpan(retArea + 14, 1)[0] = 0;
+                mem.AsSpan(retArea + 15, 1)[0] = 0;
                 return;
             }
-            WriteErrCode(getMemory(), retArea, 16, r.Err);
+            WriteErrCode(mem, retArea, 16, r.Err);
         }
 
         // result<MetadataHashValue, error-code>: 24 bytes.
         // outer disc=0 + 7 pad + lower@+8 + upper@+16.
-        private static void WriteResultMetadataHash(byte[] mem, int retArea,
+        private static void WriteResultMetadataHash(MemoryInstance mem, int retArea,
             Result<MetadataHashValue, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
                 MemoryWriter.WriteU64LE(mem, retArea + 8, r.Ok.Lower);
                 MemoryWriter.WriteU64LE(mem, retArea + 16, r.Ok.Upper);
                 return;
@@ -248,16 +249,16 @@ namespace Wacs.WASI.Preview2.Filesystem
         //   +0: disc (u8) + 7 pad to align 8
         //   +8: seconds (u64)
         //   +16: nanoseconds (u32) + 4 pad
-        private static void WriteResultDescriptorStat(byte[] mem, int retArea,
+        private static void WriteResultDescriptorStat(MemoryInstance mem, int retArea,
             Result<DescriptorStat, ErrorCode> r)
         {
             if (r.IsOk)
             {
                 var stat = r.Ok;
-                mem[retArea] = 0;
-                for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
-                mem[retArea + 8] = (byte)stat.Type;
-                for (int i = 9; i < 16; i++) mem[retArea + i] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
+                mem.AsSpan(retArea + 8, 1)[0] = (byte)stat.Type;
+                for (int i = 9; i < 16; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
                 MemoryWriter.WriteU64LE(mem, retArea + 16, stat.LinkCount);
                 MemoryWriter.WriteU64LE(mem, retArea + 24, stat.Size);
                 WriteOptionDatetime(mem, retArea + 32,
@@ -272,21 +273,21 @@ namespace Wacs.WASI.Preview2.Filesystem
         }
 
         // option<datetime>: 24 bytes, align 8.
-        private static void WriteOptionDatetime(byte[] mem, int offset,
+        private static void WriteOptionDatetime(MemoryInstance mem, int offset,
             Option<Datetime> value)
         {
             if (!value.HasValue)
             {
-                mem[offset] = 0;
-                for (int i = 1; i < 24; i++) mem[offset + i] = 0;
+                mem.AsSpan(offset, 1)[0] = 0;
+                for (int i = 1; i < 24; i++) mem.AsSpan(offset + i, 1)[0] = 0;
                 return;
             }
             var dt = value.Value;
-            mem[offset] = 1;
-            for (int i = 1; i < 8; i++) mem[offset + i] = 0;
+            mem.AsSpan(offset, 1)[0] = 1;
+            for (int i = 1; i < 8; i++) mem.AsSpan(offset + i, 1)[0] = 0;
             MemoryWriter.WriteU64LE(mem, offset + 8, dt.Seconds);
             MemoryWriter.WriteU32LE(mem, offset + 16, dt.Nanoseconds);
-            for (int i = 20; i < 24; i++) mem[offset + i] = 0;
+            for (int i = 20; i < 24; i++) mem.AsSpan(offset + i, 1)[0] = 0;
         }
 
         // -----------------------------------------------------

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Filesystem/FilesystemBindings.cs
@@ -191,8 +191,9 @@ namespace Wacs.WASI.Preview2.Filesystem
 
         // result<(list<u8>, bool), error-code>: 16 bytes.
         // outer disc=0 + 3 pad + (list ptr@+4 + list len@+8 +
-        // bool@+12 + 3 tail pad). MemoryInstance dispatches mode-
-        // aware AsSpan post-cabi_realloc; gap 11 / phase C.4b.
+        // bool@+12 + 3 tail pad). cabi_realloc may grow linear
+        // memory mid-call; mem.AsSpan re-fetches the fresh backing
+        // each access.
         private static void WriteResultBytesEofTuple(MemoryInstance mem,
             int retArea, Result<(byte[], bool), ErrorCode> r, Realloc alloc)
         {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/ExecContextExtensions.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/ExecContextExtensions.cs
@@ -19,14 +19,10 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
     /// <c>MemoryReader.ReadUtf8String(ctx.DefaultMemory, ptr, len)</c>
     /// — keeps the per-syscall code dense and readable.
     ///
-    /// <para>Phase C.4b: <see cref="Memory"/> returns the guest's
-    /// default <see cref="MemoryInstance"/> rather than its
-    /// <c>byte[] Data</c> field, so bindings using either
-    /// <see cref="MemoryStorageMode.ManagedArray"/> or
-    /// <see cref="MemoryStorageMode.NativePointer"/> see the right
-    /// backing automatically. The previous return type
-    /// (<c>byte[]</c>) silently broke in NativePointer mode where
-    /// <c>Data</c> is the empty-array sentinel.</para>
+    /// <para><see cref="Memory"/> returns the guest's default
+    /// <see cref="MemoryInstance"/> so bindings work transparently
+    /// against both <see cref="MemoryStorageMode.ManagedArray"/> and
+    /// <see cref="MemoryStorageMode.NativePointer"/> backings.</para>
     /// </summary>
     public static class ExecContextExtensions
     {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/ExecContextExtensions.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/ExecContextExtensions.cs
@@ -6,6 +6,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 using Wacs.Core.Runtime;
+using Wacs.Core.Runtime.Types;
 
 namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
 {
@@ -15,45 +16,53 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
     /// to <see cref="MemoryReader"/> / <see cref="MemoryWriter"/>
     /// that lets binding bodies write
     /// <c>ctx.ReadUtf8String(ptr, len)</c> instead of
-    /// <c>MemoryReader.ReadUtf8String(ctx.DefaultMemory.Data,
-    /// ptr, len)</c> — keeps the per-syscall code dense and
-    /// readable.
+    /// <c>MemoryReader.ReadUtf8String(ctx.DefaultMemory, ptr, len)</c>
+    /// — keeps the per-syscall code dense and readable.
+    ///
+    /// <para>Phase C.4b: <see cref="Memory"/> returns the guest's
+    /// default <see cref="MemoryInstance"/> rather than its
+    /// <c>byte[] Data</c> field, so bindings using either
+    /// <see cref="MemoryStorageMode.ManagedArray"/> or
+    /// <see cref="MemoryStorageMode.NativePointer"/> see the right
+    /// backing automatically. The previous return type
+    /// (<c>byte[]</c>) silently broke in NativePointer mode where
+    /// <c>Data</c> is the empty-array sentinel.</para>
     /// </summary>
     public static class ExecContextExtensions
     {
-        /// <summary>The guest's default linear memory backing
-        /// array. Most canonical-ABI helpers take it directly;
-        /// this just shortens the access.</summary>
-        public static byte[] Memory(this ExecContext ctx)
-            => ctx.DefaultMemory.Data;
+        /// <summary>The guest's default linear memory. Helpers
+        /// dispatch reads/writes through it; mode-aware in both
+        /// ManagedArray and NativePointer modes.</summary>
+        public static MemoryInstance Memory(this ExecContext ctx)
+            => ctx.DefaultMemory;
 
         public static string ReadUtf8String(this ExecContext ctx,
             int ptr, int len)
-            => MemoryReader.ReadUtf8String(ctx.DefaultMemory.Data,
+            => MemoryReader.ReadUtf8String(ctx.DefaultMemory,
                 ptr, len);
 
         public static byte[] ReadByteArray(this ExecContext ctx,
             int ptr, int len)
-            => MemoryReader.ReadByteArray(ctx.DefaultMemory.Data,
+            => MemoryReader.ReadByteArray(ctx.DefaultMemory,
                 ptr, len);
 
         public static byte[][] ReadByteArrayList(this ExecContext ctx,
             int listPtr, int listLen)
-            => MemoryReader.ReadByteArrayList(ctx.DefaultMemory.Data,
+            => MemoryReader.ReadByteArrayList(ctx.DefaultMemory,
                 listPtr, listLen);
 
         public static int ReadI32LE(this ExecContext ctx, int ptr)
-            => MemoryReader.ReadI32LE(ctx.DefaultMemory.Data, ptr);
+            => MemoryReader.ReadI32LE(ctx.DefaultMemory, ptr);
 
         public static void WriteI32LE(this ExecContext ctx,
             int ptr, int value)
-            => MemoryWriter.WriteI32LE(ctx.DefaultMemory.Data, ptr, value);
+            => MemoryWriter.WriteI32LE(ctx.DefaultMemory, ptr, value);
 
         public static void WriteByte(this ExecContext ctx,
             int ptr, byte value)
-            => ctx.DefaultMemory.Data[ptr] = value;
+            => ctx.DefaultMemory.AsSpan(ptr, 1)[0] = value;
 
         public static byte ReadByte(this ExecContext ctx, int ptr)
-            => ctx.DefaultMemory.Data[ptr];
+            => ctx.DefaultMemory.AsSpan(ptr, 1)[0];
     }
 }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/MemoryReader.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/MemoryReader.cs
@@ -9,6 +9,8 @@ using System;
 using System.Buffers.Binary;
 using System.Text;
 
+using Wacs.Core.Runtime.Types;
+
 namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
 {
     /// <summary>
@@ -27,20 +29,20 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
         /// <summary>UTF-8 decode a string from
         /// <paramref name="ptr"/> for <paramref name="len"/>
         /// bytes. Used for plain <c>string</c> params.</summary>
-        public static string ReadUtf8String(byte[] memory,
+        public static string ReadUtf8String(MemoryInstance memory,
             int ptr, int len)
-            => Encoding.UTF8.GetString(memory, ptr, len);
+            => Encoding.UTF8.GetString(memory.AsSpan(ptr, len));
 
         /// <summary>Copy a slice of guest memory into a fresh
         /// <c>byte[]</c>. Used for <c>list&lt;u8&gt;</c> params
         /// (the host gets a copy, not an alias into guest
         /// memory).</summary>
-        public static byte[] ReadByteArray(byte[] memory,
+        public static byte[] ReadByteArray(MemoryInstance memory,
             int ptr, int len)
         {
             var slice = new byte[len];
             if (len > 0)
-                Array.Copy(memory, ptr, slice, 0, len);
+                memory.AsSpan(ptr, len).CopyTo(slice);
             return slice;
         }
 
@@ -49,7 +51,7 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
         /// <paramref name="listLen"/> entries, each 8 bytes
         /// (bytes-ptr i32 + bytes-len i32). Returns a fresh
         /// <c>byte[][]</c> — host owns the elements.</summary>
-        public static byte[][] ReadByteArrayList(byte[] memory,
+        public static byte[][] ReadByteArrayList(MemoryInstance memory,
             int listPtr, int listLen)
         {
             var result = new byte[listLen][];
@@ -68,25 +70,25 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
         /// <summary>Read an i32 in little-endian at
         /// <paramref name="ptr"/>. Mirror of
         /// <see cref="MemoryWriter.WriteI32LE"/>.</summary>
-        public static int ReadI32LE(byte[] memory, int ptr)
+        public static int ReadI32LE(MemoryInstance memory, int ptr)
             => BinaryPrimitives.ReadInt32LittleEndian(
                 memory.AsSpan(ptr, 4));
 
         /// <summary>Read a u16 in little-endian at
         /// <paramref name="ptr"/>.</summary>
-        public static ushort ReadU16LE(byte[] memory, int ptr)
+        public static ushort ReadU16LE(MemoryInstance memory, int ptr)
             => BinaryPrimitives.ReadUInt16LittleEndian(
                 memory.AsSpan(ptr, 2));
 
         /// <summary>Read a u32 in little-endian at
         /// <paramref name="ptr"/>.</summary>
-        public static uint ReadU32LE(byte[] memory, int ptr)
+        public static uint ReadU32LE(MemoryInstance memory, int ptr)
             => BinaryPrimitives.ReadUInt32LittleEndian(
                 memory.AsSpan(ptr, 4));
 
         /// <summary>Read a u64 in little-endian at
         /// <paramref name="ptr"/>.</summary>
-        public static ulong ReadU64LE(byte[] memory, int ptr)
+        public static ulong ReadU64LE(MemoryInstance memory, int ptr)
             => BinaryPrimitives.ReadUInt64LittleEndian(
                 memory.AsSpan(ptr, 8));
     }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/MemoryWriter.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/MemoryWriter.cs
@@ -116,9 +116,9 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
                 : alloc.Allocate(1, bytes.Length);
             if (bytes.Length > 0)
             {
-                // Re-read mem.Data/AsSpan AFTER cabi_realloc — the
-                // allocator may have grown linear memory and
-                // reassigned the byte[] backing (gap 11 pattern).
+                // memory.AsSpan re-reads the backing on each access —
+                // critical because alloc.Allocate above may have
+                // triggered memory.grow.
                 new ReadOnlySpan<byte>(bytes)
                     .CopyTo(memory.AsSpan(dataPtr, bytes.Length));
             }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/MemoryWriter.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/HostBinding/CanonicalAbi/MemoryWriter.cs
@@ -9,6 +9,8 @@ using System;
 using System.Buffers.Binary;
 using System.Text;
 
+using Wacs.Core.Runtime.Types;
+
 namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
 {
     /// <summary>
@@ -24,29 +26,29 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
     {
         /// <summary>Write an i32 in little-endian at
         /// <paramref name="ptr"/>.</summary>
-        public static void WriteI32LE(byte[] memory, int ptr, int value)
+        public static void WriteI32LE(MemoryInstance memory, int ptr, int value)
         {
-            memory[ptr]     = (byte)(value & 0xFF);
-            memory[ptr + 1] = (byte)((value >> 8) & 0xFF);
-            memory[ptr + 2] = (byte)((value >> 16) & 0xFF);
-            memory[ptr + 3] = (byte)((value >> 24) & 0xFF);
+            memory.AsSpan(ptr, 1)[0]     = (byte)(value & 0xFF);
+            memory.AsSpan(ptr + 1, 1)[0] = (byte)((value >> 8) & 0xFF);
+            memory.AsSpan(ptr + 2, 1)[0] = (byte)((value >> 16) & 0xFF);
+            memory.AsSpan(ptr + 3, 1)[0] = (byte)((value >> 24) & 0xFF);
         }
 
         /// <summary>Write a u16 in little-endian at
         /// <paramref name="ptr"/>.</summary>
-        public static void WriteU16LE(byte[] memory, int ptr, ushort value)
+        public static void WriteU16LE(MemoryInstance memory, int ptr, ushort value)
             => BinaryPrimitives.WriteUInt16LittleEndian(
                 memory.AsSpan(ptr, 2), value);
 
         /// <summary>Write a u32 in little-endian at
         /// <paramref name="ptr"/>.</summary>
-        public static void WriteU32LE(byte[] memory, int ptr, uint value)
+        public static void WriteU32LE(MemoryInstance memory, int ptr, uint value)
             => BinaryPrimitives.WriteUInt32LittleEndian(
                 memory.AsSpan(ptr, 4), value);
 
         /// <summary>Write a u64 in little-endian at
         /// <paramref name="ptr"/>.</summary>
-        public static void WriteU64LE(byte[] memory, int ptr, ulong value)
+        public static void WriteU64LE(MemoryInstance memory, int ptr, ulong value)
             => BinaryPrimitives.WriteUInt64LittleEndian(
                 memory.AsSpan(ptr, 8), value);
 
@@ -54,15 +56,15 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
         /// <paramref name="ptr"/> in little-endian — the
         /// canonical-ABI default (and only) byte ordering for
         /// record fields.</summary>
-        public static void WritePrimitiveLE(byte[] memory, int ptr,
+        public static void WritePrimitiveLE(MemoryInstance memory, int ptr,
             Type t, object value)
         {
             if (t == typeof(bool))
-                memory[ptr] = (bool)value ? (byte)1 : (byte)0;
+                memory.AsSpan(ptr, 1)[0] = (bool)value ? (byte)1 : (byte)0;
             else if (t == typeof(byte))
-                memory[ptr] = (byte)value;
+                memory.AsSpan(ptr, 1)[0] = (byte)value;
             else if (t == typeof(sbyte))
-                memory[ptr] = unchecked((byte)(sbyte)value);
+                memory.AsSpan(ptr, 1)[0] = unchecked((byte)(sbyte)value);
             else if (t == typeof(short))
                 BinaryPrimitives.WriteInt16LittleEndian(
                     memory.AsSpan(ptr, 2), (short)value);
@@ -107,37 +109,41 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
         /// underlying array. Callers in WASIp1-style binders
         /// pass <c>ctx.Memory</c> as the delegate.</para></summary>
         public static (int ptr, int len) WriteUtf8StringAllocated(
-            Func<byte[]> getMemory, string s, Realloc alloc)
+            MemoryInstance memory, string s, Realloc alloc)
         {
             var bytes = Encoding.UTF8.GetBytes(s ?? "");
             int dataPtr = bytes.Length == 0 ? 0
                 : alloc.Allocate(1, bytes.Length);
             if (bytes.Length > 0)
-                Array.Copy(bytes, 0, getMemory(), dataPtr, bytes.Length);
+            {
+                // Re-read mem.Data/AsSpan AFTER cabi_realloc — the
+                // allocator may have grown linear memory and
+                // reassigned the byte[] backing (gap 11 pattern).
+                new ReadOnlySpan<byte>(bytes)
+                    .CopyTo(memory.AsSpan(dataPtr, bytes.Length));
+            }
             return (dataPtr, bytes.Length);
         }
 
         /// <summary>Write the canon-lowered <c>option&lt;string&gt;</c>
         /// retArea form at <paramref name="offset"/>: 1B disc + 3B
-        /// padding + 4B ptr + 4B len. Total 12 bytes. The
-        /// <paramref name="getMemory"/> delegate refetches the
-        /// live linear-memory buffer (alloc may grow).</summary>
-        public static void WriteOptionString(Func<byte[]> getMemory,
+        /// padding + 4B ptr + 4B len. Total 12 bytes. Reads through
+        /// <see cref="MemoryInstance"/> so writes target the right
+        /// backing in NativePointer mode and survive cabi_realloc-
+        /// triggered grow correctly.</summary>
+        public static void WriteOptionString(MemoryInstance memory,
             int offset, string? value, Realloc alloc)
         {
-            var memory = getMemory();
             if (value == null)
             {
-                memory[offset] = 0;
+                memory.AsSpan(offset, 1)[0] = 0;
                 return;
             }
-            memory[offset] = 1;
-            memory[offset + 1] = 0;
-            memory[offset + 2] = 0;
-            memory[offset + 3] = 0;
-            var (ptr, len) = WriteUtf8StringAllocated(getMemory, value, alloc);
-            // Refetch — alloc may have grown memory.
-            memory = getMemory();
+            memory.AsSpan(offset, 1)[0] = 1;
+            memory.AsSpan(offset + 1, 1)[0] = 0;
+            memory.AsSpan(offset + 2, 1)[0] = 0;
+            memory.AsSpan(offset + 3, 1)[0] = 0;
+            var (ptr, len) = WriteUtf8StringAllocated(memory, value, alloc);
             WriteI32LE(memory, offset + 4, ptr);
             WriteI32LE(memory, offset + 8, len);
         }
@@ -146,20 +152,20 @@ namespace Wacs.WASI.Preview2.HostBinding.CanonicalAbi
         /// retArea Ok side at <paramref name="offset"/>: just the
         /// outer disc byte = 0. Caller is responsible for zeroing
         /// any padding the variant alignment requires.</summary>
-        public static void WriteResultUnitOk(byte[] memory, int offset)
+        public static void WriteResultUnitOk(MemoryInstance memory, int offset)
         {
-            memory[offset] = 0;
+            memory.AsSpan(offset, 1)[0] = 0;
         }
 
         /// <summary>Zero <paramref name="length"/> bytes at
         /// <paramref name="offset"/>. Useful for clearing variant
         /// padding so stale bytes don't leak across reused
         /// retArea allocations.</summary>
-        public static void ZeroRange(byte[] memory, int offset,
+        public static void ZeroRange(MemoryInstance memory, int offset,
             int length)
         {
             for (int i = 0; i < length; i++)
-                memory[offset + i] = 0;
+                memory.AsSpan(offset + i, 1)[0] = 0;
         }
     }
 }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/ErrorCodeEncoder.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/ErrorCodeEncoder.cs
@@ -10,6 +10,8 @@ using System.Buffers.Binary;
 using System.Text;
 using Wacs.ComponentModel.Runtime;
 
+using Wacs.Core.Runtime.Types;
+
 namespace Wacs.WASI.Preview2.Http
 {
     /// <summary>Canonical-ABI encoder for the 39-case
@@ -115,16 +117,16 @@ namespace Wacs.WASI.Preview2.Http
         /// 32-byte slot so the guest sees a clean variant</item>
         /// </list>
         /// </summary>
-        public static void Write(byte[] memory, int offset,
+        public static void Write(MemoryInstance memory, int offset,
             ErrorCode value, Func<int, int, int> allocate)
         {
             // Zero the whole 32-byte slot first; the case
             // writers only touch the bytes their payload
             // occupies, so anything else stays clean.
             for (int i = 0; i < Size; i++)
-                memory[offset + i] = 0;
+                memory.AsSpan(offset + i, 1)[0] = 0;
 
-            memory[offset] = Discriminant(value);
+            memory.AsSpan(offset, 1)[0] = Discriminant(value);
             int p = offset + PayloadOffset;
 
             switch (value)
@@ -227,21 +229,21 @@ namespace Wacs.WASI.Preview2.Http
 
         // option<string>: 12 bytes — 1B disc + 3B padding +
         // 4B ptr + 4B len. ptr/len are zero when None.
-        private static void WriteOptionString(byte[] memory,
+        private static void WriteOptionString(MemoryInstance memory,
             int offset, Option<string> opt,
             Func<int, int, int> allocate)
         {
             if (!opt.HasValue)
             {
-                memory[offset] = 0;
+                memory.AsSpan(offset, 1)[0] = 0;
                 return;
             }
-            memory[offset] = 1;
+            memory.AsSpan(offset, 1)[0] = 1;
             var bytes = Encoding.UTF8.GetBytes(opt.Value);
             int dataPtr = bytes.Length == 0 ? 0
                 : allocate(1, bytes.Length);
             if (bytes.Length > 0)
-                Array.Copy(bytes, 0, memory, dataPtr, bytes.Length);
+                new ReadOnlySpan<byte>(bytes, 0, bytes.Length).CopyTo(memory.AsSpan(dataPtr, bytes.Length));
             BinaryPrimitives.WriteInt32LittleEndian(
                 memory.AsSpan(offset + 4, 4), dataPtr);
             BinaryPrimitives.WriteInt32LittleEndian(
@@ -249,46 +251,46 @@ namespace Wacs.WASI.Preview2.Http
         }
 
         // option<u8>: 2 bytes — disc + value.
-        private static void WriteOptionU8(byte[] memory,
+        private static void WriteOptionU8(MemoryInstance memory,
             int offset, Option<byte> opt)
         {
-            if (!opt.HasValue) { memory[offset] = 0; return; }
-            memory[offset] = 1;
-            memory[offset + 1] = opt.Value;
+            if (!opt.HasValue) { memory.AsSpan(offset, 1)[0] = 0; return; }
+            memory.AsSpan(offset, 1)[0] = 1;
+            memory.AsSpan(offset + 1, 1)[0] = opt.Value;
         }
 
         // option<u16>: 4 bytes — disc + 1B padding + 2B value.
-        private static void WriteOptionU16(byte[] memory,
+        private static void WriteOptionU16(MemoryInstance memory,
             int offset, Option<ushort> opt)
         {
-            if (!opt.HasValue) { memory[offset] = 0; return; }
-            memory[offset] = 1;
+            if (!opt.HasValue) { memory.AsSpan(offset, 1)[0] = 0; return; }
+            memory.AsSpan(offset, 1)[0] = 1;
             BinaryPrimitives.WriteUInt16LittleEndian(
                 memory.AsSpan(offset + 2, 2), opt.Value);
         }
 
         // option<u32>: 8 bytes — disc + 3B padding + 4B value.
-        private static void WriteOptionU32(byte[] memory,
+        private static void WriteOptionU32(MemoryInstance memory,
             int offset, Option<uint> opt)
         {
-            if (!opt.HasValue) { memory[offset] = 0; return; }
-            memory[offset] = 1;
+            if (!opt.HasValue) { memory.AsSpan(offset, 1)[0] = 0; return; }
+            memory.AsSpan(offset, 1)[0] = 1;
             BinaryPrimitives.WriteUInt32LittleEndian(
                 memory.AsSpan(offset + 4, 4), opt.Value);
         }
 
         // option<u64>: 16 bytes — disc + 7B padding + 8B value.
-        private static void WriteOptionU64(byte[] memory,
+        private static void WriteOptionU64(MemoryInstance memory,
             int offset, Option<ulong> opt)
         {
-            if (!opt.HasValue) { memory[offset] = 0; return; }
-            memory[offset] = 1;
+            if (!opt.HasValue) { memory.AsSpan(offset, 1)[0] = 0; return; }
+            memory.AsSpan(offset, 1)[0] = 1;
             BinaryPrimitives.WriteUInt64LittleEndian(
                 memory.AsSpan(offset + 8, 8), opt.Value);
         }
 
         // DnsErrorPayload (16B align 4): rcode @0, info-code @12.
-        private static void WriteDnsErrorPayload(byte[] memory,
+        private static void WriteDnsErrorPayload(MemoryInstance memory,
             int offset, DNSErrorPayload p,
             Func<int, int, int> allocate)
         {
@@ -300,21 +302,21 @@ namespace Wacs.WASI.Preview2.Http
         // alert-id (option<u8>) @0 (2 bytes), padding @2..3,
         // alert-message (option<string>) @4 (12 bytes).
         private static void WriteTlsAlertReceivedPayload(
-            byte[] memory, int offset,
+            MemoryInstance memory, int offset,
             TLSAlertReceivedPayload p,
             Func<int, int, int> allocate)
         {
             WriteOptionU8(memory, offset, p.AlertId);
             // zero pad bytes 2-3
-            memory[offset + 2] = 0;
-            memory[offset + 3] = 0;
+            memory.AsSpan(offset + 2, 1)[0] = 0;
+            memory.AsSpan(offset + 3, 1)[0] = 0;
             WriteOptionString(memory, offset + 4,
                 p.AlertMessage, allocate);
         }
 
         // FieldSizePayload (20B align 4): field-name @0,
         // field-size @12.
-        private static void WriteFieldSizePayload(byte[] memory,
+        private static void WriteFieldSizePayload(MemoryInstance memory,
             int offset, FieldSizePayload p,
             Func<int, int, int> allocate)
         {
@@ -324,12 +326,12 @@ namespace Wacs.WASI.Preview2.Http
 
         // option<FieldSizePayload> (24B align 4): disc @0,
         // 3B padding, payload @4 (20 bytes).
-        private static void WriteOptionFieldSize(byte[] memory,
+        private static void WriteOptionFieldSize(MemoryInstance memory,
             int offset, Option<FieldSizePayload> p,
             Func<int, int, int> allocate)
         {
-            if (!p.HasValue) { memory[offset] = 0; return; }
-            memory[offset] = 1;
+            if (!p.HasValue) { memory.AsSpan(offset, 1)[0] = 0; return; }
+            memory.AsSpan(offset, 1)[0] = 1;
             WriteFieldSizePayload(memory, offset + 4, p.Value, allocate);
         }
     }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.ErrorCode.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.ErrorCode.cs
@@ -42,19 +42,19 @@ namespace Wacs.WASI.Preview2.Http
                     var mem = ctx.Memory();
                     if (impl == null)
                     {
-                        mem[retArea] = 0;       // None
+                        mem.AsSpan(retArea, 1)[0] = 0;       // None
                         return;
                     }
                     var err = (Error)errors.Get(handle);
                     var code = impl.HttpErrorCode(err);
                     if (code == null)
                     {
-                        mem[retArea] = 0;       // None
+                        mem.AsSpan(retArea, 1)[0] = 0;       // None
                         return;
                     }
-                    mem[retArea] = 1;           // Some
+                    mem.AsSpan(retArea, 1)[0] = 1;           // Some
                     for (int p = 1; p < 8; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                     ErrorCodeEncoder.Write(mem, retArea + 8, code,
                         alloc.Allocate);
                 });

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.Fields.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.Fields.cs
@@ -54,10 +54,10 @@ namespace Wacs.WASI.Preview2.Http
                         int vPtr = MemoryReader.ReadI32LE(mem, eb + 8);
                         int vLen = MemoryReader.ReadI32LE(mem, eb + 12);
                         var key = Encoding.UTF8.GetString(
-                            mem, kPtr, kLen);
+                            mem.AsSpan(kPtr, kLen));
                         var val = new byte[vLen];
                         if (vLen > 0)
-                            Array.Copy(mem, vPtr, val, 0, vLen);
+                            mem.AsSpan(vPtr, vLen).CopyTo(val);
                         entries[i] = (key, val);
                     }
                     // Use the static factory (concrete-typed) so
@@ -100,8 +100,9 @@ namespace Wacs.WASI.Preview2.Http
                             : alloc.Allocate(1, bytes.Length);
                         var memInner = ctx.Memory();
                         if (bytes.Length > 0)
-                            Array.Copy(bytes, 0, memInner,
-                                dataPtr, bytes.Length);
+                            new ReadOnlySpan<byte>(bytes)
+                                .CopyTo(memInner.AsSpan(
+                                    dataPtr, bytes.Length));
                         MemoryWriter.WriteI32LE(memInner,
                             arrayPtr + i * 8, dataPtr);
                         MemoryWriter.WriteI32LE(memInner,
@@ -164,12 +165,13 @@ namespace Wacs.WASI.Preview2.Http
                         var (key, val) = arr[i];
                         var (kPtr, kLen) = MemoryWriter
                             .WriteUtf8StringAllocated(
-                                ctx.Memory, key, alloc);
+                                ctx.Memory(), key, alloc);
                         int vPtr = val.Length == 0 ? 0
                             : alloc.Allocate(1, val.Length);
                         var memInner = ctx.Memory();
                         if (val.Length > 0)
-                            Array.Copy(val, 0, memInner, vPtr, val.Length);
+                            new ReadOnlySpan<byte>(val)
+                                .CopyTo(memInner.AsSpan(vPtr, val.Length));
                         int eb = arrayPtr + i * 16;
                         MemoryWriter.WriteI32LE(memInner, eb, kPtr);
                         MemoryWriter.WriteI32LE(memInner, eb + 4, kLen);

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.Futures.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.Futures.cs
@@ -73,47 +73,47 @@ namespace Wacs.WASI.Preview2.Http
                     var mem = ctx.Memory();
                     if (!ret.HasValue)
                     {
-                        mem[retArea] = 0;           // outer None
+                        mem.AsSpan(retArea, 1)[0] = 0;           // outer None
                         return;
                     }
                     var outer = ret.Value;
                     if (!outer.IsOk)
                     {
                         // Outer Err (bare Unit) — already-consumed.
-                        mem[retArea] = 1;           // outer Some
+                        mem.AsSpan(retArea, 1)[0] = 1;           // outer Some
                         for (int p = 1; p <= 7; p++)
-                            mem[retArea + p] = 0;
-                        mem[retArea + 8] = 1;       // outer Err
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
+                        mem.AsSpan(retArea + 8, 1)[0] = 1;       // outer Err
                         for (int p = 9; p <= 55; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                         return;
                     }
                     var inner = outer.Ok;
-                    mem[retArea] = 1;               // outer Some
+                    mem.AsSpan(retArea, 1)[0] = 1;               // outer Some
                     for (int p = 1; p <= 7; p++)
-                        mem[retArea + p] = 0;
-                    mem[retArea + 8] = 0;           // outer Ok
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
+                    mem.AsSpan(retArea + 8, 1)[0] = 0;           // outer Ok
                     for (int p = 9; p <= 15; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                     if (!inner.IsOk)
                     {
-                        mem[retArea + 16] = 1;      // inner Err
+                        mem.AsSpan(retArea + 16, 1)[0] = 1;      // inner Err
                         for (int p = 17; p <= 23; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                         ErrorCodeEncoder.Write(mem, retArea + 24,
                             inner.Err, alloc.Allocate);
                         return;
                     }
-                    mem[retArea + 16] = 0;          // inner Ok
+                    mem.AsSpan(retArea + 16, 1)[0] = 0;          // inner Ok
                     for (int p = 17; p <= 23; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                     // Downcast IIncomingResponse → IncomingResponse
                     // for resource-table allocation.
                     int respHandle = responses.Allocate(
                         (IncomingResponse)inner.Ok);
                     MemoryWriter.WriteI32LE(mem, retArea + 24, respHandle);
                     for (int p = 28; p <= 55; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                 });
         }
 
@@ -194,54 +194,54 @@ namespace Wacs.WASI.Preview2.Http
                     var mem = ctx.Memory();
                     if (!ret.HasValue)
                     {
-                        mem[retArea] = 0;           // outer None
+                        mem.AsSpan(retArea, 1)[0] = 0;           // outer None
                         return;
                     }
                     var outer = ret.Value;
-                    mem[retArea] = 1;               // outer Some
+                    mem.AsSpan(retArea, 1)[0] = 1;               // outer Some
                     for (int p = 1; p <= 7; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                     if (!outer.IsOk)
                     {
                         // Outer-Err (bare Unit) — fixture path
                         // unused; treat as result=1 with empty
                         // payload.
-                        mem[retArea + 8] = 1;
+                        mem.AsSpan(retArea + 8, 1)[0] = 1;
                         for (int p = 9; p <= 47; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                         return;
                     }
                     var inner = outer.Ok;
                     if (!inner.IsOk)
                     {
-                        mem[retArea + 8] = 1;       // result Err
+                        mem.AsSpan(retArea + 8, 1)[0] = 1;       // result Err
                         for (int p = 9; p <= 15; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                         ErrorCodeEncoder.Write(mem, retArea + 16,
                             inner.Err, alloc.Allocate);
                         return;
                     }
-                    mem[retArea + 8] = 0;           // result Ok
+                    mem.AsSpan(retArea + 8, 1)[0] = 0;           // result Ok
                     for (int p = 9; p <= 15; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                     if (!inner.Ok.HasValue)
                     {
-                        mem[retArea + 16] = 0;      // inner None
+                        mem.AsSpan(retArea + 16, 1)[0] = 0;      // inner None
                         for (int p = 17; p <= 19; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                         MemoryWriter.WriteI32LE(mem, retArea + 20, 0);
                         for (int p = 24; p <= 47; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                         return;
                     }
-                    mem[retArea + 16] = 1;          // inner Some
+                    mem.AsSpan(retArea + 16, 1)[0] = 1;          // inner Some
                     for (int p = 17; p <= 19; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                     int tHandle = trailers.Allocate(
                         (Fields)inner.Ok.Value);
                     MemoryWriter.WriteI32LE(mem, retArea + 20, tHandle);
                     for (int p = 24; p <= 47; p++)
-                        mem[retArea + p] = 0;
+                        mem.AsSpan(retArea + p, 1)[0] = 0;
                 });
         }
     }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/HttpTypes.cs
@@ -12,6 +12,8 @@ using Wacs.Core.Runtime;
 using Wacs.WASI.Preview2.HostBinding;
 using Wacs.WASI.Preview2.HostBinding.CanonicalAbi;
 
+using Wacs.Core.Runtime.Types;
+
 namespace Wacs.WASI.Preview2.Http
 {
     /// <summary>
@@ -74,10 +76,10 @@ namespace Wacs.WASI.Preview2.Http
 
         // result<_, _> (bare Unit/Unit): 1 byte (just outer
         // Ok disc).
-        private static void WriteResultUnit(byte[] mem, int retArea,
+        private static void WriteResultUnit(MemoryInstance mem, int retArea,
             Result<Unit, Unit> r)
         {
-            mem[retArea] = r.IsOk ? (byte)0 : (byte)1;
+            mem.AsSpan(retArea, 1)[0] = r.IsOk ? (byte)0 : (byte)1;
         }
 
         // result<_, header-error>: 1 byte (header-error fixtures
@@ -85,49 +87,49 @@ namespace Wacs.WASI.Preview2.Http
         // method returns Result<Unit, HeaderError>; we only
         // surface the disc byte. Err-payload encoding is
         // deferred until a fixture exercises it.
-        private static void WriteResultUnitHeaderError(byte[] mem,
+        private static void WriteResultUnitHeaderError(MemoryInstance mem,
             int retArea, Result<Unit, HeaderError> r)
         {
-            mem[retArea] = r.IsOk ? (byte)0 : (byte)1;
+            mem.AsSpan(retArea, 1)[0] = r.IsOk ? (byte)0 : (byte)1;
         }
 
         // result<own<X>, _>: 8 bytes (1B disc + 3B pad +
         // 4B handle). Caller supplies an int Ok handle that
         // has been resource-table-allocated.
-        private static void WriteResultHandleBareErr(byte[] mem,
+        private static void WriteResultHandleBareErr(MemoryInstance mem,
             int retArea, Result<int, Unit> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 MemoryWriter.WriteI32LE(mem, retArea + 4, r.Ok);
                 return;
             }
             // Bare-Unit Err: disc=1, rest stays zeroed.
-            mem[retArea] = 1;
-            for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
         }
 
         // result<own<X>, header-error>: 8 bytes. Same shape as
         // result<own<X>, _> on the Ok side; Err-payload not
         // written in v0.
-        private static void WriteResultHandleHeaderError(byte[] mem,
+        private static void WriteResultHandleHeaderError(MemoryInstance mem,
             int retArea, Result<int, HeaderError> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 MemoryWriter.WriteI32LE(mem, retArea + 4, r.Ok);
                 return;
             }
-            mem[retArea] = 1;
-            for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
         }
 
         // result<_, error-code> (placeholder error-code: 1 byte
@@ -135,23 +137,23 @@ namespace Wacs.WASI.Preview2.Http
         // single-case error-code, so the result variant is just
         // 1 byte — just the outer disc. Used by outgoing-body.
         // finish (whose fixture uses a placeholder).
-        private static void WriteResultUnitPlaceholder(byte[] mem,
+        private static void WriteResultUnitPlaceholder(MemoryInstance mem,
             int retArea, Result<Unit, ErrorCode> r)
         {
-            mem[retArea] = r.IsOk ? (byte)0 : (byte)1;
+            mem.AsSpan(retArea, 1)[0] = r.IsOk ? (byte)0 : (byte)1;
         }
 
         // option<u64>: 16 bytes — disc (1B) + 7B pad + u64 (8B).
-        private static void WriteOptionU64(byte[] mem, int retArea,
+        private static void WriteOptionU64(MemoryInstance mem, int retArea,
             Option<ulong> opt)
         {
             if (!opt.HasValue)
             {
-                mem[retArea] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
                 return;
             }
-            mem[retArea] = 1;
-            for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
             MemoryWriter.WriteU64LE(mem, retArea + 8, opt.Value);
         }
 
@@ -162,15 +164,15 @@ namespace Wacs.WASI.Preview2.Http
             var mem = ctx.Memory();
             if (!opt.HasValue)
             {
-                mem[retArea] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
                 return;
             }
-            mem[retArea] = 1;
-            mem[retArea + 1] = 0;
-            mem[retArea + 2] = 0;
-            mem[retArea + 3] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            mem.AsSpan(retArea + 1, 1)[0] = 0;
+            mem.AsSpan(retArea + 2, 1)[0] = 0;
+            mem.AsSpan(retArea + 3, 1)[0] = 0;
             var (ptr, len) = MemoryWriter.WriteUtf8StringAllocated(
-                ctx.Memory, opt.Value, alloc);
+                ctx.Memory(), opt.Value, alloc);
             mem = ctx.Memory();
             MemoryWriter.WriteI32LE(mem, retArea + 4, ptr);
             MemoryWriter.WriteI32LE(mem, retArea + 8, len);
@@ -184,7 +186,7 @@ namespace Wacs.WASI.Preview2.Http
         // generated Method.Method* nested classes. Disc 0–8 are
         // no-payload; disc 9 is other(string).
         private static Method DecodeHttpMethodFlat(
-            byte[] memory, int disc, int ptr, int len)
+            MemoryInstance memory, int disc, int ptr, int len)
         {
             switch (disc)
             {
@@ -199,7 +201,7 @@ namespace Wacs.WASI.Preview2.Http
                 case 8: return new Method.MethodPatch();
                 case 9:
                     var name = Encoding.UTF8.GetString(
-                        memory, ptr, len);
+                        memory.AsSpan(ptr, len));
                     return new Method.MethodOther(name);
                 default:
                     throw new ArgumentException(
@@ -209,7 +211,7 @@ namespace Wacs.WASI.Preview2.Http
 
         // variant scheme (3 cases) flat-decoded.
         private static Scheme DecodeHttpSchemeFlat(
-            byte[] memory, int disc, int ptr, int len)
+            MemoryInstance memory, int disc, int ptr, int len)
         {
             switch (disc)
             {
@@ -217,7 +219,7 @@ namespace Wacs.WASI.Preview2.Http
                 case 1: return new Scheme.SchemeHTTPS();
                 case 2:
                     var name = Encoding.UTF8.GetString(
-                        memory, ptr, len);
+                        memory.AsSpan(ptr, len));
                     return new Scheme.SchemeOther(name);
                 default:
                     throw new ArgumentException(
@@ -266,10 +268,10 @@ namespace Wacs.WASI.Preview2.Http
         {
             var (disc, payload) = MapHttpMethod(method);
             var mem = ctx.Memory();
-            mem[retArea] = disc;
-            mem[retArea + 1] = 0;
-            mem[retArea + 2] = 0;
-            mem[retArea + 3] = 0;
+            mem.AsSpan(retArea, 1)[0] = disc;
+            mem.AsSpan(retArea + 1, 1)[0] = 0;
+            mem.AsSpan(retArea + 2, 1)[0] = 0;
+            mem.AsSpan(retArea + 3, 1)[0] = 0;
             if (payload == null)
             {
                 MemoryWriter.WriteI32LE(mem, retArea + 4, 0);
@@ -277,7 +279,7 @@ namespace Wacs.WASI.Preview2.Http
                 return;
             }
             var (ptr, len) = MemoryWriter.WriteUtf8StringAllocated(
-                ctx.Memory, payload, alloc);
+                ctx.Memory(), payload, alloc);
             mem = ctx.Memory();
             MemoryWriter.WriteI32LE(mem, retArea + 4, ptr);
             MemoryWriter.WriteI32LE(mem, retArea + 8, len);
@@ -291,18 +293,18 @@ namespace Wacs.WASI.Preview2.Http
             var mem = ctx.Memory();
             if (!opt.HasValue)
             {
-                mem[retArea] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
                 return;
             }
-            mem[retArea] = 1;
-            mem[retArea + 1] = 0;
-            mem[retArea + 2] = 0;
-            mem[retArea + 3] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            mem.AsSpan(retArea + 1, 1)[0] = 0;
+            mem.AsSpan(retArea + 2, 1)[0] = 0;
+            mem.AsSpan(retArea + 3, 1)[0] = 0;
             var (disc, payload) = MapHttpScheme(opt.Value);
-            mem[retArea + 4] = disc;
-            mem[retArea + 5] = 0;
-            mem[retArea + 6] = 0;
-            mem[retArea + 7] = 0;
+            mem.AsSpan(retArea + 4, 1)[0] = disc;
+            mem.AsSpan(retArea + 5, 1)[0] = 0;
+            mem.AsSpan(retArea + 6, 1)[0] = 0;
+            mem.AsSpan(retArea + 7, 1)[0] = 0;
             if (payload == null)
             {
                 MemoryWriter.WriteI32LE(mem, retArea + 8, 0);
@@ -310,7 +312,7 @@ namespace Wacs.WASI.Preview2.Http
                 return;
             }
             var (ptr, len) = MemoryWriter.WriteUtf8StringAllocated(
-                ctx.Memory, payload, alloc);
+                ctx.Memory(), payload, alloc);
             mem = ctx.Memory();
             MemoryWriter.WriteI32LE(mem, retArea + 8, ptr);
             MemoryWriter.WriteI32LE(mem, retArea + 12, len);

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/OutgoingHandlerBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Http/OutgoingHandlerBindings.cs
@@ -89,22 +89,22 @@ namespace Wacs.WASI.Preview2.Http
                         {
                             // Spec layout: disc@+0, pad@+1..+7,
                             // handle@+8, zero@+12..+39.
-                            mem[retArea] = 0;
+                            mem.AsSpan(retArea, 1)[0] = 0;
                             for (int p = 1; p < 8; p++)
-                                mem[retArea + p] = 0;
+                                mem.AsSpan(retArea + p, 1)[0] = 0;
                             MemoryWriter.WriteI32LE(mem,
                                 retArea + 8, handle);
                             for (int p = 12; p < 40; p++)
-                                mem[retArea + p] = 0;
+                                mem.AsSpan(retArea + p, 1)[0] = 0;
                         }
                         else
                         {
                             // Simplified: disc@+0, pad@+1..+3,
                             // handle@+4.
-                            mem[retArea] = 0;
-                            mem[retArea + 1] = 0;
-                            mem[retArea + 2] = 0;
-                            mem[retArea + 3] = 0;
+                            mem.AsSpan(retArea, 1)[0] = 0;
+                            mem.AsSpan(retArea + 1, 1)[0] = 0;
+                            mem.AsSpan(retArea + 2, 1)[0] = 0;
+                            mem.AsSpan(retArea + 3, 1)[0] = 0;
                             MemoryWriter.WriteI32LE(mem,
                                 retArea + 4, handle);
                         }
@@ -114,18 +114,18 @@ namespace Wacs.WASI.Preview2.Http
                     // Err path
                     if (spec)
                     {
-                        mem[retArea] = 1;
+                        mem.AsSpan(retArea, 1)[0] = 1;
                         for (int p = 1; p < 8; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                         ErrorCodeEncoder.Write(mem, retArea + 8,
                             result.Err, alloc.Allocate);
                     }
                     else
                     {
                         // Simplified: outer disc=1 only.
-                        mem[retArea] = 1;
+                        mem.AsSpan(retArea, 1)[0] = 1;
                         for (int p = 1; p < 8; p++)
-                            mem[retArea + p] = 0;
+                            mem.AsSpan(retArea + p, 1)[0] = 0;
                     }
                 });
         }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/IoBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/IoBindings.cs
@@ -68,7 +68,7 @@ namespace Wacs.WASI.Preview2.Io
                 {
                     var inst = (Error)errors.Get(handle);
                     var (ptr, len) = MemoryWriter.WriteUtf8StringAllocated(
-                        ctx.Memory, inst.ToDebugString(), alloc);
+                        ctx.Memory(), inst.ToDebugString(), alloc);
                     ctx.WriteI32LE(retArea, ptr);
                     ctx.WriteI32LE(retArea + 4, len);
                 });

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Io/StreamBindings.cs
@@ -60,12 +60,12 @@ namespace Wacs.WASI.Preview2.Io
                 int ptr = data.Length == 0 ? 0
                     : alloc.Allocate(1, data.Length);
                 var mem = ctx.Memory();
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 if (data.Length > 0)
-                    Array.Copy(data, 0, mem, ptr, data.Length);
+                    new ReadOnlySpan<byte>(data, 0, data.Length).CopyTo(mem.AsSpan(ptr, data.Length));
                 MemoryWriter.WriteI32LE(mem, retArea + 4, ptr);
                 MemoryWriter.WriteI32LE(mem, retArea + 8, data.Length);
                 return;
@@ -86,8 +86,8 @@ namespace Wacs.WASI.Preview2.Io
             var mem = ctx.Memory();
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
                 MemoryWriter.WriteU64LE(mem, retArea + 8, r.Ok);
                 return;
             }
@@ -105,8 +105,8 @@ namespace Wacs.WASI.Preview2.Io
             var mem = ctx.Memory();
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                for (int i = 1; i < 12; i++) mem[retArea + i] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                for (int i = 1; i < 12; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
                 return;
             }
             WriteStreamErrorVariant(ctx, errors, retArea, r.Err,
@@ -123,25 +123,25 @@ namespace Wacs.WASI.Preview2.Io
         {
             var mem = ctx.Memory();
             // Outer Err disc + leading padding to payloadOffset.
-            mem[retArea] = 1;
+            mem.AsSpan(retArea, 1)[0] = 1;
             for (int i = 1; i < payloadOffset; i++)
-                mem[retArea + i] = 0;
+                mem.AsSpan(retArea + i, 1)[0] = 0;
             if (err is StreamError.StreamErrorLastOperationFailed lof)
             {
-                mem[retArea + payloadOffset] = 0;   // case disc
+                mem.AsSpan(retArea + payloadOffset, 1)[0] = 0;   // case disc
                 for (int i = payloadOffset + 1;
                      i < handleOffset; i++)
-                    mem[retArea + i] = 0;
+                    mem.AsSpan(retArea + i, 1)[0] = 0;
                 int handle = errors.Allocate(lof.Value);
                 MemoryWriter.WriteI32LE(mem,
                     retArea + handleOffset, handle);
             }
             else  // StreamErrorClosed
             {
-                mem[retArea + payloadOffset] = 1;   // case disc
+                mem.AsSpan(retArea + payloadOffset, 1)[0] = 1;   // case disc
                 for (int i = payloadOffset + 1;
                      i < handleOffset + 4; i++)
-                    mem[retArea + i] = 0;
+                    mem.AsSpan(retArea + i, 1)[0] = 0;
             }
         }
     }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Random/RandomBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Random/RandomBindings.cs
@@ -116,7 +116,8 @@ namespace Wacs.WASI.Preview2.Random
             int ptr = data.Length == 0 ? 0
                 : alloc.Allocate(1, data.Length);
             if (data.Length > 0)
-                Array.Copy(data, 0, ctx.Memory(), ptr, data.Length);
+                new ReadOnlySpan<byte>(data)
+                    .CopyTo(ctx.Memory().AsSpan(ptr, data.Length));
             ctx.WriteI32LE(retArea, ptr);
             ctx.WriteI32LE(retArea + 4, data.Length);
         }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.IpNameLookup.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.IpNameLookup.cs
@@ -59,35 +59,35 @@ namespace Wacs.WASI.Preview2.Sockets
                         WriteErrCode(mem, retArea, 22, r.Err);
                         return;
                     }
-                    mem[retArea] = 0;       // outer Ok
-                    mem[retArea + 1] = 0;   // pad
+                    mem.AsSpan(retArea, 1)[0] = 0;       // outer Ok
+                    mem.AsSpan(retArea + 1, 1)[0] = 0;   // pad
                     var item = r.Ok;
                     if (!item.HasValue)
                     {
-                        mem[retArea + 2] = 0;     // option None
+                        mem.AsSpan(retArea + 2, 1)[0] = 0;     // option None
                         for (int i = 3; i < 22; i++)
-                            mem[retArea + i] = 0;
+                            mem.AsSpan(retArea + i, 1)[0] = 0;
                         return;
                     }
-                    mem[retArea + 2] = 1;       // option Some
-                    mem[retArea + 3] = 0;
+                    mem.AsSpan(retArea + 2, 1)[0] = 1;       // option Some
+                    mem.AsSpan(retArea + 3, 1)[0] = 0;
                     if (item.Value is IpAddress.IpAddressIpv4 v4Case)
                     {
                         var v4 = v4Case.Value;
-                        mem[retArea + 4] = 0;   // variant ipv4
-                        mem[retArea + 5] = 0;
-                        mem[retArea + 6] = v4.Item1;
-                        mem[retArea + 7] = v4.Item2;
-                        mem[retArea + 8] = v4.Item3;
-                        mem[retArea + 9] = v4.Item4;
+                        mem.AsSpan(retArea + 4, 1)[0] = 0;   // variant ipv4
+                        mem.AsSpan(retArea + 5, 1)[0] = 0;
+                        mem.AsSpan(retArea + 6, 1)[0] = v4.Item1;
+                        mem.AsSpan(retArea + 7, 1)[0] = v4.Item2;
+                        mem.AsSpan(retArea + 8, 1)[0] = v4.Item3;
+                        mem.AsSpan(retArea + 9, 1)[0] = v4.Item4;
                         for (int i = 10; i < 22; i++)
-                            mem[retArea + i] = 0;
+                            mem.AsSpan(retArea + i, 1)[0] = 0;
                     }
                     else
                     {
                         var v6 = ((IpAddress.IpAddressIpv6)item.Value).Value;
-                        mem[retArea + 4] = 1;   // variant ipv6
-                        mem[retArea + 5] = 0;
+                        mem.AsSpan(retArea + 4, 1)[0] = 1;   // variant ipv6
+                        mem.AsSpan(retArea + 5, 1)[0] = 0;
                         MemoryWriter.WriteU16LE(mem, retArea + 6, v6.Item1);
                         MemoryWriter.WriteU16LE(mem, retArea + 8, v6.Item2);
                         MemoryWriter.WriteU16LE(mem, retArea + 10, v6.Item3);

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Network.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Network.cs
@@ -43,8 +43,8 @@ namespace Wacs.WASI.Preview2.Sockets
                     // The errHandle borrow is informational; we
                     // don't dereference it in the default impl.
                     var mem = ctx.Memory();
-                    mem[retArea] = 0;       // option None
-                    mem[retArea + 1] = 0;   // payload zeroed
+                    mem.AsSpan(retArea, 1)[0] = 0;       // option None
+                    mem.AsSpan(retArea + 1, 1)[0] = 0;   // payload zeroed
                 });
         }
 

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Tcp.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Tcp.cs
@@ -104,10 +104,10 @@ namespace Wacs.WASI.Preview2.Sockets
                     if (r.IsOk)
                     {
                         var (inS, outS) = r.Ok;
-                        mem[retArea] = 0;
-                        mem[retArea + 1] = 0;
-                        mem[retArea + 2] = 0;
-                        mem[retArea + 3] = 0;
+                        mem.AsSpan(retArea, 1)[0] = 0;
+                        mem.AsSpan(retArea + 1, 1)[0] = 0;
+                        mem.AsSpan(retArea + 2, 1)[0] = 0;
+                        mem.AsSpan(retArea + 3, 1)[0] = 0;
                         MemoryWriter.WriteI32LE(mem, retArea + 4,
                             ins.Allocate((InputStream)inS));
                         MemoryWriter.WriteI32LE(mem, retArea + 8,
@@ -150,10 +150,10 @@ namespace Wacs.WASI.Preview2.Sockets
                     if (r.IsOk)
                     {
                         var (s, inS, outS) = r.Ok;
-                        mem[retArea] = 0;
-                        mem[retArea + 1] = 0;
-                        mem[retArea + 2] = 0;
-                        mem[retArea + 3] = 0;
+                        mem.AsSpan(retArea, 1)[0] = 0;
+                        mem.AsSpan(retArea + 1, 1)[0] = 0;
+                        mem.AsSpan(retArea + 2, 1)[0] = 0;
+                        mem.AsSpan(retArea + 3, 1)[0] = 0;
                         MemoryWriter.WriteI32LE(mem, retArea + 4,
                             socks.Allocate((TcpSocket)s));
                         MemoryWriter.WriteI32LE(mem, retArea + 8,

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Udp.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.Udp.cs
@@ -89,10 +89,10 @@ namespace Wacs.WASI.Preview2.Sockets
                     if (r.IsOk)
                     {
                         var (inS, outS) = r.Ok;
-                        mem[retArea] = 0;
-                        mem[retArea + 1] = 0;
-                        mem[retArea + 2] = 0;
-                        mem[retArea + 3] = 0;
+                        mem.AsSpan(retArea, 1)[0] = 0;
+                        mem.AsSpan(retArea + 1, 1)[0] = 0;
+                        mem.AsSpan(retArea + 2, 1)[0] = 0;
+                        mem.AsSpan(retArea + 3, 1)[0] = 0;
                         MemoryWriter.WriteI32LE(mem, retArea + 4,
                             ins.Allocate((IncomingDatagramStream)inS));
                         MemoryWriter.WriteI32LE(mem, retArea + 8,
@@ -212,8 +212,9 @@ namespace Wacs.WASI.Preview2.Sockets
                             : alloc.Allocate(1, dg.Data.Length);
                         var memBuf = ctx.Memory();
                         if (dg.Data.Length > 0)
-                            Array.Copy(dg.Data, 0, memBuf, dataPtr,
-                                dg.Data.Length);
+                            new ReadOnlySpan<byte>(dg.Data)
+                                .CopyTo(memBuf.AsSpan(dataPtr,
+                                    dg.Data.Length));
                         MemoryWriter.WriteI32LE(memBuf, elemBase, dataPtr);
                         MemoryWriter.WriteI32LE(memBuf, elemBase + 4,
                             dg.Data.Length);
@@ -223,10 +224,10 @@ namespace Wacs.WASI.Preview2.Sockets
                             dg.RemoteAddress);
                     }
                     mem = ctx.Memory();
-                    mem[retArea] = 0;
-                    mem[retArea + 1] = 0;
-                    mem[retArea + 2] = 0;
-                    mem[retArea + 3] = 0;
+                    mem.AsSpan(retArea, 1)[0] = 0;
+                    mem.AsSpan(retArea + 1, 1)[0] = 0;
+                    mem.AsSpan(retArea + 2, 1)[0] = 0;
+                    mem.AsSpan(retArea + 3, 1)[0] = 0;
                     MemoryWriter.WriteI32LE(mem, retArea + 4, arrayPtr);
                     MemoryWriter.WriteI32LE(mem, retArea + 8, count);
                 });
@@ -278,35 +279,35 @@ namespace Wacs.WASI.Preview2.Sockets
                             memory, elemBase + 4);
                         var data = new byte[dataLen];
                         if (dataLen > 0)
-                            Array.Copy(memory, dataPtr, data, 0, dataLen);
+                            memory.AsSpan(dataPtr, dataLen).CopyTo(data);
                         Option<IpSocketAddress> remote =
                             Option<IpSocketAddress>.None;
-                        if (memory[elemBase + 8] != 0)
+                        if (memory.AsSpan(elemBase + 8, 1)[0] != 0)
                         {
-                            byte vDisc = memory[elemBase + 12];
+                            byte vDisc = memory.AsSpan(elemBase + 12, 1)[0];
                             if (vDisc == 0)
                             {
-                                ushort port = (ushort)(memory[elemBase + 16]
-                                    | (memory[elemBase + 17] << 8));
+                                ushort port = (ushort)(memory.AsSpan(elemBase + 16, 1)[0]
+                                    | (memory.AsSpan(elemBase + 17, 1)[0] << 8));
                                 remote = Option<IpSocketAddress>.Some(
                                     new IpSocketAddress.IpSocketAddressIpv4(
                                         new Ipv4SocketAddress {
                                             Port = port,
                                             Address = (
-                                                memory[elemBase + 18],
-                                                memory[elemBase + 19],
-                                                memory[elemBase + 20],
-                                                memory[elemBase + 21]),
+                                                memory.AsSpan(elemBase + 18, 1)[0],
+                                                memory.AsSpan(elemBase + 19, 1)[0],
+                                                memory.AsSpan(elemBase + 20, 1)[0],
+                                                memory.AsSpan(elemBase + 21, 1)[0]),
                                         }));
                             }
                             else
                             {
-                                ushort port = (ushort)(memory[elemBase + 16]
-                                    | (memory[elemBase + 17] << 8));
+                                ushort port = (ushort)(memory.AsSpan(elemBase + 16, 1)[0]
+                                    | (memory.AsSpan(elemBase + 17, 1)[0] << 8));
                                 uint flow = (uint)MemoryReader.ReadI32LE(
                                     memory, elemBase + 20);
-                                ushort A(int off) => (ushort)(memory[off]
-                                    | (memory[off + 1] << 8));
+                                ushort A(int off) => (ushort)(memory.AsSpan(off, 1)[0]
+                                    | (memory.AsSpan(off + 1, 1)[0] << 8));
                                 uint scope = (uint)MemoryReader.ReadI32LE(
                                     memory, elemBase + 40);
                                 remote = Option<IpSocketAddress>.Some(

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Sockets/SocketsBindings.cs
@@ -11,6 +11,8 @@ using Wacs.Core.Runtime;
 using Wacs.WASI.Preview2.HostBinding;
 using Wacs.WASI.Preview2.HostBinding.CanonicalAbi;
 
+using Wacs.Core.Runtime.Types;
+
 namespace Wacs.WASI.Preview2.Sockets
 {
     /// <summary>
@@ -104,63 +106,63 @@ namespace Wacs.WASI.Preview2.Sockets
 
         // Encode the Err side: outer disc=1 at retArea+0,
         // ErrorCode byte at retArea+1, zero through retArea+totalSize.
-        private static void WriteErrCode(byte[] mem, int retArea,
+        private static void WriteErrCode(MemoryInstance mem, int retArea,
             int totalSize, ErrorCode code)
         {
-            mem[retArea] = 1;
-            mem[retArea + 1] = (byte)code;
-            for (int i = 2; i < totalSize; i++) mem[retArea + i] = 0;
+            mem.AsSpan(retArea, 1)[0] = 1;
+            mem.AsSpan(retArea + 1, 1)[0] = (byte)code;
+            for (int i = 2; i < totalSize; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
         }
 
         // result<_, error-code>: 2 bytes (1 disc + 1 byte).
-        private static void WriteResultUnit(byte[] mem, int retArea,
+        private static void WriteResultUnit(MemoryInstance mem, int retArea,
             Result<Unit, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
                 return;
             }
             WriteErrCode(mem, retArea, 2, r.Err);
         }
 
         // result<bool, error-code>: 2 bytes (disc + bool).
-        private static void WriteResultBool(byte[] mem, int retArea,
+        private static void WriteResultBool(MemoryInstance mem, int retArea,
             Result<bool, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = r.Ok ? (byte)1 : (byte)0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = r.Ok ? (byte)1 : (byte)0;
                 return;
             }
             WriteErrCode(mem, retArea, 2, r.Err);
         }
 
         // result<u8, error-code>: 2 bytes (disc + u8).
-        private static void WriteResultU8(byte[] mem, int retArea,
+        private static void WriteResultU8(MemoryInstance mem, int retArea,
             Result<byte, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = r.Ok;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = r.Ok;
                 return;
             }
             WriteErrCode(mem, retArea, 2, r.Err);
         }
 
         // result<u32, error-code>: 8 bytes (disc + 3 pad + u32).
-        private static void WriteResultU32(byte[] mem, int retArea,
+        private static void WriteResultU32(MemoryInstance mem, int retArea,
             Result<uint, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 MemoryWriter.WriteU32LE(mem, retArea + 4, r.Ok);
                 return;
             }
@@ -168,13 +170,13 @@ namespace Wacs.WASI.Preview2.Sockets
         }
 
         // result<u64, error-code>: 16 bytes (disc + 7 pad + u64).
-        private static void WriteResultU64(byte[] mem, int retArea,
+        private static void WriteResultU64(MemoryInstance mem, int retArea,
             Result<ulong, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                for (int i = 1; i < 8; i++) mem[retArea + i] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                for (int i = 1; i < 8; i++) mem.AsSpan(retArea + i, 1)[0] = 0;
                 MemoryWriter.WriteU64LE(mem, retArea + 8, r.Ok);
                 return;
             }
@@ -186,15 +188,15 @@ namespace Wacs.WASI.Preview2.Sockets
         // whose Ok-side handle has already been allocated via
         // the appropriate resource table; the encoder just
         // writes the handle bits.
-        private static void WriteResultHandle(byte[] mem, int retArea,
+        private static void WriteResultHandle(MemoryInstance mem, int retArea,
             Result<int, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 MemoryWriter.WriteI32LE(mem, retArea + 4, r.Ok);
                 return;
             }
@@ -242,32 +244,32 @@ namespace Wacs.WASI.Preview2.Sockets
         //   ipv4 case: port(u16)@+4, address(4B)@+6 — 6 bytes used.
         //   ipv6 case: port@+4, 2B pad@+6, flow(u32)@+8,
         //     8×u16(16B)@+12, scope(u32)@+28 — 28 bytes used.
-        private static void WriteIpSocketAddress(byte[] mem, int ptr,
+        private static void WriteIpSocketAddress(MemoryInstance mem, int ptr,
             IpSocketAddress addr)
         {
             if (addr is IpSocketAddress.IpSocketAddressIpv4 v4Case)
             {
                 var v4 = v4Case.Value;
-                mem[ptr] = 0;
-                mem[ptr + 1] = 0;
-                mem[ptr + 2] = 0;
-                mem[ptr + 3] = 0;
+                mem.AsSpan(ptr, 1)[0] = 0;
+                mem.AsSpan(ptr + 1, 1)[0] = 0;
+                mem.AsSpan(ptr + 2, 1)[0] = 0;
+                mem.AsSpan(ptr + 3, 1)[0] = 0;
                 MemoryWriter.WriteU16LE(mem, ptr + 4, v4.Port);
-                mem[ptr + 6] = v4.Address.Item1;
-                mem[ptr + 7] = v4.Address.Item2;
-                mem[ptr + 8] = v4.Address.Item3;
-                mem[ptr + 9] = v4.Address.Item4;
+                mem.AsSpan(ptr + 6, 1)[0] = v4.Address.Item1;
+                mem.AsSpan(ptr + 7, 1)[0] = v4.Address.Item2;
+                mem.AsSpan(ptr + 8, 1)[0] = v4.Address.Item3;
+                mem.AsSpan(ptr + 9, 1)[0] = v4.Address.Item4;
                 return;
             }
             var v6Case = (IpSocketAddress.IpSocketAddressIpv6)addr;
             var v6 = v6Case.Value;
-            mem[ptr] = 1;
-            mem[ptr + 1] = 0;
-            mem[ptr + 2] = 0;
-            mem[ptr + 3] = 0;
+            mem.AsSpan(ptr, 1)[0] = 1;
+            mem.AsSpan(ptr + 1, 1)[0] = 0;
+            mem.AsSpan(ptr + 2, 1)[0] = 0;
+            mem.AsSpan(ptr + 3, 1)[0] = 0;
             MemoryWriter.WriteU16LE(mem, ptr + 4, v6.Port);
-            mem[ptr + 6] = 0;
-            mem[ptr + 7] = 0;
+            mem.AsSpan(ptr + 6, 1)[0] = 0;
+            mem.AsSpan(ptr + 7, 1)[0] = 0;
             MemoryWriter.WriteU32LE(mem, ptr + 8, v6.FlowInfo);
             MemoryWriter.WriteU16LE(mem, ptr + 12, v6.Address.Item1);
             MemoryWriter.WriteU16LE(mem, ptr + 14, v6.Address.Item2);
@@ -282,15 +284,15 @@ namespace Wacs.WASI.Preview2.Sockets
 
         // result<ip-socket-address, error-code>: 36 bytes.
         // outer disc=0 + 3 pad + ip-socket-address (32B) at +4.
-        private static void WriteResultIpSocketAddress(byte[] mem, int retArea,
+        private static void WriteResultIpSocketAddress(MemoryInstance mem, int retArea,
             Result<IpSocketAddress, ErrorCode> r)
         {
             if (r.IsOk)
             {
-                mem[retArea] = 0;
-                mem[retArea + 1] = 0;
-                mem[retArea + 2] = 0;
-                mem[retArea + 3] = 0;
+                mem.AsSpan(retArea, 1)[0] = 0;
+                mem.AsSpan(retArea + 1, 1)[0] = 0;
+                mem.AsSpan(retArea + 2, 1)[0] = 0;
+                mem.AsSpan(retArea + 3, 1)[0] = 0;
                 WriteIpSocketAddress(mem, retArea + 4, r.Ok);
                 return;
             }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2</AssemblyName>
-        <AssemblyVersion>0.3.2</AssemblyVersion>
-        <Version>0.3.2</Version>
+        <AssemblyVersion>0.4.0</AssemblyVersion>
+        <Version>0.4.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2</AssemblyName>
-        <AssemblyVersion>0.3.1</AssemblyVersion>
-        <Version>0.3.1</Version>
+        <AssemblyVersion>0.3.2</AssemblyVersion>
+        <Version>0.3.2</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>


### PR DESCRIPTION
## Summary
- **Gap 10 — descriptor.stat lifting**: fixes `descriptor.stat-at` returning size:0 for files. The IImports stub was silently catching record-with-option-fields and returning the zero-default; the lift path now bubbles real metadata (so `std::fs::metadata().len()` is correct).
- **Gap 11 — post-grow byte[] safety**: fixes input-stream.read AOOR for buffers that cross a page boundary. cabi_realloc + memory.grow had been invalidating a captured `byte[]` reference; canonical-ABI store sites now refresh through `MemoryInstance` after every grow.
- **Gap 12 — storage modes + memory64**: introduces `RuntimeOptions.MemoryStorage`. `ManagedArray` is the default (byte[], ~2 GiB cap); `NativePointer` swaps in `NativeMemory.AllocZeroed` backing (no Array.MaxLength cap, can carry the wasm32 4 GiB ceiling and memory64 modules). Bounds checks moved to wrap-safe unsigned form covering memory32 + memory64. `wacs run --native-memory` plumbs the mode through interpreter, transpiler, and component-model paths end-to-end. `WacsHostMemory` is mode-aware so wasip1/wasip2 host bindings work transparently against either backing.

## Package version bumps (minor)
- WACS 0.12.4 → 0.13.0
- WACS.Cli 1.4.2 → 1.5.0
- WACS.Transpiler.Lib 0.7.5 → 0.8.0
- WACS.ComponentModel 0.2.1 → 0.3.0
- WACS.WASI.Preview2 0.3.2 → 0.4.0
- WACS.WASI.Preview1 0.12.1 → 0.13.0
- WACS.HostBindings.Abstractions 0.2.1 → 0.3.0

## Test plan
- [x] Wacs.Core.Test — 394/394 passing
- [x] Wacs.Transpiler.Test — 752/752 passing (1 skipped)
- [x] Wacs.ComponentModel.Test — 350/350 passing
- [x] Wacs.WASI.Preview2.Test — 189/189 passing
- [x] Wacs.WASI.Preview1.Test — 72/72 passing
- [x] Wacs.HostBindings.Test — 14/14 passing
- [x] Spec.Test — 770/770 passing (2 skipped)
- [x] memory64 end-to-end coverage in MemoryNativePointerEndToEndTests
- [x] PrimitiveStoreGrowTests covers the cabi_realloc grow-staleness path
- [x] WacsHostMemoryTests cover NativePointer-mode adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)