### PR TITLE
Gaps 24-27: LlamaSharp / GGUF on the transpiler-direct-link path (end-to-end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## WACS.Cli 1.5.16 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.4 — gaps 24 + 25: LlamaSharp / GGUF on the transpiler-direct-link path
+## WACS.Cli 1.5.17 / WACS.Transpiler.Lib 0.8.11 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.4 — gaps 24 + 25 + 26: LlamaSharp / GGUF on the transpiler-direct-link path
 
 The wasi-nn LlamaSharp/GGUF harness (`guest-llm/`, Qwen2.5 0.5B
 Instruct Q4_K_M) tripped `"NotFound: no named-model resolver
@@ -61,6 +61,32 @@ with out-of-bounds memory access. The new `--wasi-nn-backend`
 flag suggested in round-19 isn't needed — the implicit
 `--bind` walk covers the same UX.
 
+### Pre-load `--bind` assemblies before scope construction (gap 26)
+
+Round-21 verification revealed that the `TryLoadAssembly`
+AppDomain fallback was correct — but the auto-wire ran during
+`WasiPreview2RuntimeScope` construction in
+`ExecuteComponentTranspiled`, which fires from
+`configureImports`. `--bind` doesn't run until later, in
+`ApplyBindings` (intentionally, so explicit `BindHostFunction`
+shims can override the wasip2 trap-stubs). At scope-construction
+time, `--bind`-supplied assemblies aren't in AppDomain yet —
+so the round-21 walk has nothing to find.
+
+Fix: split the load step from the bind step. New
+`BindingLoader.LoadAssembly(string)` returns just the resolved
+`Assembly` without activating any `IBindable` types; existing
+`LoadFromAssembly(string)` delegates to it. New
+`PreloadBindAssemblies` in `RunHandler` calls
+`BindingLoader.LoadAssembly` for every `--bind` / shorthand
+entry BEFORE scope construction. The actual `BindToRuntime`
+calls still defer to `ApplyBindings` (preserving override
+semantics); `Assembly.LoadFrom` is idempotent on path so the
+second pass is a no-op.
+
+The two-phase load-then-bind pattern matches what round 1 /
+round 7 already established for the IBindable lifecycle.
+
 ### `TryLoadAssembly` AppDomain fallback (gap 25)
 
 Round-20 verification surfaced gap 25: with the LoadByName
@@ -111,8 +137,11 @@ utility yet.
 - `WACS.WASI.Preview2.DependencyInjection` 0.1.2 → **0.1.4**
   (LlamaSharp auto-wire in `WasiPreview2RuntimeScope` +
   `TryLoadAssembly` AppDomain fallback)
-- `WACS.Cli` 1.5.14 → **1.5.16** (release event +
-  `--bind` → DI-sibling auto-pull)
+- `WACS.Transpiler.Lib` 0.8.10 → **0.8.11**
+  (`BindingLoader.LoadAssembly` load-only entry point)
+- `WACS.Cli` 1.5.14 → **1.5.17** (release event +
+  `--bind` → DI-sibling auto-pull +
+  `PreloadBindAssemblies` ordering fix)
 
 (Untouched: `WACS`, `WASI.Preview1`, `.Preview2`, `.WASI.NN`,
 `.WASI.NN.OnnxRuntime`, `.WASI.NN.LlamaSharp`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## WACS.Cli 1.5.15 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.3 — gap 24: `LoadByName` honors `LoadByNameBackend`; LlamaSharp auto-wires; `--bind` pulls WASI.NN siblings
+## WACS.Cli 1.5.16 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.4 — gaps 24 + 25: LlamaSharp / GGUF on the transpiler-direct-link path
 
 The wasi-nn LlamaSharp/GGUF harness (`guest-llm/`, Qwen2.5 0.5B
 Instruct Q4_K_M) tripped `"NotFound: no named-model resolver
@@ -61,6 +61,33 @@ with out-of-bounds memory access. The new `--wasi-nn-backend`
 flag suggested in round-19 isn't needed — the implicit
 `--bind` walk covers the same UX.
 
+### `TryLoadAssembly` AppDomain fallback (gap 25)
+
+Round-20 verification surfaced gap 25: with the LoadByName
+parity fix in, the auto-wire still silently no-op'd for
+`--bind <path-to-LlamaSharp.dll>` because
+`WasiPreview2RuntimeScope.TryLoadAssembly` used
+`Assembly.Load(name)` only. `Assembly.Load` searches the
+default load context's by-name registry; `--bind <path>`
+lands the assembly via `Assembly.LoadFrom` into the
+`LoadFromContext`, where the by-name lookup misses.
+
+Same architectural shape as the round-18 fix in
+`HostPackageResolver.TryFindResourceImpl`. `TryLoadAssembly`
+now walks `AppDomain.CurrentDomain.GetAssemblies()` on miss,
+matching by `Assembly.GetName().Name` (case-insensitive). The
+fallback skips dynamic assemblies and catches malformed-
+metadata exceptions from collectable contexts so a single
+hiccup can't blank out the search.
+
+The `TryFindResourceImpl` AppDomain walk and the new
+`TryLoadAssembly` AppDomain walk are deliberately
+duplicated (both ~25 LOC) rather than extracted into a
+shared helper — they're in different assemblies (resolver in
+`Wacs.Transpiler.Lib`, scope in `Wacs.WASI.Preview2.DependencyInjection`)
+and the cross-package coupling isn't worth a shared
+utility yet.
+
 ### Test surface
 
 - `Wacs.WASI.NN.Test/GraphFuncsImplLoadByNameTests` (3 tests):
@@ -81,9 +108,10 @@ flag suggested in round-19 isn't needed — the implicit
 
 - `WACS.WASI.NN.DependencyInjection` 0.2.0 → **0.2.1**
   (LoadByName routes through LoadByNameBackend)
-- `WACS.WASI.Preview2.DependencyInjection` 0.1.2 → **0.1.3**
-  (LlamaSharp auto-wire in `WasiPreview2RuntimeScope`)
-- `WACS.Cli` 1.5.14 → **1.5.15** (release event +
+- `WACS.WASI.Preview2.DependencyInjection` 0.1.2 → **0.1.4**
+  (LlamaSharp auto-wire in `WasiPreview2RuntimeScope` +
+  `TryLoadAssembly` AppDomain fallback)
+- `WACS.Cli` 1.5.14 → **1.5.16** (release event +
   `--bind` → DI-sibling auto-pull)
 
 (Untouched: `WACS`, `WASI.Preview1`, `.Preview2`, `.WASI.NN`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,96 @@
 # Changelog
 
+## WACS.Cli 1.5.15 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.3 — gap 24: `LoadByName` honors `LoadByNameBackend`; LlamaSharp auto-wires; `--bind` pulls WASI.NN siblings
+
+The wasi-nn LlamaSharp/GGUF harness (`guest-llm/`, Qwen2.5 0.5B
+Instruct Q4_K_M) tripped `"NotFound: no named-model resolver
+configured"` at the first `compute(...)` even though
+`load_by_name(...)` had returned `Ok` upstream. The DI bundle's
+`GraphFuncsImpl.LoadByName` only checked `NamedModelResolver` +
+`Backends`, never the sibling `LoadByNameBackend` field that the
+WitBindings path (`WasiNNHost.LoadGraphByNameDispatch`) uses for
+backends with internal name registries.
+
+### `GraphFuncsImpl.LoadByName` parity with `WasiNNHost`
+
+`Wacs.WASI.NN.DependencyInjection/GraphFuncsImpl.cs` now mirrors
+`WasiNNHost.LoadGraphByNameDispatch`:
+
+```csharp
+if (_config.LoadByNameBackend != null)
+    return Result<...>.FromOk(new Graph(
+        _config.LoadByNameBackend.LoadGraphByName(name, ExecutionTarget.CPU)));
+// fall through to NamedModelResolver → bytes → backend
+```
+
+LlamaSharp's `LoadGraph(builders)` always traps
+`UnsupportedOperation` (a multi-GB GGUF passed through canonical-
+ABI lift would force a multi-GB host copy on every load); the
+direct `LoadByNameBackend` path lets the backend resolve models
+through its own registry without that round-trip. Closes gap 24
+architecturally.
+
+### LlamaSharp auto-wire in `WasiPreview2RuntimeScope`
+
+Round-14 added `BuildOnnxConfigureCallback` to wire
+`OnnxBackend` into the DI bundle's `WasiNNConfiguration` at
+scope-construction time. Round-20 generalizes the pattern: a
+sibling `BuildLlamaSharpConfigureCallback` detects
+`Wacs.WASI.NN.LlamaSharp.LlamaSharpBackend`, builds an
+env-driven registry from `WACS_WASINN_GGUF_DIR` (mirrors
+`WasiNNLlamaSharpBindable`'s scan), instantiates the backend
+via `FromPaths(registry)`, and wires it into BOTH
+`Backends[GGML]` AND `LoadByNameBackend`. The two callbacks
+combine via `Delegate.Combine` into one multicast configure that
+runs against the same options instance.
+
+`CombineCallbacks` is generic — adding a new wasi-nn backend
+auto-wire requires one new `BuildXxxConfigureCallback` plus a
+line in `ReflectivelyAddWasiNN`'s combine call.
+
+### `--bind` auto-pulls DI siblings for `Wacs.WASI.NN.*`
+
+Sub-gap 24a: when `--bind` resolves an assembly whose identity
+starts with `Wacs.WASI.NN.` (LlamaSharp / MLNet / future
+backends), `RunHandler.ResolveHostPackages` now adds
+`Wacs.WASI.NN` + `Wacs.WASI.NN.DependencyInjection` to
+host-packages automatically. Mirrors round-18's `--wasi-nn`
+plumbing for the OnnxRuntime case. Without it, the resolver had
+incomplete WitSource coverage and post-`compute` lifts trapped
+with out-of-bounds memory access. The new `--wasi-nn-backend`
+flag suggested in round-19 isn't needed — the implicit
+`--bind` walk covers the same UX.
+
+### Test surface
+
+- `Wacs.WASI.NN.Test/GraphFuncsImplLoadByNameTests` (3 tests):
+  `LoadByNameBackend` direct-path, byte-flow fallback when
+  `LoadByNameBackend` null, and the diagnostic NotFound when
+  neither is wired (asserts the error message mentions
+  `LoadByNameBackend` so the failure mode is discoverable).
+- `Wacs.WASI.NN.LlamaSharp.Test/WasiPreview2RuntimeScopeLlamaSharpTests`:
+  the auto-wire fires on a real `WasiPreview2RuntimeScope`
+  construction; `IGraphFuncs.LoadByName` no longer reports the
+  pre-fix "no named-model resolver" symptom. The test project
+  gains references to `Wacs.WASI.NN.DependencyInjection` and
+  `Wacs.WASI.Preview2.DependencyInjection` (the only test
+  project where all four needed packages co-exist without a
+  cycle).
+
+### Versions
+
+- `WACS.WASI.NN.DependencyInjection` 0.2.0 → **0.2.1**
+  (LoadByName routes through LoadByNameBackend)
+- `WACS.WASI.Preview2.DependencyInjection` 0.1.2 → **0.1.3**
+  (LlamaSharp auto-wire in `WasiPreview2RuntimeScope`)
+- `WACS.Cli` 1.5.14 → **1.5.15** (release event +
+  `--bind` → DI-sibling auto-pull)
+
+(Untouched: `WACS`, `WASI.Preview1`, `.Preview2`, `.WASI.NN`,
+`.WASI.NN.OnnxRuntime`, `.WASI.NN.LlamaSharp`,
+`.WASI.NN.MLNet`, `WACS.Transpiler.Lib`, `WACS.ComponentModel`,
+`WACS.HostBindings.Abstractions`.)
+
 ## WACS.Cli 1.5.14 / WACS.Transpiler.Lib 0.8.10 — `[constructor]X` SourceGen-shape impl-class discovery falls back to AppDomain (gap 23)
 
 The wasi-nn SLM's `Tensor::new(dimensions, ty, data)` returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## WACS.Cli 1.5.17 / WACS.Transpiler.Lib 0.8.11 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.4 — gaps 24 + 25 + 26: LlamaSharp / GGUF on the transpiler-direct-link path
+## WACS.Cli 1.5.18 / WACS.Transpiler.Lib 0.8.11 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.NN.LlamaSharp 0.2.1 / WACS.WASI.NN.MLNet 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.4 — gaps 24 + 25 + 26 + 27: LlamaSharp / GGUF on the transpiler-direct-link path (end-to-end)
 
 The wasi-nn LlamaSharp/GGUF harness (`guest-llm/`, Qwen2.5 0.5B
 Instruct Q4_K_M) tripped `"NotFound: no named-model resolver
@@ -60,6 +60,43 @@ incomplete WitSource coverage and post-`compute` lifts trapped
 with out-of-bounds memory access. The new `--wasi-nn-backend`
 flag suggested in round-19 isn't needed — the implicit
 `--bind` walk covers the same UX.
+
+### `EnableDynamicLoading` on backend csprojs (gap 27)
+
+Round-22 verification confirmed gaps 24-26 closed correctly —
+end-to-end Qwen2.5 0.5B GGUF inference produced real output
+through `wacs run --wasip2 --bind <LlamaSharp.dll>` after manual
+deps staging. The remaining hurdle was a packaging issue: the
+`Wacs.WASI.NN.LlamaSharp` library project's bin emitted only the
+backend assembly + project refs, NOT the upstream NuGet
+transitives (`LLamaSharp.dll`, `LLamaSharp.Backend.Cpu`'s
+RID-specific natives, `Microsoft.Extensions.*`). At
+`Assembly.LoadFrom(<path>)` time, the LoadFromContext resolver
+read deps.json but couldn't satisfy the deps from the runtime's
+TPA list (Wacs.Console doesn't carry LlamaSharp) or the empty
+LoadFromContext directory.
+
+Fix: `<EnableDynamicLoading>true</EnableDynamicLoading>` in
+`Wacs.WASI.NN.LlamaSharp.csproj` (and the symmetric
+`Wacs.WASI.NN.MLNet.csproj`). MSBuild now copies every NuGet
+managed dep + RID-specific native lib into the project's bin,
+and the deps.json points at them locally. Bin grows from
+~10 MB to ~150 MB (LlamaSharp's natives are chunky); acceptable
+for a backend whose entire purpose is loading multi-GB models.
+
+ONNX backend takes a different path — round-1 already bundles
+`Wacs.WASI.NN.OnnxRuntime` directly into `Wacs.Console`'s csproj
+via `ExcludeAssets="compile"`, which is why `--wasi-nn` works
+bare-name. Gap 27's fix is for the embedder-supplies-the-backend
+flow (`--bind <path>`), not the bundled-default-backend flow.
+
+Documentation: `docs/COMPONENT_CHAINING.md` gains a fully worked
+GGUF inference example walking through the build + run + how
+each prior fix participates. The Wacs.WASI.NN README's CLI
+quick-start now points at the explicit-path form (the bare-name
+`--bind Wacs.WASI.NN.LlamaSharp` only works when the assembly
+is on the CLI's TPA, which it isn't unless an embedder bundles
+it explicitly).
 
 ### Pre-load `--bind` assemblies before scope construction (gap 26)
 
@@ -134,12 +171,19 @@ utility yet.
 
 - `WACS.WASI.NN.DependencyInjection` 0.2.0 → **0.2.1**
   (LoadByName routes through LoadByNameBackend)
+- `WACS.WASI.NN.LlamaSharp` 0.2.0 → **0.2.1**
+  (EnableDynamicLoading: bin carries the backend's NuGet
+  transitives so `--bind <path>` LoadFromContext probes
+  resolve)
+- `WACS.WASI.NN.MLNet` 0.2.0 → **0.2.1**
+  (EnableDynamicLoading: same shape — symmetric prep for the
+  embedder-supplies-the-backend flow)
 - `WACS.WASI.Preview2.DependencyInjection` 0.1.2 → **0.1.4**
   (LlamaSharp auto-wire in `WasiPreview2RuntimeScope` +
   `TryLoadAssembly` AppDomain fallback)
 - `WACS.Transpiler.Lib` 0.8.10 → **0.8.11**
   (`BindingLoader.LoadAssembly` load-only entry point)
-- `WACS.Cli` 1.5.14 → **1.5.17** (release event +
+- `WACS.Cli` 1.5.14 → **1.5.18** (release event +
   `--bind` → DI-sibling auto-pull +
   `PreloadBindAssemblies` ordering fix)
 

--- a/Wacs.Console/Wacs.Console/README.md
+++ b/Wacs.Console/Wacs.Console/README.md
@@ -198,7 +198,7 @@ wacs run app.wasm --bind ./MyGameHost.dll
 | `--bind <asm>` | — | Load `IBindable` host packages. Accepts a file path (`Assembly.LoadFrom`) or assembly name (`Assembly.Load`). Repeat or comma-separate. |
 | `--host-package <name>` | — | Component-mode `[WitSource]` host package(s). Accepts assembly name or file path. |
 | `--wasip2` | off | Shorthand: `--host-package Wacs.WASI.Preview2 + Wacs.WASI.Preview2.DependencyInjection`. The DI sibling carries the SourceGen-shape impl classes the transpiler instantiates for `[constructor]X`; both halves are needed for direct-link emit. See [`docs/COMPONENT_CHAINING.md`](../../docs/COMPONENT_CHAINING.md). |
-| `--wasi-nn` | off | Shorthand: adds `Wacs.WASI.NN + Wacs.WASI.NN.DependencyInjection + Wacs.WASI.NN.OnnxRuntime`. ONNX is the default backend; for ML.NET / LlamaSharp use `--bind <package>` directly. The composite `WasiPreview2NNBundle` is auto-discovered when both `--wasip2` and `--wasi-nn` are set. |
+| `--wasi-nn` | off | Shorthand: adds `Wacs.WASI.NN + Wacs.WASI.NN.DependencyInjection + Wacs.WASI.NN.OnnxRuntime`. ONNX is the default backend; for ML.NET / LlamaSharp use `--bind <package>` directly — `--bind` auto-pulls `Wacs.WASI.NN + .DependencyInjection` when the bound assembly's identity starts with `Wacs.WASI.NN.` (gap 24a). The composite `WasiPreview2NNBundle` is auto-discovered when both `--wasip2` and a wasi-nn backend are wired. |
 | `--wasi-threads` | off | Shorthand `--bind Wacs.WASI.Threads`. Wires `wasi:thread-spawn`; module must declare/import shared memory and export `wasi_thread_start (param i32 i32)`. |
 | `--profile` | off | JetBrains dotTrace measure-profiler session. |
 | `--log-gas` | off | Print total instructions executed. |

--- a/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
+++ b/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
@@ -886,6 +886,21 @@ namespace Wacs.Console.Verbs
                 // verification).
                 names.Add("Wacs.WASI.NN.DependencyInjection");
             }
+            // --bind that resolves to a Wacs.WASI.NN.* sibling
+            // (LlamaSharp / MLNet) implicitly needs the same DI +
+            // typed-surface packages on host-packages — otherwise
+            // the resolver ends up with incomplete WitSource
+            // coverage and post-compute lifts trap with
+            // out-of-bounds memory access (gap 24a, round-19
+            // sibling observation). Mirrors the round-18 plumbing
+            // for `--wasi-nn` (the OnnxRuntime case).
+            if (BindReferencesWasiNNFamily(opts))
+            {
+                if (!names.Contains("Wacs.WASI.NN"))
+                    names.Add("Wacs.WASI.NN");
+                if (!names.Contains("Wacs.WASI.NN.DependencyInjection"))
+                    names.Add("Wacs.WASI.NN.DependencyInjection");
+            }
             foreach (var n in opts.HostPackage ?? Enumerable.Empty<string>())
             {
                 if (string.IsNullOrWhiteSpace(n)) continue;
@@ -914,6 +929,32 @@ namespace Wacs.Console.Verbs
                 asms.Add(asm);
             }
             return asms;
+        }
+
+        // True when any --bind entry references a
+        // `Wacs.WASI.NN.*` assembly — by name (`--bind
+        // Wacs.WASI.NN.LlamaSharp`) or by file path whose basename
+        // starts with that prefix (`--bind /.../Wacs.WASI.NN.MLNet.dll`).
+        // Used to auto-pull the WASI.NN typed-surface + DI sibling
+        // packages onto host-packages so the resolver has complete
+        // WitSource coverage for the family. Sub-gap 24a
+        // (round-19 sibling observation).
+        private static bool BindReferencesWasiNNFamily(RunOptions opts)
+        {
+            foreach (var entry in opts.Bind ?? Enumerable.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(entry)) continue;
+                var trimmed = entry.Trim();
+                // Path form: take basename without .dll suffix.
+                var ident = File.Exists(trimmed)
+                    ? Path.GetFileNameWithoutExtension(trimmed)
+                    : trimmed;
+                if (ident == null) continue;
+                if (ident.StartsWith("Wacs.WASI.NN.",
+                    StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
         }
 
         private static TranspilerOptions BuildTranspilerOptions(RunOptions opts)

--- a/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
+++ b/Wacs.Console/Wacs.Console/Verbs/RunHandler.cs
@@ -645,6 +645,30 @@ namespace Wacs.Console.Verbs
                             ComponentImportStubs.RegisterAll(rt,
                                 parsed.CoreModules[primary]);
 
+                            // Pre-load `--bind` assemblies into
+                            // AppDomain BEFORE scope construction so
+                            // the wasip2 DI scope's reflective
+                            // backend auto-wire (which walks
+                            // AppDomain on `Assembly.Load(name)`
+                            // miss — round 21 fix) can discover
+                            // them. Without this preload the
+                            // auto-wire's `TryLoadAssembly` returns
+                            // null for `--bind <path-to-LlamaSharp.dll>`
+                            // because `ApplyBindings` (which fires
+                            // `Assembly.LoadFrom`) hasn't run yet.
+                            // Closes gap 26 (round-21 verification:
+                            // ordering bug).
+                            //
+                            // The actual `BindToRuntime` calls
+                            // still defer to `ApplyBindings` below
+                            // — the preload only populates
+                            // AppDomain. `BindingLoader.LoadAssembly`
+                            // is idempotent (`Assembly.LoadFrom` on
+                            // a path returns the cached Assembly
+                            // for that path) so the second-pass
+                            // load is a no-op.
+                            PreloadBindAssemblies(opts);
+
                             // Build the wasip2 scope BEFORE
                             // ApplyBindings so wasip2's
                             // BindToRuntime registrations land
@@ -774,6 +798,37 @@ namespace Wacs.Console.Verbs
         /// registration so they override the stubs for any imports
         /// they cover.</para>
         /// </summary>
+        // Pre-load `--bind` assemblies (and the shorthand-flag
+        // siblings) into AppDomain WITHOUT activating any
+        // `IBindable` types. Used by the component-transpiler
+        // path so the wasip2 DI scope's reflective backend
+        // auto-wire — which walks AppDomain when
+        // `Assembly.Load(name)` misses (round 21) — can discover
+        // `Assembly.LoadFrom`'d packages before scope
+        // construction (gap 26). The actual `BindToRuntime` calls
+        // still happen later via `ApplyBindings`; the load step
+        // is idempotent so the second-pass `LoadFromAssembly`
+        // doesn't reload.
+        //
+        // Failures here are silent — diagnostic / surface-area
+        // belongs to `ApplyBindings` (which surfaces a clear
+        // `binding assembly not found` if the path / name
+        // doesn't resolve). Catching here just avoids tearing
+        // down scope construction on a bad `--bind` entry.
+        private static void PreloadBindAssemblies(RunOptions opts)
+        {
+            var paths = new List<string>();
+            if (opts.WasiNN) paths.Add("Wacs.WASI.NN.OnnxRuntime");
+            if (opts.WasiThreads) paths.Add("Wacs.WASI.Threads");
+            if (opts.Bind != null) paths.AddRange(opts.Bind);
+            foreach (var p in paths)
+            {
+                if (string.IsNullOrWhiteSpace(p)) continue;
+                try { BindingLoader.LoadAssembly(p.Trim()); }
+                catch { /* surface via ApplyBindings */ }
+            }
+        }
+
         private static void ApplyBindings(RunOptions opts,
             WasmRuntime runtime, List<IDisposable>? disposables = null)
         {

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.17</Version>
-    <AssemblyVersion>1.5.17</AssemblyVersion>
+    <Version>1.5.18</Version>
+    <AssemblyVersion>1.5.18</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.14</Version>
-    <AssemblyVersion>1.5.14</AssemblyVersion>
+    <Version>1.5.15</Version>
+    <AssemblyVersion>1.5.15</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.15</Version>
-    <AssemblyVersion>1.5.15</AssemblyVersion>
+    <Version>1.5.16</Version>
+    <AssemblyVersion>1.5.16</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.16</Version>
-    <AssemblyVersion>1.5.16</AssemblyVersion>
+    <Version>1.5.17</Version>
+    <AssemblyVersion>1.5.17</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Hosting/BindingLoader.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Hosting/BindingLoader.cs
@@ -43,23 +43,37 @@ namespace Wacs.Transpiler.Hosting
         /// <c>--host-package</c>.</para>
         /// </summary>
         public static List<IBindable> LoadFromAssembly(string nameOrPath)
+            => LoadFromAssembly(LoadAssembly(nameOrPath));
+
+        /// <summary>
+        /// Resolve the assembly identified by
+        /// <paramref name="nameOrPath"/> WITHOUT activating any
+        /// <see cref="IBindable"/> types. A file path on disk is
+        /// loaded via <see cref="Assembly.LoadFrom(string)"/>;
+        /// otherwise the argument is treated as an assembly name
+        /// and resolved via <see cref="Assembly.Load(string)"/>.
+        ///
+        /// <para>Used by host CLIs that need the assembly in
+        /// AppDomain before triggering scope-construction-time
+        /// auto-discovery (gap 26: the wasi-nn DI scope's
+        /// reflective backend auto-wire walks AppDomain on miss,
+        /// but requires `--bind` paths to have been
+        /// `Assembly.LoadFrom`'d first). Callers wanting both
+        /// load and activate use <see cref="LoadFromAssembly(string)"/>;
+        /// the load step is idempotent so calling both with the
+        /// same path is fine.</para>
+        /// </summary>
+        public static Assembly LoadAssembly(string nameOrPath)
         {
-            Assembly asm;
             if (File.Exists(nameOrPath))
+                return Assembly.LoadFrom(Path.GetFullPath(nameOrPath));
+            try { return Assembly.Load(nameOrPath); }
+            catch (Exception ex)
             {
-                asm = Assembly.LoadFrom(Path.GetFullPath(nameOrPath));
+                throw new FileNotFoundException(
+                    "binding assembly not found as file or name: "
+                    + nameOrPath + " (" + ex.Message + ")");
             }
-            else
-            {
-                try { asm = Assembly.Load(nameOrPath); }
-                catch (Exception ex)
-                {
-                    throw new FileNotFoundException(
-                        "binding assembly not found as file or name: "
-                        + nameOrPath + " (" + ex.Message + ")");
-                }
-            }
-            return LoadFromAssembly(asm);
         }
 
         /// <summary>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -15,8 +15,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.8.10</Version>
-        <AssemblyVersion>0.8.10</AssemblyVersion>
+        <Version>0.8.11</Version>
+        <AssemblyVersion>0.8.11</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.7.2 fixes a re-instantiation bug where Module classes with active data segments would come up zeroed on the second `Activator.CreateInstance` because spec §4.5.4 segment-drop emptied the process-wide ModuleInit registry. Module ctors now restore from `ModuleInitData.SavedDataSegments` before each CopyDataSegment so every fresh instance sees its memory initialized. v0.7 retires Lokad.ILPack for PersistedAssemblyBuilder (.NET 9), moves WASM data segments + the codec blob to RVA-mapped initialized data (62.5% smaller than the prior base64-in-#US path, true zero-copy from PE pages to ModuleInitData via UnmanagedMemoryStream), and introduces EmissionTarget.Auto as the new default — promotes to AotLinked when the module fits a conservative envelope (compute / memory / globals / tables + active+passive segments / multi-memory / local tags / imported functions), falling back to Standard otherwise. ~50% first-trial cold-start cut on promoted modules. ImportDispatcher now throws on missing handlers by default (lenient: true opts out). v0.6 consumed the Branch Hinting proposal's metadata.code.branch_hint custom section. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>

--- a/Wacs.WASI/Wacs.WASI.NN/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/README.md
@@ -23,11 +23,33 @@ architecture deep-dive.
 
 ## Quick start
 
-**CLI** — `wacs run my.component.wasm --wasip2 --wasi-nn` (ONNX). The
-ONNX backend ships bundled with the CLI; resolves out-of-box. Other
-backends: `--bind Wacs.WASI.NN.MLNet` or `--bind Wacs.WASI.NN.LlamaSharp`
-(may require additional native binaries on the load path; for
-LlamaSharp set `WACS_WASINN_GGUF_DIR=/path/to/models`).
+**CLI — ONNX (bundled with the CLI):**
+
+```sh
+wacs run my.component.wasm --wasip2 --wasi-nn
+```
+
+**CLI — LlamaSharp (GGUF / llama.cpp):** the LlamaSharp backend
+isn't bundled with the CLI, so pass the project bin's path
+explicitly. The backend csproj uses `EnableDynamicLoading`, so
+its bin carries `LLamaSharp.dll` + native runtimes + transitive
+NuGets — the LoadFromContext probe satisfies them all locally:
+
+```sh
+export WACS_WASINN_GGUF_DIR=/path/to/models
+LLAMA=$(realpath Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/bin/Release/net8.0/Wacs.WASI.NN.LlamaSharp.dll)
+wacs run my.component.wasm --wasip2 --bind "$LLAMA"
+```
+
+`--bind` auto-pulls `WACS.WASI.NN` +
+`WACS.WASI.NN.DependencyInjection` onto host-packages when the
+identity starts with `Wacs.WASI.NN.`; the wasip2 DI scope's
+auto-wire registers the backend in BOTH `Backends[GGML]` AND
+`LoadByNameBackend`, so guests calling
+`wasi:nn/graph.load-by-name(name)` direct-link cleanly. See
+[`docs/COMPONENT_CHAINING.md#gguf-inference-example-llamasharp-backend`](../../docs/COMPONENT_CHAINING.md#gguf-inference-example-llamasharp-backend)
+for the full chain. ML.NET-flavored ORT works the same shape:
+`--bind <wacs-source>/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/bin/Release/net8.0/Wacs.WASI.NN.MLNet.dll`.
 
 **Embedder** — interpreter path:
 

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/GraphFuncsImpl.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/GraphFuncsImpl.cs
@@ -73,11 +73,32 @@ namespace Wacs.WASI.NN.DependencyInjection
                     return Result<Nn.IGraph, Nn.IError>.FromErr(
                         new Error(Nn.ErrorCode.UnsupportedOperation,
                             "load-by-name is disabled for this configuration"));
+
+                // Direct path: backend with internal registry
+                // (LlamaSharp / GGUF, future LLM-serving stacks).
+                // Mirrors WasiNNHost.LoadGraphByNameDispatch — the
+                // LoadByNameBackend hook lets backends that resolve
+                // models by file path / handle skip the byte-loader
+                // indirection entirely (canonical-ABI lift would
+                // force a multi-GB host copy on every load
+                // otherwise). Closes gap 24 (round 19).
+                if (_config.LoadByNameBackend != null)
+                {
+                    var bg = _config.LoadByNameBackend.LoadGraphByName(
+                        name, TypesExecutionTarget.CPU);
+                    return Result<Nn.IGraph, Nn.IError>.FromOk(
+                        new Graph(bg));
+                }
+
+                // Byte-flow path: host registry returns bytes,
+                // routed through encoding-keyed Backends (the
+                // ONNX-style flow).
                 var resolver = _config.NamedModelResolver;
                 if (resolver == null)
                     return Result<Nn.IGraph, Nn.IError>.FromErr(
                         new Error(Nn.ErrorCode.NotFound,
-                            "no named-model resolver configured"));
+                            "no named-model resolver configured "
+                            + "and no LoadByNameBackend wired"));
                 var record = resolver(name);
                 if (record == null)
                     return Result<Nn.IGraph, Nn.IError>.FromErr(
@@ -88,8 +109,8 @@ namespace Wacs.WASI.NN.DependencyInjection
                         new Error(Nn.ErrorCode.InvalidEncoding,
                             "No backend registered for encoding "
                             + record.Value.Encoding));
-                var bg = backend.LoadGraph(record.Value.Builders, record.Value.Target);
-                return Result<Nn.IGraph, Nn.IError>.FromOk(new Graph(bg));
+                var bgBytes = backend.LoadGraph(record.Value.Builders, record.Value.Target);
+                return Result<Nn.IGraph, Nn.IError>.FromOk(new Graph(bgBytes));
             }
             catch (Types.WasiNNException ex)
             {

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/Wacs.WASI.NN.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/Wacs.WASI.NN.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.2.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp.Test/Wacs.WASI.NN.LlamaSharp.Test.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp.Test/Wacs.WASI.NN.LlamaSharp.Test.csproj
@@ -26,6 +26,12 @@
     <ItemGroup>
         <ProjectReference Include="..\Wacs.WASI.NN\Wacs.WASI.NN.csproj" />
         <ProjectReference Include="..\Wacs.WASI.NN.LlamaSharp\Wacs.WASI.NN.LlamaSharp.csproj" />
+        <!-- Round-20 / gap-24 regression test cross-references the
+             Preview2 DI scope's reflective LlamaSharp auto-wire.
+             Equivalent to the WasiPreview2RuntimeScopeTests setup
+             in the OnnxRuntime.Test project (round-19/gap-20). -->
+        <ProjectReference Include="..\Wacs.WASI.NN.DependencyInjection\Wacs.WASI.NN.DependencyInjection.csproj" />
+        <ProjectReference Include="..\..\Wacs.WASI.Preview2\Wacs.WASI.Preview2.DependencyInjection\Wacs.WASI.Preview2.DependencyInjection.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp.Test/WasiPreview2RuntimeScopeLlamaSharpTests.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp.Test/WasiPreview2RuntimeScopeLlamaSharpTests.cs
@@ -7,6 +7,8 @@
 
 using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
 using Wacs.Core.Runtime;
 using Wacs.WASI.NN.DependencyInjection;
 using Wacs.WASI.NN.Types;
@@ -30,6 +32,49 @@ namespace Wacs.WASI.NN.LlamaSharp.Test
     // can actually load a model.
     public class WasiPreview2RuntimeScopeLlamaSharpTests
     {
+        // Round-21 / gap-25 regression: TryLoadAssembly must
+        // resolve Wacs.WASI.NN.LlamaSharp regardless of which load
+        // context placed it in AppDomain. Pre-fix used
+        // Assembly.Load(name) only — missed --bind <path>
+        // assemblies in LoadFromContext. Post-fix walks
+        // AppDomain.CurrentDomain.GetAssemblies() on miss.
+        //
+        // The pure LoadFromContext path is hard to set up in xunit
+        // (any project-referenced assembly lands in the default
+        // context, so Assembly.Load(name) succeeds before the
+        // fallback fires). What this test verifies:
+        //   1. TryLoadAssembly returns the right Assembly object
+        //      for a name that's loadable. Smoke check that the
+        //      OR-of-two-paths logic doesn't break the happy path.
+        //   2. TryLoadAssembly returns null for a clearly-bogus
+        //      name. Confirms the AppDomain walk's
+        //      `IsDynamic`/malformed-metadata guards don't crash.
+        // The full LoadFromContext case is verified empirically in
+        // wasi-nn/WACS-GAPS.md round 21 (the CLI's --bind <path>
+        // flow lands LlamaSharp in LoadFromContext; the fallback
+        // closes the auto-wire path).
+        [Fact]
+        public void TryLoadAssembly_ResolvesKnownAndReturnsNullForBogus()
+        {
+            var tryLoad = typeof(WasiPreview2RuntimeScope).GetMethod(
+                "TryLoadAssembly",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(tryLoad);
+
+            // Happy path — a referenced assembly resolves.
+            var llama = (Assembly?)tryLoad!.Invoke(null,
+                new object?[] { "Wacs.WASI.NN.LlamaSharp" });
+            Assert.NotNull(llama);
+            Assert.Equal("Wacs.WASI.NN.LlamaSharp",
+                llama!.GetName().Name);
+
+            // Negative path — clearly-bogus name returns null
+            // (caller treats this as "not loadable, skip").
+            var miss = (Assembly?)tryLoad.Invoke(null,
+                new object?[] { "NonexistentAssemblyName_qZ9_" });
+            Assert.Null(miss);
+        }
+
         [Fact]
         public void LoadByNameBackend_AutoWiredFromLlamaSharpAssembly()
         {

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp.Test/WasiPreview2RuntimeScopeLlamaSharpTests.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp.Test/WasiPreview2RuntimeScopeLlamaSharpTests.cs
@@ -1,0 +1,82 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.IO;
+using Wacs.Core.Runtime;
+using Wacs.WASI.NN.DependencyInjection;
+using Wacs.WASI.NN.Types;
+using Wacs.WASI.Preview2.DependencyInjection;
+using Xunit;
+
+namespace Wacs.WASI.NN.LlamaSharp.Test
+{
+    // Round-20 (gap 24) regression tests: WasiPreview2RuntimeScope
+    // must auto-wire the LlamaSharp backend into BOTH
+    // Backends[GGML] and LoadByNameBackend on the DI bundle's
+    // WasiNNConfiguration when Wacs.WASI.NN.LlamaSharp is on the
+    // load path. Symmetric to the round-19 OnnxRuntime test in
+    // Wacs.WASI.NN.OnnxRuntime.Test.
+    //
+    // These tests don't load any GGUF — the auto-wire's registry
+    // builder is fail-soft so an unset/missing
+    // $WACS_WASINN_GGUF_DIR yields an empty registry and the
+    // backend wires through anyway. What we verify is that the
+    // CONFIGURATION carries the backend, not that the backend
+    // can actually load a model.
+    public class WasiPreview2RuntimeScopeLlamaSharpTests
+    {
+        [Fact]
+        public void LoadByNameBackend_AutoWiredFromLlamaSharpAssembly()
+        {
+            // Capture stderr so a future regression's diagnostic
+            // warning shows up in the failure message.
+            var stderr = new StringWriter();
+            var origErr = Console.Error;
+            Console.SetError(stderr);
+            try
+            {
+                var runtime = new WasmRuntime();
+                using var scope = new WasiPreview2RuntimeScope(runtime);
+
+                var bundle = Assert.IsType<WasiPreview2NNBundle>(scope.Bundle);
+
+                // Reach the WasiNNConfiguration through the bundle's
+                // resolved IGraphFuncs. The DI bundle's GraphFuncsImpl
+                // takes the configuration as ctor arg; we don't have a
+                // public accessor for the inner config, so we resolve
+                // it via the configured service provider's surface.
+                // Simpler probe: call IGraphFuncs.LoadByName with a
+                // bogus name and assert the error code is *not* the
+                // pre-fix gap 24 symptom ("no named-model resolver").
+                // If LoadByNameBackend is wired, LlamaSharp's
+                // LoadGraphByName fires and reports its own error
+                // (NotFound for unknown names) — different shape.
+                var graphFuncs = bundle.GraphFuncs;
+                Assert.NotNull(graphFuncs);
+
+                var result = graphFuncs.LoadByName("nonexistent-model");
+
+                // Regardless of whether $WACS_WASINN_GGUF_DIR is
+                // set in the test environment, "nonexistent-model"
+                // shouldn't be in the registry. We assert the
+                // error is NOT the pre-fix gap 24 symptom — i.e.
+                // the message must NOT mention "no named-model
+                // resolver" (that's the byte-flow's error from
+                // before LoadByNameBackend was checked).
+                Assert.True(result.IsErr);
+                var errData = result.Err.Data();
+                Assert.DoesNotContain("no named-model resolver", errData,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                Console.SetError(origErr);
+            }
+        }
+    }
+}

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
@@ -12,11 +12,25 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.LlamaSharp</AssemblyName>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.2.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;llm;llama;gguf;wacs</PackageTags>
+        <!-- This backend is loaded via `wacs run [bind] <path>`'s
+             Assembly.LoadFrom: the wasi-nn embedder model where
+             a backend assembly is supplied by path, not bundled
+             with the CLI. EnableDynamicLoading copies every
+             transitive NuGet (LLamaSharp + LLamaSharp.Backend.Cpu's
+             RID-specific natives + the Microsoft.Extensions.*
+             stack LlamaSharp pulls transitively) into the
+             project's bin alongside the assembly, so the LoadFromContext
+             resolver can satisfy the deps without TPA / NuGet-cache
+             probing.
+             Sibling MLNet backend has the same pattern; ONNX
+             takes a different path (round-1 CLI csproj bundle).
+             Gap 27 / round-22 verification. -->
+        <EnableDynamicLoading>true</EnableDynamicLoading>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
@@ -12,11 +12,23 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.MLNet</AssemblyName>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.2.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;mlnet;wacs</PackageTags>
+        <!-- Carry every NuGet transitive (Microsoft.ML +
+             Microsoft.ML.OnnxTransformer + the OrtValue-native
+             ORT 1.20 + the System.Numerics.Tensors / Apache
+             Arrow / Newtonsoft.Json / etc. that ML.NET pulls)
+             into the project's bin so `wacs run [bind] <path>`
+             resolves the LoadFromContext deps without TPA
+             probing. Sibling LlamaSharp backend has the same
+             flag; ONNX backend takes a different path
+             (round-1 CLI csproj bundle). Gap 27 / round-22
+             verification: symmetric fix in case future
+             embedders bind this MLNet backend. -->
+        <EnableDynamicLoading>true</EnableDynamicLoading>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.Test/GraphFuncsImplLoadByNameTests.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.Test/GraphFuncsImplLoadByNameTests.cs
@@ -1,0 +1,192 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Wacs.WASI.NN.DependencyInjection;
+using Wacs.WASI.NN.Types;
+using Xunit;
+using NnGraphFuncs = Wacs.WASI.NN.Nn.IGraphFuncs;
+using NnErrorCode = Wacs.WASI.NN.Nn.ErrorCode;
+
+namespace Wacs.WASI.NN.Test
+{
+    // Regression test for wasi-nn/WACS-GAPS.md gap 24.
+    //
+    // The DI bundle's GraphFuncsImpl.LoadByName historically only
+    // checked WasiNNConfiguration.NamedModelResolver, ignoring the
+    // sibling LoadByNameBackend field. The WitBindings path
+    // (WasiNNHost.LoadGraphByNameDispatch) checked LoadByNameBackend
+    // first, then fell back to the resolver — backends with
+    // internal name registries (LlamaSharp / GGUF) wired
+    // LoadByNameBackend and worked through the legacy interpreter
+    // path but tripped "no named-model resolver configured" through
+    // the DI bundle / transpiler-direct-link path.
+    //
+    // Round-19 fix: GraphFuncsImpl.LoadByName routes through
+    // LoadByNameBackend.LoadGraphByName(name, target) BEFORE the
+    // resolver check — same shape as WitBindings.
+    public class GraphFuncsImplLoadByNameTests
+    {
+        // Minimal stub backend that responds only to LoadGraphByName.
+        // Throws from the byte-flow LoadGraph path (matches LlamaSharp's
+        // intentional UnsupportedOperation surface for multi-GB GGUFs).
+        private sealed class NameOnlyStubBackend : IBackend
+        {
+            private readonly Dictionary<string, IBackendGraph> _registry;
+            public NameOnlyStubBackend(
+                Dictionary<string, IBackendGraph> registry)
+            { _registry = registry; }
+
+            public IReadOnlyCollection<GraphEncoding> SupportedEncodings
+                => new[] { GraphEncoding.GGML };
+
+            public IBackendGraph LoadGraph(
+                IReadOnlyList<ReadOnlyMemory<byte>> builders,
+                ExecutionTarget target)
+                => throw new WasiNNException(
+                    ErrorCode.UnsupportedOperation,
+                    "byte-loader path is intentionally unsupported");
+
+            public IBackendGraph LoadGraphByName(
+                string name, ExecutionTarget target)
+            {
+                if (!_registry.TryGetValue(name, out var graph))
+                    throw new WasiNNException(
+                        ErrorCode.NotFound,
+                        "no graph registered for '" + name + "'");
+                return graph;
+            }
+        }
+
+        private sealed class StubBackendGraph : IBackendGraph
+        {
+            public string Tag { get; }
+            public StubBackendGraph(string tag) { Tag = tag; }
+            public IBackendContext CreateContext()
+                => throw new NotImplementedException("not exercised");
+            public void Dispose() { }
+        }
+
+        [Fact]
+        public void LoadByName_RoutesThroughLoadByNameBackend_WhenWired()
+        {
+            // The Direct path: LoadByNameBackend wired, no
+            // NamedModelResolver. Pre-fix this returned NotFound
+            // ("no named-model resolver configured"). Post-fix the
+            // backend's LoadGraphByName fires and the OK arm carries
+            // the lifted IGraph.
+            var stubGraph = new StubBackendGraph("qwen");
+            var registry = new Dictionary<string, IBackendGraph>
+            {
+                { "qwen-0.5b", stubGraph },
+            };
+            var backend = new NameOnlyStubBackend(registry);
+
+            var config = WasiNNConfiguration.DefaultConfiguration();
+            config.LoadByNameBackend = backend;
+            // Leave NamedModelResolver and Backends[GGML] unset to
+            // confirm the new branch fires before either check.
+
+            var funcs = (NnGraphFuncs)NewGraphFuncsImpl(config);
+            var result = funcs.LoadByName("qwen-0.5b");
+
+            Assert.True(result.IsOk,
+                "LoadByName should route through LoadByNameBackend; "
+                + "got Err " + (result.IsErr
+                    ? result.Err.Code() + ": " + result.Err.Data()
+                    : "<unreachable>"));
+        }
+
+        [Fact]
+        public void LoadByName_FallsBackToResolver_WhenLoadByNameBackendNull()
+        {
+            // The byte-flow path: LoadByNameBackend null, resolver
+            // returns a (bytes, encoding) record, Backends[encoding]
+            // resolves the byte-loader. Existing behavior — the new
+            // branch must not break it.
+            var byteGraph = new StubBackendGraph("byte");
+            var bytesBackend = new NameOnlyStubBackend(
+                new Dictionary<string, IBackendGraph>());
+            // Hack the byte-flow side: inject a backend whose
+            // LoadGraph (rather than LoadGraphByName) yields the
+            // graph. NameOnlyStubBackend trips on LoadGraph by
+            // design, so use a different stub here.
+            var byteFlowBackend = new ByteFlowStubBackend(byteGraph);
+
+            var config = WasiNNConfiguration.DefaultConfiguration();
+            config.LoadByNameBackend = null;
+            config.NamedModelResolver = name => new NamedModel(
+                encoding: GraphEncoding.ONNX,
+                builders: new[] { ReadOnlyMemory<byte>.Empty },
+                target: ExecutionTarget.CPU);
+            config.Backends[GraphEncoding.ONNX] = byteFlowBackend;
+
+            var funcs = (NnGraphFuncs)NewGraphFuncsImpl(config);
+            var result = funcs.LoadByName("any");
+
+            Assert.True(result.IsOk,
+                "Byte-flow fallback should work when LoadByNameBackend "
+                + "is null; got Err "
+                + (result.IsErr
+                    ? result.Err.Code() + ": " + result.Err.Data()
+                    : "<unreachable>"));
+        }
+
+        [Fact]
+        public void LoadByName_ReturnsNotFound_WhenNeitherWired()
+        {
+            // Both paths absent: should return NotFound with a
+            // diagnostic that mentions LoadByNameBackend (so the
+            // failure mode is discoverable from the error message
+            // alone, not just by reading the source).
+            var config = WasiNNConfiguration.DefaultConfiguration();
+            // No LoadByNameBackend, no NamedModelResolver.
+
+            var funcs = (NnGraphFuncs)NewGraphFuncsImpl(config);
+            var result = funcs.LoadByName("any");
+
+            Assert.True(result.IsErr);
+            Assert.Equal(NnErrorCode.NotFound, result.Err.Code());
+            Assert.Contains("LoadByNameBackend", result.Err.Data());
+        }
+
+        // GraphFuncsImpl is internal sealed; reach it via reflection
+        // so we don't need to widen the surface for tests.
+        private static object NewGraphFuncsImpl(WasiNNConfiguration config)
+        {
+            var t = typeof(WasiNNBundle).Assembly.GetType(
+                "Wacs.WASI.NN.DependencyInjection.GraphFuncsImpl",
+                throwOnError: true)!;
+            return Activator.CreateInstance(t,
+                BindingFlags.Instance | BindingFlags.NonPublic
+                    | BindingFlags.Public,
+                binder: null,
+                args: new object?[] { config },
+                culture: null)!;
+        }
+
+        // Byte-flow stub: LoadGraph yields the supplied graph.
+        // LoadGraphByName traps so the test catches a path-confusion
+        // regression (the byte-flow test must NOT touch the name path).
+        private sealed class ByteFlowStubBackend : IBackend
+        {
+            private readonly IBackendGraph _g;
+            public ByteFlowStubBackend(IBackendGraph g) { _g = g; }
+            public IReadOnlyCollection<GraphEncoding> SupportedEncodings
+                => new[] { GraphEncoding.ONNX };
+            public IBackendGraph LoadGraph(
+                IReadOnlyList<ReadOnlyMemory<byte>> builders,
+                ExecutionTarget target) => _g;
+            public IBackendGraph LoadGraphByName(
+                string name, ExecutionTarget target)
+                => throw new InvalidOperationException(
+                    "byte-flow stub's name path must not be invoked");
+        }
+    }
+}

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.1.3</AssemblyVersion>
-        <Version>0.1.3</Version>
+        <AssemblyVersion>0.1.4</AssemblyVersion>
+        <Version>0.1.4</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.1.2</AssemblyVersion>
-        <Version>0.1.2</Version>
+        <AssemblyVersion>0.1.3</AssemblyVersion>
+        <Version>0.1.3</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
@@ -7,7 +7,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Wacs.ComponentModel.Validation;
@@ -211,21 +213,27 @@ namespace Wacs.WASI.Preview2.DependencyInjection
                 "Wacs.WASI.NN.DependencyInjection.WasiNNServiceCollectionExtensions");
             if (nnExtType == null) return;
 
-            // Build a configure callback that wires the ONNX
-            // backend, if Wacs.WASI.NN.OnnxRuntime is loadable
-            // and OnnxBackend's parameterless ctor succeeds.
-            // Surfaces failures as stderr warnings instead of
-            // returning silently — the SLM's "InvalidEncoding:
-            // No backend registered for ONNX" symptom is a lot
-            // easier to root-cause when the underlying load /
-            // ctor failure shows up at startup time (round-13
-            // follow-up gap 20).
-            var configureDelegate = BuildOnnxConfigureCallback(nnAsm!);
+            // Build per-backend configure callbacks for whatever
+            // wasi-nn backends are loadable. Each callback runs
+            // INSIDE AddWasiNN's configure step (before
+            // TryAddSingleton(opts.Configuration)), so the registered
+            // Configuration instance carries every wired backend in
+            // one go.
+            //
+            // Failures surface as stderr warnings (vs. silent
+            // returns) — the SLM's round-13 "InvalidEncoding"
+            // symptom and round-19's "no named-model resolver
+            // configured" both root-cause faster when the load /
+            // ctor failure shows up at startup time, not at first
+            // guest call.
+            var onnxCallback = BuildOnnxConfigureCallback(nnAsm!);
+            var llamaCallback = BuildLlamaSharpConfigureCallback(nnAsm!);
+            var configureDelegate = CombineCallbacks(
+                onnxCallback, llamaCallback);
 
             // services.AddWasiNN(configure) — configure runs
-            // BEFORE TryAddSingleton(opts.Configuration), so the
-            // backend lands in opts.Configuration.Backends and
-            // gets registered as part of the same instance
+            // BEFORE TryAddSingleton(opts.Configuration), so each
+            // backend lands on the same Configuration instance
             // GraphFuncsImpl resolves later.
             nnExtType.GetMethod("AddWasiNN",
                     BindingFlags.Public | BindingFlags.Static)!
@@ -328,6 +336,179 @@ namespace Wacs.WASI.Preview2.DependencyInjection
             var lambda = System.Linq.Expressions.Expression.Lambda(
                 actionType, call, optsParam);
             return lambda.Compile();
+        }
+
+        // Combine per-backend configure callbacks into one
+        // multicast Action<options>. Multicast invocation fires
+        // each subscriber in registration order against the same
+        // options instance — exactly what we need when
+        // AddWasiNN's `configure?.Invoke(opts)` runs. Returns
+        // null if every input is null (in which case AddWasiNN
+        // gets a null configure and runs with an empty
+        // Configuration, matching the no-backend-loadable
+        // behavior).
+        private static Delegate? CombineCallbacks(
+            params Delegate?[] callbacks)
+        {
+            Delegate? result = null;
+            foreach (var cb in callbacks)
+            {
+                if (cb == null) continue;
+                result = result == null
+                    ? cb
+                    : Delegate.Combine(result, cb);
+            }
+            return result;
+        }
+
+        // Build an Action<WasiNNDependencyInjectionOptions>
+        // delegate that wires the LlamaSharp backend, scanning
+        // <c>WACS_WASINN_GGUF_DIR</c> for *.gguf files (matches
+        // WasiNNLlamaSharpBindable's env-driven registry shape).
+        // Registers the backend under BOTH:
+        //   - opts.AddBackend(GraphEncoding.GGML, backend) — for
+        //     embedders that route through the encoding-keyed
+        //     Backends dict (currently unused for LlamaSharp
+        //     since its byte-loader path traps, but left wired
+        //     for symmetry with ONNX);
+        //   - opts.Configuration.LoadByNameBackend = backend —
+        //     the load-by-name path GraphFuncsImpl checks before
+        //     falling back to the byte-flow (gap 24).
+        //
+        // Returns null when:
+        //   - Wacs.WASI.NN.LlamaSharp isn't loadable (the common
+        //     case for `wacs run --wasip2 --wasi-nn` — only ONNX
+        //     ships bundled);
+        //   - the LlamaSharpBackend type / FromPaths factory /
+        //     LoadByNameBackend property can't be resolved;
+        //   - FromPaths throws.
+        // Each non-quiet error path emits a stderr warning so the
+        // failure mode is discoverable at startup time.
+        private static Delegate? BuildLlamaSharpConfigureCallback(
+            Assembly nnAsm)
+        {
+            var optsType = nnAsm.GetType(
+                "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
+            if (optsType == null) return null;
+
+            var addBackend = optsType.GetMethod("AddBackend");
+            if (addBackend == null) return null;
+            var addBackendParams = addBackend.GetParameters();
+            if (addBackendParams.Length != 2) return null;
+            var encodingType = addBackendParams[0].ParameterType;
+            var backendIfaceType = addBackendParams[1].ParameterType;
+
+            var llamaAsm = TryLoadAssembly("Wacs.WASI.NN.LlamaSharp");
+            if (llamaAsm == null) return null;  // not an error.
+
+            var llamaBackendType = llamaAsm.GetType(
+                "Wacs.WASI.NN.LlamaSharp.LlamaSharpBackend");
+            if (llamaBackendType == null)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: Wacs.WASI.NN.LlamaSharp is loadable but "
+                    + "LlamaSharpBackend type wasn't found. wasi-nn "
+                    + "GGUF guests will see NotFound errors.");
+                return null;
+            }
+
+            var fromPaths = llamaBackendType.GetMethod("FromPaths",
+                BindingFlags.Public | BindingFlags.Static);
+            if (fromPaths == null)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: LlamaSharpBackend.FromPaths(IDictionary"
+                    + "<string,string>) static factory not found. "
+                    + "Cannot auto-wire LlamaSharp; embedders should "
+                    + "construct LlamaSharpBackend directly via "
+                    + "AddWasiNN(b => b.AddBackend(...)).");
+                return null;
+            }
+
+            var registry = BuildGgufRegistryFromEnv();
+
+            object? llamaBackend;
+            try { llamaBackend = fromPaths.Invoke(null, new object?[] { registry }); }
+            catch (Exception ex)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: LlamaSharpBackend.FromPaths failed: "
+                    + ex.GetType().Name + ": " + ex.Message
+                    + ". wasi-nn GGUF guests will see NotFound "
+                    + "errors. Check that the LLamaSharp native "
+                    + "library is on the load path.");
+                return null;
+            }
+            if (llamaBackend == null) return null;
+
+            // Resolve the LoadByNameBackend property on
+            // WasiNNConfiguration via opts.Configuration.
+            var configProp = optsType.GetProperty("Configuration");
+            if (configProp == null) return null;
+            var configType = configProp.PropertyType;
+            var loadByNameProp = configType.GetProperty("LoadByNameBackend");
+            if (loadByNameProp == null
+                || loadByNameProp.GetSetMethod() == null)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: WasiNNConfiguration.LoadByNameBackend "
+                    + "property missing or read-only; cannot route "
+                    + "GGUF graph.load-by-name through LlamaSharp.");
+                return null;
+            }
+
+            // GGML = 5 in both Nn.GraphEncoding and
+            // Types.GraphEncoding (cross-checked at file scope).
+            object ggmlEncoding = Enum.ToObject(encodingType, 5);
+
+            // Build:
+            //   opts.AddBackend(GraphEncoding.GGML, backend);
+            //   opts.Configuration.LoadByNameBackend = backend;
+            var optsParam = Expression.Parameter(optsType, "opts");
+            var addCall = Expression.Call(
+                optsParam,
+                addBackend,
+                Expression.Constant(ggmlEncoding, encodingType),
+                Expression.Constant(llamaBackend, backendIfaceType));
+            var configAccess = Expression.Property(optsParam, configProp);
+            var assign = Expression.Assign(
+                Expression.Property(configAccess, loadByNameProp),
+                Expression.Constant(llamaBackend,
+                    loadByNameProp.PropertyType));
+            var block = Expression.Block(addCall, assign);
+            var actionType = typeof(Action<>).MakeGenericType(optsType);
+            return Expression.Lambda(actionType, block, optsParam)
+                .Compile();
+        }
+
+        // Mirrors WasiNNLlamaSharpBindable's env-driven scan:
+        // read $WACS_WASINN_GGUF_DIR, enumerate *.gguf files in
+        // the top-level dir, register each under its filename-
+        // sans-extension. Empty registry on miss / unset / IO
+        // error — matches the IBindable's fail-soft posture so
+        // the auto-wire never crashes scope construction.
+        private static IDictionary<string, string>
+            BuildGgufRegistryFromEnv()
+        {
+            var dir = Environment.GetEnvironmentVariable(
+                "WACS_WASINN_GGUF_DIR");
+            var registry = new Dictionary<string, string>(
+                StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(dir)) return registry;
+            try
+            {
+                if (!Directory.Exists(dir)) return registry;
+                foreach (var path in Directory.EnumerateFiles(dir,
+                    "*.gguf", SearchOption.TopDirectoryOnly))
+                {
+                    var name = Path.GetFileNameWithoutExtension(path);
+                    if (!string.IsNullOrEmpty(name))
+                        registry[name!] = path;
+                }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+            return registry;
         }
 
         private static Assembly? TryLoadAssembly(string name)

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
@@ -511,10 +511,49 @@ namespace Wacs.WASI.Preview2.DependencyInjection
             return registry;
         }
 
+        // Resolve a named assembly across both .NET load contexts.
+        // First tries `Assembly.Load(name)` (the default context —
+        // covers project-referenced and CLR-resolved-by-name
+        // dependencies). On miss, walks `AppDomain.CurrentDomain
+        // .GetAssemblies()` to catch assemblies already loaded into
+        // the LoadFromContext via `Assembly.LoadFrom(path)` — the
+        // path the CLI's `--bind <path>` walks. Without the fallback,
+        // `--bind /path/to/Wacs.WASI.NN.LlamaSharp.dll` populates
+        // AppDomain but the auto-wire's Assembly.Load(name) misses
+        // it, the LlamaSharp backend never registers in the DI's
+        // WasiNNConfiguration, and `compute(...)` trips NotFound at
+        // first guest call (gap 25, round-20 verification).
+        //
+        // Mirror of the round-18 fix in HostPackageResolver
+        // .TryFindResourceImpl — same AppDomain-vs-default-context
+        // split, same fallback shape.
         private static Assembly? TryLoadAssembly(string name)
         {
-            try { return Assembly.Load(name); }
-            catch { return null; }
+            try
+            {
+                var asm = Assembly.Load(name);
+                if (asm != null) return asm;
+            }
+            catch { /* fall through to AppDomain walk */ }
+
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (asm.IsDynamic) continue;
+                try
+                {
+                    if (string.Equals(asm.GetName().Name, name,
+                        StringComparison.OrdinalIgnoreCase))
+                        return asm;
+                }
+                catch
+                {
+                    // Malformed metadata on a collectable / dynamic-
+                    // but-not-flagged assembly. Skip and keep walking;
+                    // a single-asm hiccup must not blank out the
+                    // search.
+                }
+            }
+            return null;
         }
 
         public void Dispose()

--- a/docs/COMPONENT_CHAINING.md
+++ b/docs/COMPONENT_CHAINING.md
@@ -36,6 +36,7 @@ embedders bypassing the CLI need to either include them in
 | `--wasip2` | `WACS.WASI.Preview2`<br>`WACS.WASI.Preview2.DependencyInjection` | Typed `[WitSource]` interfaces (Preview 2)<br>Bundle + impl classes for direct-link emit |
 | `--wasi-nn` | adds `WACS.WASI.NN`<br>`WACS.WASI.NN.DependencyInjection`<br>`WACS.WASI.NN.OnnxRuntime` | wasi-nn typed surface<br>`Tensor` / `Graph` / `GraphExecutionContext` / `Error` impls + `WasiPreview2NNBundle` composite<br>ONNX backend (default; swap with `--bind` for other backends) |
 | `--wasi-threads` | adds `WACS.WASI.Threads` | `wasi:thread-spawn` |
+| `--bind <path-to-Wacs.WASI.NN.LlamaSharp.dll>` | auto-pulls `WACS.WASI.NN` + `WASI.NN.DependencyInjection`<br>(LoadFromContext: `LLamaSharp` + `LLamaSharp.Backend.Cpu` natives + `Microsoft.Extensions.*`) | GGUF / llama.cpp backend. The `--bind` walk resolves the typed-surface + DI siblings automatically; the LlamaSharp NuGet's transitive deps ride along via the project's `EnableDynamicLoading` bin layout. |
 | Custom host binding | `--bind <Asm>` | Any `IBindable` host package (game APIs, custom imports, etc.) |
 
 **Why both `WASI.NN` and `WASI.NN.DependencyInjection`?** Typed
@@ -120,16 +121,106 @@ What this does:
   the guest at `/models` (matching wasmtime's mount-pair syntax)
 
 For other wasi-nn backends, swap the ONNX default with
-`--bind`:
+`--bind`. Backends other than ONNX aren't bundled with the CLI
+(round-1 plumbing only ships `Wacs.WASI.NN.OnnxRuntime`); pass
+the explicit path to the backend assembly instead:
 
 ```bash
-# ML.NET-flavored ORT wrapping
-wacs run my.component.wasm --wasip2 --wasi-nn --bind Wacs.WASI.NN.MLNet
+# ML.NET-flavored ORT wrapping (path to the backend assembly's bin)
+wacs run my.component.wasm --wasip2 \
+    --bind <wacs-source>/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/bin/Release/net8.0/Wacs.WASI.NN.MLNet.dll
 
-# LlamaSharp / GGUF
+# LlamaSharp / GGUF (see GGUF section below for a fuller walkthrough)
 WACS_WASINN_GGUF_DIR=./models \
-  wacs run my.component.wasm --wasip2 --wasi-nn --bind Wacs.WASI.NN.LlamaSharp
+  wacs run my.component.wasm --wasip2 \
+    --bind <wacs-source>/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/bin/Release/net8.0/Wacs.WASI.NN.LlamaSharp.dll
 ```
+
+`--bind` automatically pulls `WACS.WASI.NN` +
+`WACS.WASI.NN.DependencyInjection` onto host-packages when the
+bound assembly's identity starts with `Wacs.WASI.NN.` — same DI
+auto-wire, no extra flags. The backend csproj's
+`<EnableDynamicLoading>true</EnableDynamicLoading>` ships the
+NuGet transitive deps next to the assembly so the
+LoadFromContext probe satisfies them locally.
+
+### GGUF inference example (LlamaSharp backend)
+
+End-to-end run of a Qwen / Llama / Mistral / etc. GGUF through a
+wasip2 component that uses `wasi:nn/graph.load-by-name` (the
+WasmEdge convention: input + output U8 tensors carrying UTF-8
+prompt / response bytes; LlamaSharp does tokenization + chat
+templating + sampling host-side).
+
+**Setup** — drop GGUFs into a directory and tell the LlamaSharp
+backend where to find them. The backend scans `*.gguf` in the
+top-level dir at startup; each file registers under its
+filename-sans-extension as the load-by-name key:
+
+```sh
+mkdir -p ./models
+# Example: pull a small Qwen quant
+huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct-GGUF \
+    qwen2.5-0.5b-instruct-q4_k_m.gguf \
+    --local-dir ./models
+
+export WACS_WASINN_GGUF_DIR="$(pwd)/models"
+```
+
+**Build the backend assembly** (the project's bin will carry
+LLamaSharp.dll, LLamaSharp.Backend.Cpu's RID-specific native
+dylibs / .so / .dll, and the Microsoft.Extensions.*
+transitives, all from `EnableDynamicLoading`):
+
+```sh
+dotnet build Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp -c Release
+```
+
+**Run** — the guest calls `load_by_name("qwen2.5-0.5b-instruct-q4_k_m")`:
+
+```sh
+LLAMA=$(realpath Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/bin/Release/net8.0/Wacs.WASI.NN.LlamaSharp.dll)
+
+wacs run my-llm.component.wasm \
+    --wasip2 \
+    --bind "$LLAMA"
+```
+
+What happens under the hood:
+
+1. `--bind <path>` triggers `BindingLoader.LoadFromAssembly` →
+   the LlamaSharp backend assembly lands in `LoadFromContext`.
+   The deps.json sitting next to it (from
+   `EnableDynamicLoading`) tells the resolver where to find
+   `LLamaSharp.dll` + native runtimes.
+2. Sub-gap-24a auto-pull: the `--bind`'s
+   `Wacs.WASI.NN.LlamaSharp` identity matches the
+   `Wacs.WASI.NN.*` prefix → `WACS.WASI.NN` +
+   `WACS.WASI.NN.DependencyInjection` get added to
+   host-packages so the resolver has full WitSource coverage.
+3. CLI pre-loads all `--bind` paths into AppDomain BEFORE
+   constructing `WasiPreview2RuntimeScope` (gap-26 ordering
+   fix).
+4. Scope construction's `ReflectivelyAddWasiNN` walks AppDomain
+   (gap-25 fallback), finds `Wacs.WASI.NN.LlamaSharp`, calls
+   `LlamaSharpBackend.FromPaths(<env-driven-registry>)`,
+   wires the backend into BOTH `Backends[GGML]` AND
+   `LoadByNameBackend` on the DI's `WasiNNConfiguration`.
+5. Guest `load_by_name(...)` direct-links to
+   `GraphFuncsImpl.LoadByName` (gap-24 fix), which routes
+   through `LoadByNameBackend.LoadGraphByName` directly —
+   the byte-flow indirection is bypassed (a multi-GB GGUF
+   would otherwise force a multi-GB host copy on every load).
+6. `compute(...)` runs llama.cpp's generation loop host-side;
+   the U8 output tensor lifts back through the canonical-ABI
+   `list<tuple<string, own<tensor>>>` return (PR #128
+   gaps 22 + 24-26).
+
+For other backend NuGets / GPU runtimes, swap
+`LLamaSharp.Backend.Cpu` in `Wacs.WASI.NN.LlamaSharp.csproj`
+with `LLamaSharp.Backend.Cuda12` / `.Vulkan` / `.MacMetal` and
+rebuild. No source changes; the `EnableDynamicLoading` bin
+copies whichever backend NuGet's natives are pulled.
 
 ### Embedder (one-shot)
 


### PR DESCRIPTION
## Summary

Closes the wasi-nn LlamaSharp / GGUF arc. After PR #127 closed the Gemma 3 ONNX SLM end-to-end (gap 23), the LlamaSharp/GGUF trial run surfaced four cascading gaps; each round's fix landed and was verified by the user before the next round opened. Round 22 produced real Qwen2.5 0.5B inference output through `wacs run --wasip2 --bind <path-to-LlamaSharp.dll>` — same `phase-2 goal achieved` bar the SLM hit at round 18.

| Round | Commit | Gap | Severity | Fix |
|---|---|---|---|---|
| 20 | `005b52d0` | **24** — DI bundle's `GraphFuncsImpl.LoadByName` ignored `LoadByNameBackend` | blocking | Port `WasiNNHost.LoadGraphByNameDispatch` shape: check `LoadByNameBackend` first, fall back to `NamedModelResolver` |
| 20 | `005b52d0` | **24a** — `--bind <Wacs.WASI.NN.*>` didn't auto-pull DI siblings | UX | `RunHandler.ResolveHostPackages` walks `--bind` entries; `Wacs.WASI.NN.*` identities pull `WACS.WASI.NN` + `.DependencyInjection` |
| 20 | `005b52d0` | (auto-wire) | — | `BuildLlamaSharpConfigureCallback` mirrors round-14's ONNX pattern; per-backend configure callbacks combine via `Delegate.Combine`. Wires LlamaSharp into BOTH `Backends[GGML]` AND `LoadByNameBackend` |
| 21 | `59570788` | **25** — `TryLoadAssembly` missed `LoadFrom`'d assemblies | blocking | AppDomain fallback (mirror of round-18's `TryFindResourceImpl`). Walks `AppDomain.CurrentDomain.GetAssemblies()` on `Assembly.Load(name)` miss |
| 22 | `4809f460` | **26** — `--bind` ran AFTER scope construction, so the auto-wire's AppDomain walk had nothing to find | blocking | `BindingLoader.LoadAssembly(string)` (load-only API); `RunHandler.PreloadBindAssemblies` populates AppDomain BEFORE `WasiPreview2RuntimeScope` constructs |
| 23 | `dc9f45bc` | **27** — backend project bin didn't carry NuGet transitives | blocking | `<EnableDynamicLoading>true</EnableDynamicLoading>` on LlamaSharp + MLNet csprojs. Library bin now ships every transitive + RID-specific native lib |

The post-gap-27 invocation:

```sh
export WACS_WASINN_GGUF_DIR=/path/to/models
wacs run my-llm.component.wasm --wasip2 \
    --bind <wacs>/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/bin/Release/net8.0/Wacs.WASI.NN.LlamaSharp.dll
```

No manual deps staging, no `--host-package`, no shim. Worked GGUF example (with under-the-hood walkthrough naming each gap's role) lives at [`docs/COMPONENT_CHAINING.md`](docs/COMPONENT_CHAINING.md#gguf-inference-example-llamasharp-backend).

## Test plan

- [x] Wacs.WASI.NN.Test 21/21 (3 new gap-24 LoadByName tests)
- [x] Wacs.WASI.NN.LlamaSharp.Test 8/8 + 2 skip (1 new gap-24a auto-wire test, 1 new gap-25 TryLoadAssembly test)
- [x] Wacs.WASI.NN.OnnxRuntime.Test 10/10 — no regression in the round-14 ONNX path
- [x] Wacs.WASI.NN.MLNet.Test 7/7
- [x] Spec.Test 770/772, Wacs.Transpiler.Test 775/776, Wacs.Core.Test 397/397, Wacs.WASI.Preview2.Test 189/189, Wacs.ComponentModel.Test 354/354
- [x] AOT smoke green (`wacs aot --wasi fd_write-to-stdout.wasm` prints `hello`)
- [x] Build verified: `Wacs.WASI.NN.LlamaSharp/bin/Release/net8.0/` now carries `LLamaSharp.dll`, `Microsoft.Extensions.*.dll`, `runtimes/osx-arm64/native/libllama.dylib` (+ siblings)
- [x] **End-to-end empirical**: WACS-GAPS round-22 verification ran Qwen2.5 0.5B Q4_K_M GGUF through `wacs run --wasip2 --bind <path>` and got real Metal-backed inference output, exit 0
- [x] Pre-existing failures (Wacs.Compilation.Test 2/62, Feature.Detect 4/22) verified pre-existing across rounds 14-22

## Versions

- `WACS.WASI.NN.DependencyInjection` 0.2.0 → 0.2.1 (LoadByName routes through LoadByNameBackend)
- `WACS.WASI.NN.LlamaSharp` 0.2.0 → 0.2.1 (EnableDynamicLoading)
- `WACS.WASI.NN.MLNet` 0.2.0 → 0.2.1 (EnableDynamicLoading, symmetric)
- `WACS.WASI.Preview2.DependencyInjection` 0.1.2 → 0.1.4 (LlamaSharp auto-wire + TryLoadAssembly AppDomain fallback)
- `WACS.Transpiler.Lib` 0.8.10 → 0.8.11 (`BindingLoader.LoadAssembly` load-only API)
- `WACS.Cli` 1.5.14 → 1.5.18 (release event + `--bind` → DI-sibling auto-pull + `PreloadBindAssemblies` ordering fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)