### PR TITLE
NuGet packages: include README.md in published packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## All NuGet packages — README included in published packages
+
+Eleven packages gain a `<PackageReadmeFile>README.md</PackageReadmeFile>` entry plus a
+local `README.md`. Eight of them got fresh consumer-facing READMEs; two (`WACS.WASI.NN`
+and `WACS.WASI.Preview2`) already had READMEs that just needed the csproj wiring; one
+(`WACS.Transpiler.Lib`) had its csproj packing the deprecated `WACS.Transpiler` CLI tool's
+README — the architecture doc previously at `Wacs.Transpiler.Lib/README.md` moved to
+`ARCHITECTURE.md` and a fresh embedder-focused README took its place.
+
+Each README covers: what the package is, who should install it, a minimal install +
+quick-start example, what's inside, and links to deeper docs (top-level README,
+[`docs/COMPONENT_CHAINING.md`](docs/COMPONENT_CHAINING.md)). NuGet.org now renders the
+package-specific README on every package's listing page.
+
+### Versions
+
+Patch-level bumps (README is metadata; no public-API or behavior change):
+
+- `WACS.ComponentModel` 0.3.4 → **0.3.5**
+- `WACS.ComponentModel.Bindgen.Lib` 0.1.0 → **0.1.1**
+- `WACS.WASI.NN` 0.3.0 → **0.3.1**
+- `WACS.WASI.NN.DependencyInjection` 0.2.1 → **0.2.2**
+- `WACS.WASI.NN.OnnxRuntime` 0.2.2 → **0.2.3**
+- `WACS.WASI.NN.LlamaSharp` 0.2.1 → **0.2.2**
+- `WACS.WASI.NN.MLNet` 0.2.1 → **0.2.2**
+- `WACS.WASI.Preview2` 0.4.0 → **0.4.1**
+- `WACS.WASI.Preview2.DependencyInjection` 0.1.4 → **0.1.5**
+- `WACS.WASI.Threads` 0.2.0 → **0.2.1**
+- `WACS.Transpiler.Lib` 0.8.11 → **0.8.12**
+
+(Untouched: `WACS`, `WASI.Preview1` (already had README + wiring),
+`WACS.HostBindings.{Abstractions,SourceGen}` (already had READMEs + wiring),
+`WACS.Cli` (already had README + wiring), `WACS.Transpiler` (deprecated; keeps its
+existing deprecation-notice README).)
+
 ## WACS.Cli 1.5.18 / WACS.Transpiler.Lib 0.8.11 / WACS.WASI.NN.DependencyInjection 0.2.1 / WACS.WASI.NN.LlamaSharp 0.2.1 / WACS.WASI.NN.MLNet 0.2.1 / WACS.WASI.Preview2.DependencyInjection 0.1.4 — gaps 24 + 25 + 26 + 27: LlamaSharp / GGUF on the transpiler-direct-link path (end-to-end)
 
 The wasi-nn LlamaSharp/GGUF harness (`guest-llm/`, Qwen2.5 0.5B

--- a/Wacs.ComponentModel/Wacs.ComponentModel.Bindgen.Lib/README.md
+++ b/Wacs.ComponentModel/Wacs.ComponentModel.Bindgen.Lib/README.md
@@ -1,0 +1,67 @@
+# WACS.ComponentModel.Bindgen.Lib
+
+Programmatic WIT ↔ C# binding generator for the
+[WACS Component Model](https://www.nuget.org/packages/WACS.ComponentModel) — both
+directions:
+
+- **Forward**: `.wit` → C# typed interfaces (host- and guest-side), tagged with
+  `[WitSource]` so `HostPackageResolver` can match imports at transpile time
+- **Reverse**: transpiled `.dll` → regenerated `.wit` + bindings (round-trip / refactoring
+  workflows)
+
+This is the library API used by the `wacs bindgen` verb in
+[`WACS.Cli`](https://www.nuget.org/packages/WACS.Cli). Reference it directly from custom
+build steps, IDE integrations, or codegen pipelines that want full control over the
+generation.
+
+## Install
+
+```bash
+dotnet add package WACS.ComponentModel.Bindgen.Lib
+```
+
+## Forward — WIT to C#
+
+```csharp
+using Wacs.ComponentModel.Bindgen;
+
+var generator = new ForwardBindgen();
+var result = generator.Generate(
+    witPath: "wit/cli/world.wit",
+    options: new ForwardOptions
+    {
+        Namespace = "MyApp.Wasi",
+        TargetSide = BindingSide.Host,   // or Guest
+    });
+
+foreach (var (path, source) in result.Files)
+    File.WriteAllText(Path.Combine("./gen", path), source);
+```
+
+## Reverse — DLL to WIT
+
+```csharp
+var reverse = new ReverseBindgen();
+var (witFiles, csFiles) = reverse.Regenerate("path/to/transpiled.dll");
+
+File.WriteAllText("regen/world.wit", witFiles["world.wit"]);
+```
+
+## Build-time source generation
+
+For projects that consume WIT at compile time (no separate `wacs bindgen` invocation), the
+sibling source generator
+[`WACS.ComponentModel.Bindgen.SourceGen`](https://github.com/kelnishi/WACS/tree/main/Wacs.ComponentModel/Wacs.ComponentModel.Bindgen.SourceGen)
+runs inside the Roslyn pipeline. Both packages share the same emission core; this library
+exists for the imperative case where the codegen needs to drive directly (e.g. tooling that
+iterates on WIT during development).
+
+## Documentation
+
+- Top-level WACS [README](https://github.com/kelnishi/WACS#component-model--wasi-preview-2)
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+  for the runtime side
+
+## License
+
+Apache-2.0

--- a/Wacs.ComponentModel/Wacs.ComponentModel.Bindgen.Lib/Wacs.ComponentModel.Bindgen.Lib.csproj
+++ b/Wacs.ComponentModel/Wacs.ComponentModel.Bindgen.Lib/Wacs.ComponentModel.Bindgen.Lib.csproj
@@ -12,15 +12,23 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.ComponentModel.Bindgen.Lib</AssemblyName>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <Version>0.1.0</Version>
+        <AssemblyVersion>0.1.1</AssemblyVersion>
+        <Version>0.1.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="README.md">
+        <Pack>true</Pack>
+        <PackagePath/>
+      </None>
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Wacs.ComponentModel\Wacs.ComponentModel.csproj" />

--- a/Wacs.ComponentModel/Wacs.ComponentModel/README.md
+++ b/Wacs.ComponentModel/Wacs.ComponentModel/README.md
@@ -1,0 +1,75 @@
+# WACS.ComponentModel
+
+WebAssembly Component Model runtime for [WACS](https://github.com/kelnishi/WACS) — WIT parsing,
+canonical-ABI lift/lower, resource handles, and component instantiation. Layered on the same
+parse / validate / link pipeline WACS uses for core modules; works with both the interpreter
+and the AOT transpiler engines.
+
+## What's inside
+
+- **Component runtime** — `ComponentInstance.Instantiate`, resource registries, variant /
+  option / result / list / record / tuple / flags lift+lower
+- **Canonical ABI** — full lift/lower including aggregate returns through retArea, UTF-8 /
+  UTF-16 / Latin-1 string encodings, recursive variant arms, instance-method resource calls
+- **WIT parser** — vendored upstream grammar, `WitLoader` resolves `use` chains across
+  packages, embedded WIT files in assemblies via `WitContract.FromAssembly`
+- **`ComponentBridge`** — cross-engine adapter that lets interpreted and transpiled
+  components compose against the same typed contract
+- **`Linker.Validate(WitContract)`** — link-time check that bound host implementations
+  match the WIT contract (catches drift before the component runs)
+
+## Install
+
+```bash
+dotnet add package WACS.ComponentModel
+```
+
+## Quick start
+
+```csharp
+using Wacs.ComponentModel.Runtime;
+
+var bytes = File.ReadAllBytes("hello.component.wasm");
+var ci = ComponentInstance.Instantiate(bytes,
+    rt =>
+    {
+        // configure host bindings on the underlying WasmRuntime
+        // — `--bind` shims, WASI Preview 2 hosts, custom IBindables
+    });
+
+var result = ci.Invoke("greet", new object?[] { "world" });
+Console.WriteLine(result);
+```
+
+For the WASI Preview 2 host implementations (cli / clocks / filesystem / http / io /
+random / sockets), pair this package with [`WACS.WASI.Preview2`](https://www.nuget.org/packages/WACS.WASI.Preview2)
+or [`WACS.WASI.Preview2.DependencyInjection`](https://www.nuget.org/packages/WACS.WASI.Preview2.DependencyInjection).
+
+For programmatic WIT ↔ C# binding generation, see
+[`WACS.ComponentModel.Bindgen.Lib`](https://www.nuget.org/packages/WACS.ComponentModel.Bindgen.Lib).
+
+## Engines
+
+This package handles the component-model layer; the underlying core wasm executes through
+either:
+
+- **Interpreter** ([`WACS`](https://www.nuget.org/packages/WACS)) — AOT-safe, ~270–385 iter/s
+  on CoreMark, suitable for Unity IL2CPP / `PublishAot`.
+- **Transpiler** ([`WACS.Transpiler.Lib`](https://www.nuget.org/packages/WACS.Transpiler.Lib))
+  — `Reflection.Emit` AOT, ~17 500 iter/s on CoreMark, ~50% of native C speed.
+
+The `wacs run --wasip2` CLI verb auto-routes to the transpiler engine when WASI Preview 2
+host packages are wired. See the top-level
+[WACS README](https://github.com/kelnishi/WACS#component-model--wasi-preview-2) for the full
+matrix.
+
+## Documentation
+
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+  — runtime requirements, host-package composition, end-to-end CLI / embedder examples
+- [`Wacs.ComponentModel/Validation/README.md`](https://github.com/kelnishi/WACS/blob/main/Wacs.ComponentModel/Wacs.ComponentModel/Validation/README.md)
+  — WIT contract validation deep-dive
+
+## License
+
+Apache-2.0

--- a/Wacs.ComponentModel/Wacs.ComponentModel/Wacs.ComponentModel.csproj
+++ b/Wacs.ComponentModel/Wacs.ComponentModel/Wacs.ComponentModel.csproj
@@ -12,15 +12,23 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.ComponentModel</AssemblyName>
-        <AssemblyVersion>0.3.4</AssemblyVersion>
-        <Version>0.3.4</Version>
+        <AssemblyVersion>0.3.5</AssemblyVersion>
+        <Version>0.3.5</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
+    </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DebugSymbols>true</DebugSymbols>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/ARCHITECTURE.md
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/ARCHITECTURE.md
@@ -1,0 +1,706 @@
+# Wacs.Transpiler.Lib — Architecture
+
+The WACS AOT transpiler converts a WebAssembly module into a .NET assembly
+whose public surface is a regular CLR `Module` class with typed `IExports` /
+`IImports` interfaces. The generated assembly runs through the CLR's normal
+JIT (or NativeAOT codegen if the consumer asks), bypassing the
+expression-tree dispatch the interpreter (`Wacs.Core.Runtime`) uses.
+
+This README documents the *architecture* — pipeline stages, design choices,
+and a code map. For CLI usage and integration recipes, see the
+[`wacs aot` section](../../Wacs.Console/Wacs.Console/README.md#wacs-aot--wasm--nativeaot-native-binary)
+of the Wacs.Console README.
+
+## Where it sits
+
+```
+WASM bytes
+    │
+    ▼  BinaryModuleParser.ParseWasm
+WasmModule (Wacs.Core)
+    │
+    ▼  WasmRuntime.InstantiateModule   (interpreter pre-pass — types, validation)
+ModuleInstance
+    │
+    ▼  ModuleTranspiler.Transpile        ← THIS LIBRARY
+TranspilationResult { PersistedAssemblyBuilder, types, methods, manifest }
+    │
+    ▼  TranspilationResult.Bake          (Save → MemoryStream → AssemblyLoadContext.LoadFromStream)
+loaded Assembly with runtime-instantiable Module class
+    │
+    ▼  TranspiledModuleLoader.Load       (discovery + import wiring)
+LoadedModule handle ready for export invocation
+```
+
+The transpiler reuses the interpreter for the parse / validate / instantiate
+pre-pass — the same `WasmModule` and `ModuleInstance` types feed both engines.
+This guarantees the two engines see the same module shape and the spec-test
+corpus exercises both.
+
+## Public entry points
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `ModuleTranspiler.Transpile(ModuleInstance, WasmRuntime, string)` | `AOT/ModuleTranspiler.cs:313` | Compile a core wasm module to IL. Returns `TranspilationResult`. |
+| `ComponentTranspiler.TranspileSingleModule(Stream, …)` | `AOT/Component/ComponentTranspiler.cs:155` | Component-model wrapper. Routes to `ModuleTranspiler` and lays in the WIT-shaped surface (`ComponentExports`, `[WitSource]`-tagged `I{Iface}` types, `ComponentMetadata`). |
+| `TranspilationResult.Bake()` | `AOT/ModuleTranspiler.cs` | Save the `PersistedAssemblyBuilder` to a `MemoryStream`, load it back into the default `AssemblyLoadContext`, and remap public type/method accessors to the loaded types. Idempotent; auto-fired by public accessors. |
+| `TranspilationResult.SaveAssembly(string)` | `AOT/ModuleTranspiler.cs` | Persist to `.dll`. Internally bakes once and writes the cached PE bytes. |
+| `TranspiledModuleLoader.Load(string, object?, bool)` | `Hosting/TranspiledModuleLoader.cs:61` | Load a saved `.dll`, discover Module class + imports interface, instantiate, return a `LoadedModule` handle. Supports collectible `AssemblyLoadContext` isolation. |
+| `MainEntryEmitter.Emit(TranspilationResult, string, string)` | `AOT/MainEntryEmitter.cs` | Bake a `Program.Main(string[])` into the assembly that constructs the module, parses argv, and invokes a named export. Component-mode equivalent: `ComponentMainEntryEmitter`. |
+
+## Pipeline (linear walk)
+
+The numbered steps below correspond to comments in
+`AOT/ModuleTranspiler.cs:Transpile`.
+
+### 0. Assembly + module builder
+
+```csharp
+var assemblyBuilder = new PersistedAssemblyBuilder(
+    assemblyName, typeof(object).Assembly);
+var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name!);
+```
+
+`PersistedAssemblyBuilder` is the .NET 9+ replacement for the legacy
+`AssemblyBuilderAccess.Save` mode (which Microsoft removed when .NET Core
+shipped). Types defined under it are *metadata-only* until the assembly is
+serialized via `Save(Stream)` and reloaded; see [Bake](#bake) below.
+
+### 0a. Interface generation (`InterfaceGenerator`)
+
+Walks `moduleInst.Repr.Exports` / `moduleInst.Repr.Imports`. Emits two
+typed interfaces:
+
+- `IExports` — one method per wasm export, signature in CLR-ised form
+  (e.g. `i32` → `int`, `f64` → `double`, multi-return → `(out T1, out T2)`
+  pattern).
+- `IImports` — one method per wasm import. The Module class's constructor
+  takes one as a parameter; every guest→host call dispatches through it
+  (or, if the host package resolved the import, through inline IL — see
+  [direct-linked imports](#direct-linked-imports-component-mode)).
+
+Emits `[WacsTranspiledImports("Ns.IImports")]` on the assembly so
+`WACS.HostBindings.SourceGen` consumers can find the import surface. Also
+emits `[WacsImportNames]` carrying the `(methodName, wasmModule, wasmName)`
+mapping for source-gen binding match.
+
+### 0a.1. Host-package resolver (component mode only)
+
+If `TranspilerOptions.Resolver` is set, every import method is queried
+against it. Hits get inline IL emission (skips the delegate-table dispatch);
+misses keep the legacy path. The map is stashed on
+`_options.ResolverImportBindings` and consumed by `CallEmitter` /
+`DirectLinkedImportEmit` at IL emission time.
+
+### 0b. GC type emission (`GcTypeEmitter`)
+
+WASM GC structs/arrays become native CLR classes — typed fields, not
+`StoreStruct`/`Value[]` wrappers. Each emitted type registers under
+`(initDataId, typeIdx)` in `GcTypeRegistry`. The runtime's `ConvertStoreArray`
+and `ConvertStoreStruct` (`Emitters/GcEmitter.cs`) call
+`Activator.CreateInstance` against that runtime Type — see
+[GcTypeRegistry remap](#gctyperegistry-remap) for how those registry entries
+flow from metadata-only `TypeBuilder.CreateType()` results to runtime types.
+
+### 0c. Element segment evaluation (mostly eager, partly deferred)
+
+For each wasm element segment:
+
+```csharp
+for (int i = 0; i < elem.Initializers.Length; i++)
+    values[i] = EvaluateElemExpr(elem.Initializers[i], gcTypeEmitter);
+ModuleInit.RegisterElemSegment(values);
+```
+
+Initializers that produce GC objects (`array.new`, `array.new_default`,
+`array.new_fixed`) need the emitted CLR types to be runtime-instantiable —
+which they aren't yet under PAB. Those segments get flagged via
+`HasGcConstructor` (`AOT/ModuleTranspiler.cs`) and stashed on the result for
+post-Bake re-evaluation; see [Deferred GC element segments](#deferred-gc-element-segments).
+
+### 1. Method stubs (Pass 1)
+
+```csharp
+methodBuilders[i] = CreateMethodStub(typeBuilder, funcInst, funcType, i);
+```
+
+Each wasm function gets a `MethodBuilder` on the `Functions` class with the
+correct CLR signature: first param is `ThinContext` (carries memory, table,
+global slots), then mapped wasm params, then `out` params for multi-return
+results past the first. Two-pass design lets the IL emitter emit `call`
+references to functions defined later in the module without worrying about
+emit order.
+
+### 2. IL emission (Pass 2 — `FunctionCodegen` + emitters)
+
+```csharp
+var codegen = new FunctionCodegen(mb, funcInst, …);
+bool emitted = codegen.TryEmit();
+if (!emitted) EmitFallbackBody(mb, …);
+```
+
+`FunctionCodegen` walks the function's wasm instructions and dispatches each
+to a per-prefix emitter:
+
+| Prefix | Emitter | Examples |
+|---|---|---|
+| Numeric | `Emitters/NumericEmitter.cs` | `i32.add`, `f64.mul`, `local.tee`, … |
+| Variable | `Emitters/VariableEmitter.cs` | `local.get`, `local.set`, `global.get` |
+| Memory | `Emitters/MemoryEmitter.cs` | `i32.load`, `i64.store8`, `memory.size` |
+| Control | `Emitters/ControlEmitter.cs` | `block`, `loop`, `if`, `br`, `br_table` |
+| Call | `Emitters/CallEmitter.cs` | `call`, `call_indirect`, `return_call*` |
+| Reference | `Emitters/TableRefEmitter.cs` | `ref.null`, `ref.func`, `table.get` |
+| Bulk (0xFC prefix) | `Emitters/BulkEmitter.cs` | `memory.copy/fill/init`, `table.copy/init`, `data.drop`, `elem.drop` |
+| Atomic (0xFE prefix) | `Emitters/AtomicEmitter.cs` | `i32.atomic.rmw.add`, `memory.atomic.notify` |
+| GC (0xFB prefix) | `Emitters/GcEmitter.cs` | `struct.new`, `array.get_s`, `ref.test`, `br_on_cast` |
+| SIMD (0xFD prefix) | `Emitters/SimdEmitter.cs` | `v128.load`, `i32x4.add`, `i8x16.shuffle` |
+| Exceptions (0x06/0x07/0x08) | `Emitters/ExceptionEmitter.cs` | `try_table`, `throw`, `throw_ref` |
+
+Each emitter reads/writes the IL-side stack via `StackAnalysis` so multi-arity
+operations track type information across blocks. Functions whose IL would
+violate ECMA-335 stack consistency (or whose emit code rejects an unsupported
+edge case) fall back to a stub that throws `WacsTranspilerFallback` at runtime
+— the runtime then routes the call through the interpreter's stack invoker.
+
+`CilValidator` (`AOT/CilValidator.cs`) runs after IL emission and rejects bad
+emissions at *transpile time* instead of letting them surface as
+`InvalidProgramException` at JIT.
+
+### 3. Module class generation (`ModuleClassGenerator`)
+
+Builds the `Module` class consumers see. Hot code paths:
+
+- **Constructor** (`AOT/ModuleClassGenerator.cs:EmitConstructor`)
+  - Standard emission: calls `InitializationHelper.InitializeFromEmbedded(span, initDataId)` against the RVA-mapped codec blob (see [Codec blob](#codec-blob-__wacsinitdata)).
+  - AotLinked emission: builds `ThinContext` from inlined IL constants — no codec, no registry roundtrip. See [Emission targets](#emission-targets).
+- **Export methods** (`EmitExportMethods`) — one per `IExports` method, body forwards to the corresponding `Functions` static method with `_ctx` prepended.
+- **Memory properties** (`EmitMemoryProperties`) — exposes `Memory[i]` as `byte[]` getters so component-mode code (`ComponentExportsEmit`) can blit canonical-ABI strings/arrays.
+
+### 4. CreateType + Bake
+
+```csharp
+var functionsType = typeBuilder.CreateType()!;
+var moduleClassType = moduleClassGen.CreateType();
+var result = new TranspilationResult(…);
+result.SetPendingElemReeval(gcTypeEmitter, pendingElemReeval);
+return result;
+```
+
+After `Transpile` returns, the result is *pre-bake*: types are
+metadata-only `PersistedTypeBuilder.CreateType()` outputs. Callers that want
+to add more types — `MainEntryEmitter`, `ComponentMainEntryEmitter`,
+`ComponentTranspiler`'s composition step — do so via `result.ModuleBuilder`
+and the internal `*Builder` accessors. First touch of a public accessor
+(`result.Assembly`, `result.ModuleClass`, etc.) triggers `Bake()`, which
+freezes the builder.
+
+## Architectural design choices
+
+### PersistedAssemblyBuilder + Bake roundtrip
+
+**Why:** `AssemblyBuilder.DefineDynamicAssembly(Run)` produces an
+in-process-only assembly that can't be serialized. The legacy WACS
+transpiler (pre-migration) used `Lokad.ILPack 0.3.1` to walk the live dynamic
+assembly and write a PE — but Lokad NRE'd on `Ldtoken` of any field created
+via `DefineInitializedData`, blocking RVA-mapped data segments end-to-end.
+
+**Fix:** Build into a `PersistedAssemblyBuilder` (`System.Reflection.Emit`,
+.NET 9+). It supports `DefineInitializedData` end-to-end through `Save`. The
+catch is that its `TypeBuilder.CreateType()` returns a *metadata-only* Type
+that can't be `Activator.CreateInstance`'d — the runtime needs the assembly
+to round-trip through `Save(Stream)` + `AssemblyLoadContext.LoadFromStream`
+first.
+
+`TranspilationResult.Bake()` does the round-trip once and remaps:
+
+- `Assembly`, `ModuleClass`, `ExportsInterface`, `ImportsInterface`,
+  `FunctionsType` → resolved by `FullName` against the loaded assembly.
+- `Methods[]`, `FunctionMethodMap` → resolved by name + parameter
+  signature on the loaded declaring type.
+
+Public accessors (`Assembly`, `ModuleClass`, etc.) auto-bake on first read.
+Internal `*Builder` accessors (`ModuleClassBuilder`, `ExportsInterfaceBuilder`,
+…) skip the bake so emitters that run after `Transpile` returns can keep
+adding types via `result.ModuleBuilder`.
+
+#### Corelib AssemblyRef rewrite at SaveAssembly
+
+PAB stamps the saved DLL's corelib AssemblyRef as `System.Private.CoreLib`
+(the runtime impl identity, taken from `typeof(object).Assembly`). The C#
+compiler resolves base types from the ref-pack contract `System.Runtime`
+instead, so consumer csprojs that statically reference our saved `.dll`
+trip CS0012: *"the type 'Object' is defined in an assembly that is not
+referenced. You must add a reference to assembly 'System.Private.CoreLib'"*.
+
+The official PAB workaround
+([dotnet/runtime#103357](https://github.com/dotnet/runtime/issues/103357))
+is to hand PAB a `MetadataLoadContext`-loaded `System.Runtime` from the
+ref pack instead of `typeof(object).Assembly` — but only if every type
+passed to PAB is also MLC-bound. Our IL emit uses impl `typeof(...)`
+everywhere; mixing the two produces saved DLLs whose memberrefs can't
+runtime-bind. Migrating the entire IL-emit pipeline to MLC-bound corelib
+types is a large refactor we punted.
+
+Instead, [`CoreLibAssemblyRefRewriter`](AOT/CoreLibAssemblyRefRewriter.cs)
+post-processes a copy of the baked bytes at
+`TranspilationResult.SaveAssembly` time, rewriting the corelib AssemblyRef
+in place: name `System.Private.CoreLib` → `System.Runtime`, public-key
+blob shrunk from a 160-byte full key to the 8-byte System.Runtime PKT,
+Flags bit cleared. The runtime treats both identities as type-equivalent
+through type-forwards, so semantics are preserved. The in-process
+Bake/Load round-trip skips the rewriter entirely so the loaded
+`_assembly` keeps its impl-corelib identity for callers that introspect
+metadata reflectively.
+
+**Known limitation.** Generic-instantiation FieldRefs that cross the
+renamed corelib boundary (e.g. `[System.Runtime]List<Wacs.Core.Value>`)
+fail to bind in isolated `AssemblyLoadContext`s. The
+`AotLinkedCallIndirectModule_CrossProcess_RoundTrip` test exercises this
+(Skip-marked with the same explanation in the test source). The
+`wacs aot --wasi` smoke test path works fine because it uses Standard
+emission and never triggers AOT-linked generic FieldRefs. The hack
+disappears whenever PAB upstream fixes the issue or the IL-emit pipeline
+is migrated to MLC-bound corelib types — see the long-form rationale in
+the rewriter source.
+
+### RVA-mapped data segments
+
+Wasm data segment bytes are stored as RVA-mapped initialized data in the
+emitted PE — bytes live in the `.sdata`/`.rdata` section, demand-paged from
+disk by the OS loader, surfaced zero-copy as `ReadOnlySpan<byte>` via
+`RuntimeHelpers.CreateSpan<byte>(field.FieldHandle)`.
+
+Two distinct blobs:
+
+#### `__WACSAotData.Segment_N` (active data segments under AotLinked emission)
+
+`AOT/ModuleClassGenerator.cs:EmitDataSegmentCopies` emits, per active
+segment:
+
+```il
+ldtoken     <__WACSAotData.Segment_N>
+call        ReadOnlySpan<byte> RuntimeHelpers::CreateSpan<byte>(RuntimeFieldHandle)
+ldloc       ctxLocal
+ldfld       <ctx.Memories>
+ldc.i4      memIdx
+ldelem.ref
+ldfld       <Memory.Data>
+ldc.i4      offset
+ldc.i4      len
+call        BulkHelpers::CopySegmentToMemory(ReadOnlySpan<byte>, byte[], int, int)
+```
+
+`BulkHelpers.CopySegmentToMemory` (`AOT/Emitters/BulkEmitter.cs`) does
+`src.Slice(0, len).CopyTo(dst.AsSpan(dstOffset, len))` — a single
+`memcpy`-equivalent from PE pages to the wasm linear memory's backing array.
+
+#### Codec blob (`__WACSInit.Data`)
+
+The whole `ModuleInitData` (memories, tables, globals, type hashes,
+saved-segment bytes, deferred globals — everything the cross-process Module
+ctor needs) is serialized via `InitDataCodec.Encode` and stashed as RVA on
+`__WACSInit.Data`. The Module ctor IL:
+
+```il
+ldtoken     <__WACSInit.Data>
+call        ReadOnlySpan<byte> RuntimeHelpers::CreateSpan<byte>(RuntimeFieldHandle)
+ldc.i4      _initDataId
+call        ThinContext InitializationHelper::InitializeFromEmbedded(ReadOnlySpan<byte>, int)
+```
+
+`InitializeFromEmbedded` has two paths:
+
+- **In-process** (transpile-and-load in same process): `InitRegistry`
+  contains the entry; skip the codec entirely. The pinned span is never
+  touched.
+- **Cross-process** (saved `.dll` loaded fresh): `InitRegistry` is empty;
+  call `InitDataCodec.Decode(ReadOnlySpan<byte>)` which uses
+  `UnmanagedMemoryStream` over the pinned span — no allocation, no copy
+  (true zero-copy from PE pages to `ModuleInitData`).
+
+Pre-migration the same blob lived in the user-string heap (`#US`) as a
+base64 string literal decoded on cctor. That cost ~2.67× disk
+(4/3 base64 expansion × 2 UTF-16 doubling) plus a one-shot
+`Convert.FromBase64String` allocation at startup. Measurements on a 4 KB
+data segment fixture (see `Wacs.Transpiler.Test/PeShapeTests.cs`):
+
+| Metric | RVA path | Base64 baseline |
+|---|---|---|
+| Codec blob on disk | 4 205 B | 11 213 B |
+| Reduction | — | **62.5%** |
+
+### Deferred GC element segments
+
+GC-typed element-segment initializers (`array.new` etc.) need the emitted
+CLR class to be *runtime-instantiable* (so `Activator.CreateInstance` works).
+Pre-bake the class is metadata-only and `CreateInstance` refuses with
+`ArgumentException("Type must be a type provided by the runtime.")`.
+
+Pipeline:
+
+1. During `Transpile`, `ModuleInit.RegisterElemSegment` is called eagerly
+   with placeholder `Value(ValType.Any)` for any segment whose initializer
+   contains `array.new`/`array.new_default`/`array.new_fixed`.
+2. The (segId, initializers[]) pairs land on
+   `TranspilationResult._pendingElemReeval`.
+3. `Bake()` calls `gcTypeEmitter.RemapEmittedToLoadedTypes(loadedAssembly)`
+   — replaces every `EmittedTypes[idx].ClrType` with the runtime-loaded
+   equivalent.
+4. Re-runs `EvaluateElemExprForBake` against each captured initializer and
+   calls `ModuleInit.UpdateElemSegment` to overwrite the placeholder.
+
+Same pattern via `GcTypeRegistry.RemapToLoadedTypes` for the runtime
+helpers (`ConvertStoreArray`, `ConvertStoreStruct`) that consume the
+registry post-Bake.
+
+### Emission targets
+
+`TranspilerOptions.Emission` selects between three modes:
+
+- **`Auto`** (default) — picks `AotLinked` when the module fits the
+  feasibility envelope (`IsAotLinkedAutoPromotable` in
+  `ModuleClassGenerator.cs`); falls back to `Standard` otherwise.
+  Saves ~50% on first-trial cold start and ~28% on warm cold start
+  for promoted modules — the codec stack
+  (`InitDataCodec.Decode`, `BinaryReader`, `InitializeFromData`)
+  never JITs and never runs.
+- **`Standard`** — Module ctor calls
+  `InitializationHelper.InitializeFromEmbedded` against the RVA-mapped
+  codec blob. Cross-process safe; works for any module shape. The
+  codec machinery (`InitDataCodec`, `InitRegistry`, `ModuleInit`)
+  ships in the consumer's binary.
+- **`AotLinked`** — Module ctor builds `ThinContext` directly from
+  inlined IL constants. No `__WACSInit` holder, no codec call, no
+  registry dependency. NativeAOT consumers can dead-strip the codec
+  machinery from the final native binary. Throws at transpile time
+  via `AssertAotLinkedFeasible` if the module shape requires the
+  codec stack — use `Auto` for the "AotLinked when feasible,
+  Standard otherwise" semantics.
+
+The `AotLinkedSavedDllOmitsCodecHolderType` test
+(`Wacs.Transpiler.Test/AotLinkedEmissionTests.cs`) is the trim-evidence
+assertion: confirms the saved AotLinked `.dll` references neither the
+`__WACSInit` holder type nor `InitializeFromEmbedded`.
+
+#### Auto promotion envelope
+
+`IsAotLinkedAutoPromotable` is stricter than `IsAotLinkedFeasible` —
+it only promotes shapes already covered by an existing AotLinked
+emission test, so a configuration that's feasible-but-not-tested
+falls back to Standard rather than risking silent miscompilation.
+
+Currently auto-promoted:
+
+| Shape | Coverage |
+|---|---|
+| Compute-only modules | ✅ |
+| Single memory + active data segments | ✅ |
+| Primitive globals (i32/i64/f32/f64) + null/funcref/externref globals | ✅ |
+| Tables + funcref active element segments + `call_indirect` | ✅ |
+| `ref.test` / `br_on_cast` on funcref | ✅ |
+| Passive data segments + `memory.init` | ✅ |
+| Passive funcref element segments + `table.init` | ✅ |
+| Multi-memory | ✅ |
+| Local exception tags | ✅ |
+| Imported functions (wired through `IImports`) | ✅ |
+
+Still rejected — fall back to `Standard`:
+
+- Imported memory / table / global / tag (linker integration)
+- GC global inits (`array.new`, `struct.new` initializers)
+- GC element values (`ref.i31`, `array.new` in element segments)
+- Modules with non-encodable element segment initializers
+  (`global.get` references, etc.)
+
+The Auto-fallback path is silent: if a module isn't promotable, it
+just transpiles to Standard and the consumer sees the codec ctor.
+`Emission = AotLinked` explicitly throws if the user pinned the
+target but the module is out of envelope — useful for whole-program
+NativeAOT builds where you want a build-time error rather than a
+silent fallback.
+
+#### What AotLinked emission emits
+
+The AotLinked ctor body, in order (see
+`ModuleClassGenerator.EmitAotLinkedCtorBody`):
+
+1. **Memory / Table / Global arrays** — `EmitMemoryArray`,
+   `EmitTablesArray`, `EmitGlobalsArray` allocate per-instance
+   `MemoryInstance[]` / `TableInstance[]` / `GlobalInstance[]` from
+   constant counts + per-slot `Newobj` + `EmitPrimitiveValue` for
+   the initial value (handles primitives, null refs, non-null
+   funcref/externref).
+2. **`new ThinContext(memories, tables, globals, null, null)`** —
+   the `ImportDelegates` and `FuncTable` slots are populated later.
+3. **`EmitDataSegmentCopies`** — for each active data segment, copy
+   from `__WACSAotData.Segment_N` (RVA-mapped) into the right
+   memory slot via `BulkHelpers.CopySegmentToMemory`.
+4. **`EmitElementSegmentCopies`** — for each active funcref/null
+   element segment, write the resolved Value into
+   `ctx.Tables[i].Elements[slot]`.
+5. **`EmitTypeHashArrays`** — populate `ctx.FuncTypeHashes`,
+   `FuncTypeSuperHashes`, `TypeHashes`, `TypeIsFunc` as IL-baked
+   constant arrays (consumed by `call_indirect` subtype checks +
+   `ref.test`/`ref.cast`).
+6. **`EmitActiveSegmentDrops`** — `ModuleInit.DropDataSegment` /
+   `DropElemSegment` for each active segment (WASM 3.0 §4.5.4
+   step 16).
+7. **`EmitSegmentBaseIds`** — stamp `ctx.DataSegmentBaseId` /
+   `ElemSegmentBaseId` from transpile-time constants.
+8. **`EmitInitDataIdStamp`** — `ctx.InitDataId = _initDataId`. Keys
+   into `MultiReturnMethodRegistry` (call_indirect dispatch for
+   multi-result funcs) and `GcTypeRegistry` (runtime GC type
+   lookups).
+9. **`EmitPassiveDataSegmentRegistrations`** — for each passive
+   data segment, `ModuleInit.RegisterDataSegmentAt(absoluteId,
+   span.ToArray())` so cross-process `memory.init` resolves.
+10. **`EmitPassiveElementSegmentRegistrations`** — same recipe for
+    element segments, encoded as `int[]` (`-1` = null, `>=0` =
+    funcIdx).
+11. **`EmitTagsArray`** — `ctx.Tags = new TagInstance[totalTags]`
+    with one fresh `TagInstance(null)` per local tag (identity-
+    based equality only).
+
+After `EmitAotLinkedCtorBody`, the ctor falls through to the shared
+post-init steps used by `Standard`:
+`EmitImportDelegateWiring`, `EmitFuncTablePopulation`,
+`EmitTypedDelegateShimsAndRegister`, `EmitCabiReallocCacheIfPresent`,
+`BindTableDelegates`, `_ctx` field assignment, start-fn invocation.
+
+### Direct-linked imports (component mode)
+
+Default import dispatch:
+
+```il
+ldarg.0
+ldfld   ctx.ImportDelegates
+ldc.i4  i
+ldelem.ref
+… box args …
+callvirt System.Delegate::DynamicInvoke
+```
+
+That works but pays the boxing + dictionary-style dispatch on every
+guest→host call. With a `HostPackageResolver` configured,
+`DirectLinkedImportEmit` recognizes typed `[WitSource]`-tagged interfaces and
+emits inline IL:
+
+```il
+ldarg.0
+ldfld   ctx.HostBundle
+callvirt T_HostBundle::get_TypedInterface()
+… push wasm args (with canonical-ABI lift if needed) …
+callvirt I_TypedInterface::Method(…)
+… store results to wasm linear memory at retArea (canonical-ABI lower) …
+```
+
+Direct-linked dispatch handles roughly the same shape matrix
+`wit-bindgen-csharp` does:
+
+| Shape | Notes |
+|---|---|
+| primitives | `i32` / `i64` / `f32` / `f64` + narrow ints + `bool` |
+| `string` | `cabi_realloc` + UTF-8 / UTF-16 / Latin1 encode per import option |
+| `byte[]` (`list<u8>`) | `cabi_realloc` + raw memcpy |
+| `Option<T>` | recursive on inner shape (incl. `Option<Option<X>>` / `Option<Result<X,Y>>`) |
+| `Result<TOk, TErr>` | each arm storable per the same rules |
+| resource handle (`own<R>` / `borrow<R>`) | `Resources.AllocateResource` (return) / `Resources.GetResource` (param) |
+| `list<T>` for primitive `T` / `string` / `byte[]` | outer `(ptr, count)` + per-element store |
+| `list<list<T>>` | three-level `cabi_realloc` (outer pair-array + per-sub buffers) |
+| `list<own<R>>` | per-element `AllocateResource` + `i32` handle |
+| `list<tuple<...>>` / `list<record<...>>` | per-element fields packed inline at the type's natural stride. Field types may be primitive / `string` / `byte[]` **or `own<R>`** — covers `wasi:filesystem/preopens.get-directories` (`list<tuple<own<descriptor>, string>>`), `wasi:cli/environment.get-environment` (`list<tuple<string, string>>`), and the broader env / args / headers / TCP `accept` "list of (resource-or-string, label)" shape class. |
+| `list<Option<X>>` / `list<Result<X, Y>>` | per-element variant store at outer-ptr + i*elemSize |
+| variants | `EmitVariantStoreAt` per-case payload encoding |
+
+Shapes outside that fall back to the delegate path silently.
+`CanEmitDirect` (in `DirectLinkedImportEmit.cs`) is the gate;
+the resolver-aware predicate variants
+(`IsTupleOfFlatFields` / `IsRecordOfFlatFields`) are what gate
+the resource-bearing aggregates.
+
+### `ThinContext` — the runtime hand-off slot
+
+`AOT/ThinContext.cs` is the runtime context the generated IL threads
+through every call. Fields:
+
+- `Memories` / `Tables` / `Globals` — the standalone allocation slots,
+  populated either from the codec or from inlined IL (AotLinked).
+- `ImportDelegates` / `FuncTable` — used by call-indirect / non-direct-
+  linked imports.
+- `Module` / `Store` — back-references to the interpreter side, populated
+  only when the assembly runs inside a `WasmRuntime` (mixed-mode). Null in
+  standalone runs.
+- `HostBundle` — direct-linked imports' typed bundle source.
+- `Resources` — slot for component-resource handle tables.
+- `InitDataId` — the transpile-time `InitRegistry` key for in-process fast
+  paths.
+
+Every transpiled function takes `ThinContext` as its first parameter.
+Functions that need cross-module state (call_indirect to imported
+functions, throw-into-host, etc.) read it from there; pure compute
+functions ignore it.
+
+### Codec format (`InitDataCodec`)
+
+`AOT/InitDataCodec.cs` implements a versioned binary format documented in
+`AOT/InitDataFormat.md`. Header carries an 8-byte `WACSINIT` magic + 1-byte
+major + 1-byte minor + 2-byte reserved. Body is a sequence of
+`(tag, length-prefixed-payload)` sections.
+
+Encoder produces `byte[]`; decoder accepts both `byte[]` (legacy) and
+`ReadOnlySpan<byte>` (zero-copy, used by the RVA path). Both routes share a
+private `DecodeFromStream(Stream)` helper — the span overload wraps the
+pinned span in `UnmanagedMemoryStream` via `fixed (byte* p = bytes)`. This is
+the only `unsafe` block in the lib.
+
+Forward compat: unknown section tags are skipped via `ms.Position = end`,
+so a v1.M decoder can read v1.N (N > M) files for any additive section
+extension. Bumping major is the breaking-change escape hatch.
+
+## Testing surface
+
+| Test class | What it covers |
+|---|---|
+| `TranspilerTests` | Per-wast `TranspileEachWastModuleNoCrash` smoke — every spec-test wasm transpiles without throwing. |
+| `AotSpecTests` | Full WebAssembly 3.0 spec test suite executed through the transpiler — assert-equiv with the interpreter. |
+| `AotLinkedEmissionTests` | AotLinked emission end-to-end + trim-evidence (saved `.dll` doesn't reference codec machinery). |
+| `CrossProcessLoadTests` | Save → wipe `InitRegistry`/`ModuleInit` → load via `AssemblyLoadContext` → invoke. Exercises the cross-process codec path that the in-process tests don't. |
+| `PeShapeTests` | PE-shape regression assertions: `__WACSInit.Data` field RVA non-zero, no large UTF-16 LE base64 run in the `.dll`, plus diagnostic prints (assembly size + cold-start timing). |
+| `ComponentTranspilerTests` | Component-mode emission — argv-parse `--emit-main`, named-WIT-type lookup, tuple-return / Result-return shapes. |
+| `DirectLinkedImportTests` | Component-mode inline-IL import dispatch matrix (primitives, strings, lists, options, results, resources). |
+| `BranchHintEmissionTests` | `metadata.code.branch_hint` custom-section consumption — `if`-arm reordering and `_coldTailEmissions`. |
+| `InitDataCodecTests` | Codec encode/decode round-trip for every section. |
+
+## Code map
+
+```
+Wacs.Transpiler.Lib/
+├── AOT/
+│   ├── ModuleTranspiler.cs        — orchestrator + TranspilationResult lifecycle (Bake)
+│   ├── FunctionCodegen.cs         — per-function IL emission driver, dispatches to emitters
+│   ├── ModuleClassGenerator.cs    — Module class shape: ctor, exports, memory props
+│   ├── InterfaceGenerator.cs      — IExports / IImports interface emission
+│   ├── GcTypeEmitter.cs           — WASM GC structs/arrays → CLR classes
+│   ├── DataSegmentEmitter.cs      — wasm data section walker; emits MemoryDecl + DataSegmentInfo
+│   ├── InitDataCodec.cs           — versioned binary serializer for ModuleInitData
+│   ├── InitDataFormat.md          — codec format spec
+│   ├── InitializationHelper.cs    — runtime init, GcTypeRegistry, ModuleInit
+│   ├── ModuleInit.cs              — runtime-side data/element segment registry
+│   ├── ThinContext.cs             — runtime context threaded through transpiled IL
+│   ├── ModuleLinker.cs            — multi-module composition (cross-module imports)
+│   ├── CilValidator.cs            — transpile-time CIL stack-shape validation
+│   ├── StackAnalysis.cs           — typed-stack tracking during emission
+│   ├── TranspilerOptions.cs       — public options surface (SIMD strategy, emission target, …)
+│   ├── MainEntryEmitter.cs        — emits Program.Main for core-WASM modules
+│   ├── Emitters/
+│   │   ├── NumericEmitter.cs      — i32/i64/f32/f64 + sign-ext + wrap
+│   │   ├── VariableEmitter.cs     — local.get/set/tee, global.get/set
+│   │   ├── MemoryEmitter.cs       — load/store + memory.size/grow
+│   │   ├── ControlEmitter.cs      — block/loop/if/br/br_table/return
+│   │   ├── CallEmitter.cs         — call/call_indirect/return_call*
+│   │   ├── TableRefEmitter.cs     — ref.* + table.*
+│   │   ├── BulkEmitter.cs         — 0xFC-prefix bulk memory/table + BulkHelpers runtime helper
+│   │   ├── AtomicEmitter.cs       — 0xFE-prefix shared-memory atomics
+│   │   ├── GcEmitter.cs           — 0xFB-prefix struct/array/i31/extern + ConvertStoreArray/Struct
+│   │   ├── SimdEmitter.cs         — 0xFD-prefix v128 (scalar + intrinsics paths)
+│   │   ├── SimdHelpers.cs         — scalar fallback implementations of v128 ops
+│   │   └── ExceptionEmitter.cs    — try_table/throw/throw_ref + WasmException
+│   └── Component/
+│       ├── ComponentTranspiler.cs       — component-model entry point
+│       ├── ComponentExportsEmit.cs      — emits ComponentExports static class with WIT-shaped methods
+│       ├── ExportInterfaceEmit.cs       — emits [WitSource]-tagged I{Iface} types
+│       ├── DirectLinkedImportEmit.cs    — inline IL import dispatch
+│       ├── HostPackageResolver.cs       — discovers (package, interface, item) bindings on host packages
+│       ├── ComponentMainEntryEmitter.cs — Program.Main for components
+│       ├── ComponentMainHost.cs         — argv parser + invoker shared by ComponentMain
+│       ├── ComponentImportStubs.cs      — DispatchProxy-based no-op IImports for components
+│       ├── ComponentAssemblyEmit.cs     — embeds ComponentMetadata.EmbeddedWitBytes
+│       └── TupleFieldAccess.cs          — Roslyn-compiled ItemPofN<…> helpers (PAB-Ldfld workaround)
+└── Hosting/
+    ├── TranspiledModuleLoader.cs  — public `Load(path|assembly, imports?, isolate?)` entry
+    ├── HostedRunner.cs            — runs an export through a TranspilationResult (used by --run path)
+    ├── ImportDispatcher.cs        — DispatchProxy factory for IImports proxies; throws on missing handler by default, lenient: true opts out
+    └── BindingLoader.cs           — IBindable assembly discovery (for --bind)
+```
+
+## Key invariants and constraints
+
+- **`Wacs.Core` stays at `net8.0;netstandard2.1`** — runtime-side public
+  surface. The transpiler-side projects (`Wacs.Transpiler.Lib`,
+  `Wacs.Transpiler`, `Wacs.Console`, `Wacs.Transpiler.Test`,
+  `Wacs.ComponentModel.Bindgen.Test`, `Wacs.Bench`) are at `net9.0` for
+  `PersistedAssemblyBuilder`.
+- **AOT compatibility is a hard requirement.** No runtime
+  `Reflection.Emit`, no `MakeGenericMethod` outside source-generators or
+  build-time code. The transpiler itself runs on the dev machine; the
+  generated assembly must be NativeAOT-friendly. Components emitted with
+  `Emission = AotLinked` can be dead-stripped of the codec stack.
+- **Transpile-time validation > runtime validation.** `CilValidator`,
+  `Debug.Assert` on `Value` construction, no sentinel types — the goal is
+  every transpile failure surfaces with a (module, instruction, reason)
+  triple at transpile time, never as `InvalidProgramException` at JIT.
+- **Symmetric API surfaces across engines.** A consumer who writes against
+  `WasmRuntime + ModuleInstance` (interpreter) can swap to a transpiled
+  `Module` class without API churn — same `IExports`, same `IImports`,
+  same memory model.
+- **The text and binary parsers must agree.** A bug in `BinaryModuleParser`
+  is mirrored in `TextModuleParser`; fixes go in the validator layer when
+  the gap is value-range. The transpiler trusts whatever `ModuleInstance`
+  the parse produces.
+
+## Performance characteristics
+
+Cold start of a 4 KB-data-segment saved `.dll`, measured by
+`PeShapeTests.Diagnostic_ColdStartFromSavedDll`:
+
+| Phase | Time |
+|---|---|
+| `AssemblyLoadContext.LoadFromAssemblyPath` | ~110 µs |
+| Module ctor (cross-process codec decode + memory init + segment copy) | ~3.3 ms |
+| First export call (read byte at offset 0) | ~150 µs |
+| **Total cold** | **~3.6 ms** |
+
+In-process transpile cold start is dominated by IL emission (Pass 2). For
+larger modules (CoreMark scale) IL emission dominates over PAB
+`Save`+`Load`. AotLinked emission elides the codec decode; for compute-only
+fixtures the Module ctor drops to sub-100 µs.
+
+### Auto vs Standard on fib(100) cold start
+
+`Wacs.Bench.Coldstart` numbers (post-warmup median for steady-state,
+first-trial for cold), µs:
+
+| Phase | Standard | AotLinked (Auto-promoted) | Δ |
+|---|---|---|---|
+| Activate (first) | 1715 | 765 | **−55%** |
+| Activate (steady) | 289 | 198 | **−32%** |
+| TOTAL (first) | 1981 | 989 | **−50%** |
+| TOTAL (steady) | 417 | 300 | **−28%** |
+
+Saved `.dll` size on the same fixture: 4 608 → 4 096 bytes
+(**−11%**) — the `__WACSInit` codec blob is gone.
+
+### Phase breakdown of an AotLinked Module ctor (post-warmup, fib)
+
+`PeShapeTests.Diagnostic_ProfileModuleCtor` decomposes the ctor.
+For fib (1 export, no funcref tables) post-warmup:
+
+| Phase | Time |
+|---|---|
+| AssemblyLoadContext.LoadFromAssemblyPath | ~15 µs |
+| `RuntimeHelpers.CreateSpan<byte>` over `__WACSInit.Data` (Standard) | ~4 µs |
+| `InitDataCodec.Decode(span)` (Standard, cross-process) | ~6 µs |
+| `InitializeFromData` (Standard, cross-process) | ~5 µs |
+| Activator.CreateInstance (full ctor) | ~150-300 µs |
+| Residual (FuncTable + delegate shims + BindTableDelegates) | ~130 µs |
+
+The codec stack is sub-30 µs even on the cross-process path under
+Standard — what AotLinked saves is the **first-trial JIT** of those
+methods, plus skipping their work entirely. The structural ~130 µs
+residual is the same under both emissions (FuncTable population
+is amortizable via static-template work that's been analyzed but
+not landed).
+
+## License
+
+Apache 2.0 — see [LICENSE](https://github.com/kelnishi/WACS/blob/main/LICENSE).

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/README.md
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/README.md
@@ -1,706 +1,147 @@
-# Wacs.Transpiler.Lib — Architecture
+# WACS.Transpiler.Lib
 
-The WACS AOT transpiler converts a WebAssembly module into a .NET assembly
-whose public surface is a regular CLR `Module` class with typed `IExports` /
-`IImports` interfaces. The generated assembly runs through the CLR's normal
-JIT (or NativeAOT codegen if the consumer asks), bypassing the
-expression-tree dispatch the interpreter (`Wacs.Core.Runtime`) uses.
+Programmatic API for WACS's ahead-of-time WebAssembly → .NET IL transpiler. Reference this
+package when you want to drive transpilation, loading, and dispatch of saved
+`.dll`s **from inside a host process** — Unity / Godot embedders, ASP.NET workers, custom
+toolchains, build pipelines.
 
-This README documents the *architecture* — pipeline stages, design choices,
-and a code map. For CLI usage and integration recipes, see the
-[`wacs aot` section](../../Wacs.Console/Wacs.Console/README.md#wacs-aot--wasm--nativeaot-native-binary)
-of the Wacs.Console README.
+For one-shot CLI use (`wacs build app.wasm -o app.dll`), install
+[`WACS.Cli`](https://www.nuget.org/packages/WACS.Cli) instead. This package is the
+library API behind that CLI.
 
-## Where it sits
+## Install
 
-```
-WASM bytes
-    │
-    ▼  BinaryModuleParser.ParseWasm
-WasmModule (Wacs.Core)
-    │
-    ▼  WasmRuntime.InstantiateModule   (interpreter pre-pass — types, validation)
-ModuleInstance
-    │
-    ▼  ModuleTranspiler.Transpile        ← THIS LIBRARY
-TranspilationResult { PersistedAssemblyBuilder, types, methods, manifest }
-    │
-    ▼  TranspilationResult.Bake          (Save → MemoryStream → AssemblyLoadContext.LoadFromStream)
-loaded Assembly with runtime-instantiable Module class
-    │
-    ▼  TranspiledModuleLoader.Load       (discovery + import wiring)
-LoadedModule handle ready for export invocation
+```bash
+dotnet add package WACS.Transpiler.Lib
 ```
 
-The transpiler reuses the interpreter for the parse / validate / instantiate
-pre-pass — the same `WasmModule` and `ModuleInstance` types feed both engines.
-This guarantees the two engines see the same module shape and the spec-test
-corpus exercises both.
+## Quick start — in-process transpile + run
 
-## Public entry points
-
-| Symbol | File | Purpose |
-|---|---|---|
-| `ModuleTranspiler.Transpile(ModuleInstance, WasmRuntime, string)` | `AOT/ModuleTranspiler.cs:313` | Compile a core wasm module to IL. Returns `TranspilationResult`. |
-| `ComponentTranspiler.TranspileSingleModule(Stream, …)` | `AOT/Component/ComponentTranspiler.cs:155` | Component-model wrapper. Routes to `ModuleTranspiler` and lays in the WIT-shaped surface (`ComponentExports`, `[WitSource]`-tagged `I{Iface}` types, `ComponentMetadata`). |
-| `TranspilationResult.Bake()` | `AOT/ModuleTranspiler.cs` | Save the `PersistedAssemblyBuilder` to a `MemoryStream`, load it back into the default `AssemblyLoadContext`, and remap public type/method accessors to the loaded types. Idempotent; auto-fired by public accessors. |
-| `TranspilationResult.SaveAssembly(string)` | `AOT/ModuleTranspiler.cs` | Persist to `.dll`. Internally bakes once and writes the cached PE bytes. |
-| `TranspiledModuleLoader.Load(string, object?, bool)` | `Hosting/TranspiledModuleLoader.cs:61` | Load a saved `.dll`, discover Module class + imports interface, instantiate, return a `LoadedModule` handle. Supports collectible `AssemblyLoadContext` isolation. |
-| `MainEntryEmitter.Emit(TranspilationResult, string, string)` | `AOT/MainEntryEmitter.cs` | Bake a `Program.Main(string[])` into the assembly that constructs the module, parses argv, and invokes a named export. Component-mode equivalent: `ComponentMainEntryEmitter`. |
-
-## Pipeline (linear walk)
-
-The numbered steps below correspond to comments in
-`AOT/ModuleTranspiler.cs:Transpile`.
-
-### 0. Assembly + module builder
+JIT-capable hosts (desktop, server, `dotnet run`, Godot Mono) can transpile and execute
+in one step using `Reflection.Emit`. Roughly **64×** the WACS interpreter on
+compute-bound workloads (~17 500 vs ~270 iter/s on CoreMark, M3 Max).
 
 ```csharp
-var assemblyBuilder = new PersistedAssemblyBuilder(
-    assemblyName, typeof(object).Assembly);
-var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name!);
+using Wacs.Core;
+using Wacs.Core.Runtime;
+using Wacs.Transpiler.AOT;
+
+var runtime = new WasmRuntime();
+runtime.BindHostFunction<Action<int>>(("env", "log"), v => Console.WriteLine(v));
+
+using var fs = File.OpenRead("app.wasm");
+var module = BinaryModuleParser.ParseWasm(fs);
+var moduleInst = runtime.InstantiateModule(module);
+
+var transpiler = new ModuleTranspiler("MyApp.Wasm", new TranspilerOptions
+{
+    Simd = SimdStrategy.HardwareIntrinsics,
+});
+var result = transpiler.Transpile(moduleInst, runtime, "WasmModule");
+
+// result.ModuleClass is a fresh CLR Type. Construct + invoke through
+// the generated IExports / IImports interfaces.
 ```
 
-`PersistedAssemblyBuilder` is the .NET 9+ replacement for the legacy
-`AssemblyBuilderAccess.Save` mode (which Microsoft removed when .NET Core
-shipped). Types defined under it are *metadata-only* until the assembly is
-serialized via `Save(Stream)` and reloaded; see [Bake](#bake) below.
+## Quick start — pre-compile + load (AOT-safe runtime)
 
-### 0a. Interface generation (`InterfaceGenerator`)
+For AOT-only targets that can't run `Reflection.Emit` (Unity IL2CPP, NativeAOT, iOS, Mono
+AOT), pre-compile on a JIT host and ship the `.dll`:
 
-Walks `moduleInst.Repr.Exports` / `moduleInst.Repr.Imports`. Emits two
-typed interfaces:
+```bash
+# On the build machine:
+wacs build app.wasm -o app.dll
+```
 
-- `IExports` — one method per wasm export, signature in CLR-ised form
-  (e.g. `i32` → `int`, `f64` → `double`, multi-return → `(out T1, out T2)`
-  pattern).
-- `IImports` — one method per wasm import. The Module class's constructor
-  takes one as a parameter; every guest→host call dispatches through it
-  (or, if the host package resolved the import, through inline IL — see
-  [direct-linked imports](#direct-linked-imports-component-mode)).
-
-Emits `[WacsTranspiledImports("Ns.IImports")]` on the assembly so
-`WACS.HostBindings.SourceGen` consumers can find the import surface. Also
-emits `[WacsImportNames]` carrying the `(methodName, wasmModule, wasmName)`
-mapping for source-gen binding match.
-
-### 0a.1. Host-package resolver (component mode only)
-
-If `TranspilerOptions.Resolver` is set, every import method is queried
-against it. Hits get inline IL emission (skips the delegate-table dispatch);
-misses keep the legacy path. The map is stashed on
-`_options.ResolverImportBindings` and consumed by `CallEmitter` /
-`DirectLinkedImportEmit` at IL emission time.
-
-### 0b. GC type emission (`GcTypeEmitter`)
-
-WASM GC structs/arrays become native CLR classes — typed fields, not
-`StoreStruct`/`Value[]` wrappers. Each emitted type registers under
-`(initDataId, typeIdx)` in `GcTypeRegistry`. The runtime's `ConvertStoreArray`
-and `ConvertStoreStruct` (`Emitters/GcEmitter.cs`) call
-`Activator.CreateInstance` against that runtime Type — see
-[GcTypeRegistry remap](#gctyperegistry-remap) for how those registry entries
-flow from metadata-only `TypeBuilder.CreateType()` results to runtime types.
-
-### 0c. Element segment evaluation (mostly eager, partly deferred)
-
-For each wasm element segment:
+Then load it at runtime via `TranspiledModuleLoader` — same throughput, no
+`Reflection.Emit` dependency:
 
 ```csharp
-for (int i = 0; i < elem.Initializers.Length; i++)
-    values[i] = EvaluateElemExpr(elem.Initializers[i], gcTypeEmitter);
-ModuleInit.RegisterElemSegment(values);
+using Wacs.Core.Runtime;
+using Wacs.Transpiler.Hosting;
+
+var runtime = new WasmRuntime();
+runtime.BindHostFunction<Action<int>>(("env", "log"), v => Console.WriteLine(v));
+
+var loader = new TranspiledModuleLoader();
+var loaded = loader.Load("app.dll", runtime);
+// loaded.Invoke / loaded.Exports give you the typed surface
 ```
 
-Initializers that produce GC objects (`array.new`, `array.new_default`,
-`array.new_fixed`) need the emitted CLR types to be runtime-instantiable —
-which they aren't yet under PAB. Those segments get flagged via
-`HasGcConstructor` (`AOT/ModuleTranspiler.cs`) and stashed on the result for
-post-Bake re-evaluation; see [Deferred GC element segments](#deferred-gc-element-segments).
+## Component model
 
-### 1. Method stubs (Pass 1)
+For component-mode wasm (the wasi-p2 / `.component.wasm` shape), pair this package with
+[`WACS.ComponentModel`](https://www.nuget.org/packages/WACS.ComponentModel) and use
+`ComponentTranspiler.TranspileSingleModule`:
 
 ```csharp
-methodBuilders[i] = CreateMethodStub(typeBuilder, funcInst, funcType, i);
+using Wacs.Transpiler.AOT.Component;
+
+using var fs = File.OpenRead("app.component.wasm");
+var result = ComponentTranspiler.TranspileSingleModule(
+    fs,
+    assemblyNamespace: "MyApp.Wasm",
+    moduleName: "Module",
+    options: new TranspilerOptions
+    {
+        // HostPackageResolver auto-built when null — walks HostPackages
+        HostPackages = new[]
+        {
+            typeof(Wacs.WASI.Preview2.Cli.CliBindings).Assembly,
+            typeof(Wacs.WASI.Preview2.DependencyInjection.WasiPreview2Bundle).Assembly,
+        },
+    },
+    configureImports: rt =>
+    {
+        // Wire WASI Preview 2 + custom IBindable host packages
+    });
 ```
 
-Each wasm function gets a `MethodBuilder` on the `Functions` class with the
-correct CLR signature: first param is `ThinContext` (carries memory, table,
-global slots), then mapped wasm params, then `out` params for multi-return
-results past the first. Two-pass design lets the IL emitter emit `call`
-references to functions defined later in the module without worrying about
-emit order.
-
-### 2. IL emission (Pass 2 — `FunctionCodegen` + emitters)
-
-```csharp
-var codegen = new FunctionCodegen(mb, funcInst, …);
-bool emitted = codegen.TryEmit();
-if (!emitted) EmitFallbackBody(mb, …);
-```
-
-`FunctionCodegen` walks the function's wasm instructions and dispatches each
-to a per-prefix emitter:
-
-| Prefix | Emitter | Examples |
-|---|---|---|
-| Numeric | `Emitters/NumericEmitter.cs` | `i32.add`, `f64.mul`, `local.tee`, … |
-| Variable | `Emitters/VariableEmitter.cs` | `local.get`, `local.set`, `global.get` |
-| Memory | `Emitters/MemoryEmitter.cs` | `i32.load`, `i64.store8`, `memory.size` |
-| Control | `Emitters/ControlEmitter.cs` | `block`, `loop`, `if`, `br`, `br_table` |
-| Call | `Emitters/CallEmitter.cs` | `call`, `call_indirect`, `return_call*` |
-| Reference | `Emitters/TableRefEmitter.cs` | `ref.null`, `ref.func`, `table.get` |
-| Bulk (0xFC prefix) | `Emitters/BulkEmitter.cs` | `memory.copy/fill/init`, `table.copy/init`, `data.drop`, `elem.drop` |
-| Atomic (0xFE prefix) | `Emitters/AtomicEmitter.cs` | `i32.atomic.rmw.add`, `memory.atomic.notify` |
-| GC (0xFB prefix) | `Emitters/GcEmitter.cs` | `struct.new`, `array.get_s`, `ref.test`, `br_on_cast` |
-| SIMD (0xFD prefix) | `Emitters/SimdEmitter.cs` | `v128.load`, `i32x4.add`, `i8x16.shuffle` |
-| Exceptions (0x06/0x07/0x08) | `Emitters/ExceptionEmitter.cs` | `try_table`, `throw`, `throw_ref` |
-
-Each emitter reads/writes the IL-side stack via `StackAnalysis` so multi-arity
-operations track type information across blocks. Functions whose IL would
-violate ECMA-335 stack consistency (or whose emit code rejects an unsupported
-edge case) fall back to a stub that throws `WacsTranspilerFallback` at runtime
-— the runtime then routes the call through the interpreter's stack invoker.
-
-`CilValidator` (`AOT/CilValidator.cs`) runs after IL emission and rejects bad
-emissions at *transpile time* instead of letting them surface as
-`InvalidProgramException` at JIT.
-
-### 3. Module class generation (`ModuleClassGenerator`)
-
-Builds the `Module` class consumers see. Hot code paths:
-
-- **Constructor** (`AOT/ModuleClassGenerator.cs:EmitConstructor`)
-  - Standard emission: calls `InitializationHelper.InitializeFromEmbedded(span, initDataId)` against the RVA-mapped codec blob (see [Codec blob](#codec-blob-__wacsinitdata)).
-  - AotLinked emission: builds `ThinContext` from inlined IL constants — no codec, no registry roundtrip. See [Emission targets](#emission-targets).
-- **Export methods** (`EmitExportMethods`) — one per `IExports` method, body forwards to the corresponding `Functions` static method with `_ctx` prepended.
-- **Memory properties** (`EmitMemoryProperties`) — exposes `Memory[i]` as `byte[]` getters so component-mode code (`ComponentExportsEmit`) can blit canonical-ABI strings/arrays.
-
-### 4. CreateType + Bake
-
-```csharp
-var functionsType = typeBuilder.CreateType()!;
-var moduleClassType = moduleClassGen.CreateType();
-var result = new TranspilationResult(…);
-result.SetPendingElemReeval(gcTypeEmitter, pendingElemReeval);
-return result;
-```
-
-After `Transpile` returns, the result is *pre-bake*: types are
-metadata-only `PersistedTypeBuilder.CreateType()` outputs. Callers that want
-to add more types — `MainEntryEmitter`, `ComponentMainEntryEmitter`,
-`ComponentTranspiler`'s composition step — do so via `result.ModuleBuilder`
-and the internal `*Builder` accessors. First touch of a public accessor
-(`result.Assembly`, `result.ModuleClass`, etc.) triggers `Bake()`, which
-freezes the builder.
-
-## Architectural design choices
-
-### PersistedAssemblyBuilder + Bake roundtrip
-
-**Why:** `AssemblyBuilder.DefineDynamicAssembly(Run)` produces an
-in-process-only assembly that can't be serialized. The legacy WACS
-transpiler (pre-migration) used `Lokad.ILPack 0.3.1` to walk the live dynamic
-assembly and write a PE — but Lokad NRE'd on `Ldtoken` of any field created
-via `DefineInitializedData`, blocking RVA-mapped data segments end-to-end.
-
-**Fix:** Build into a `PersistedAssemblyBuilder` (`System.Reflection.Emit`,
-.NET 9+). It supports `DefineInitializedData` end-to-end through `Save`. The
-catch is that its `TypeBuilder.CreateType()` returns a *metadata-only* Type
-that can't be `Activator.CreateInstance`'d — the runtime needs the assembly
-to round-trip through `Save(Stream)` + `AssemblyLoadContext.LoadFromStream`
-first.
-
-`TranspilationResult.Bake()` does the round-trip once and remaps:
-
-- `Assembly`, `ModuleClass`, `ExportsInterface`, `ImportsInterface`,
-  `FunctionsType` → resolved by `FullName` against the loaded assembly.
-- `Methods[]`, `FunctionMethodMap` → resolved by name + parameter
-  signature on the loaded declaring type.
-
-Public accessors (`Assembly`, `ModuleClass`, etc.) auto-bake on first read.
-Internal `*Builder` accessors (`ModuleClassBuilder`, `ExportsInterfaceBuilder`,
-…) skip the bake so emitters that run after `Transpile` returns can keep
-adding types via `result.ModuleBuilder`.
-
-#### Corelib AssemblyRef rewrite at SaveAssembly
-
-PAB stamps the saved DLL's corelib AssemblyRef as `System.Private.CoreLib`
-(the runtime impl identity, taken from `typeof(object).Assembly`). The C#
-compiler resolves base types from the ref-pack contract `System.Runtime`
-instead, so consumer csprojs that statically reference our saved `.dll`
-trip CS0012: *"the type 'Object' is defined in an assembly that is not
-referenced. You must add a reference to assembly 'System.Private.CoreLib'"*.
-
-The official PAB workaround
-([dotnet/runtime#103357](https://github.com/dotnet/runtime/issues/103357))
-is to hand PAB a `MetadataLoadContext`-loaded `System.Runtime` from the
-ref pack instead of `typeof(object).Assembly` — but only if every type
-passed to PAB is also MLC-bound. Our IL emit uses impl `typeof(...)`
-everywhere; mixing the two produces saved DLLs whose memberrefs can't
-runtime-bind. Migrating the entire IL-emit pipeline to MLC-bound corelib
-types is a large refactor we punted.
-
-Instead, [`CoreLibAssemblyRefRewriter`](AOT/CoreLibAssemblyRefRewriter.cs)
-post-processes a copy of the baked bytes at
-`TranspilationResult.SaveAssembly` time, rewriting the corelib AssemblyRef
-in place: name `System.Private.CoreLib` → `System.Runtime`, public-key
-blob shrunk from a 160-byte full key to the 8-byte System.Runtime PKT,
-Flags bit cleared. The runtime treats both identities as type-equivalent
-through type-forwards, so semantics are preserved. The in-process
-Bake/Load round-trip skips the rewriter entirely so the loaded
-`_assembly` keeps its impl-corelib identity for callers that introspect
-metadata reflectively.
-
-**Known limitation.** Generic-instantiation FieldRefs that cross the
-renamed corelib boundary (e.g. `[System.Runtime]List<Wacs.Core.Value>`)
-fail to bind in isolated `AssemblyLoadContext`s. The
-`AotLinkedCallIndirectModule_CrossProcess_RoundTrip` test exercises this
-(Skip-marked with the same explanation in the test source). The
-`wacs aot --wasi` smoke test path works fine because it uses Standard
-emission and never triggers AOT-linked generic FieldRefs. The hack
-disappears whenever PAB upstream fixes the issue or the IL-emit pipeline
-is migrated to MLC-bound corelib types — see the long-form rationale in
-the rewriter source.
-
-### RVA-mapped data segments
-
-Wasm data segment bytes are stored as RVA-mapped initialized data in the
-emitted PE — bytes live in the `.sdata`/`.rdata` section, demand-paged from
-disk by the OS loader, surfaced zero-copy as `ReadOnlySpan<byte>` via
-`RuntimeHelpers.CreateSpan<byte>(field.FieldHandle)`.
-
-Two distinct blobs:
-
-#### `__WACSAotData.Segment_N` (active data segments under AotLinked emission)
-
-`AOT/ModuleClassGenerator.cs:EmitDataSegmentCopies` emits, per active
-segment:
-
-```il
-ldtoken     <__WACSAotData.Segment_N>
-call        ReadOnlySpan<byte> RuntimeHelpers::CreateSpan<byte>(RuntimeFieldHandle)
-ldloc       ctxLocal
-ldfld       <ctx.Memories>
-ldc.i4      memIdx
-ldelem.ref
-ldfld       <Memory.Data>
-ldc.i4      offset
-ldc.i4      len
-call        BulkHelpers::CopySegmentToMemory(ReadOnlySpan<byte>, byte[], int, int)
-```
-
-`BulkHelpers.CopySegmentToMemory` (`AOT/Emitters/BulkEmitter.cs`) does
-`src.Slice(0, len).CopyTo(dst.AsSpan(dstOffset, len))` — a single
-`memcpy`-equivalent from PE pages to the wasm linear memory's backing array.
-
-#### Codec blob (`__WACSInit.Data`)
-
-The whole `ModuleInitData` (memories, tables, globals, type hashes,
-saved-segment bytes, deferred globals — everything the cross-process Module
-ctor needs) is serialized via `InitDataCodec.Encode` and stashed as RVA on
-`__WACSInit.Data`. The Module ctor IL:
-
-```il
-ldtoken     <__WACSInit.Data>
-call        ReadOnlySpan<byte> RuntimeHelpers::CreateSpan<byte>(RuntimeFieldHandle)
-ldc.i4      _initDataId
-call        ThinContext InitializationHelper::InitializeFromEmbedded(ReadOnlySpan<byte>, int)
-```
-
-`InitializeFromEmbedded` has two paths:
-
-- **In-process** (transpile-and-load in same process): `InitRegistry`
-  contains the entry; skip the codec entirely. The pinned span is never
-  touched.
-- **Cross-process** (saved `.dll` loaded fresh): `InitRegistry` is empty;
-  call `InitDataCodec.Decode(ReadOnlySpan<byte>)` which uses
-  `UnmanagedMemoryStream` over the pinned span — no allocation, no copy
-  (true zero-copy from PE pages to `ModuleInitData`).
-
-Pre-migration the same blob lived in the user-string heap (`#US`) as a
-base64 string literal decoded on cctor. That cost ~2.67× disk
-(4/3 base64 expansion × 2 UTF-16 doubling) plus a one-shot
-`Convert.FromBase64String` allocation at startup. Measurements on a 4 KB
-data segment fixture (see `Wacs.Transpiler.Test/PeShapeTests.cs`):
-
-| Metric | RVA path | Base64 baseline |
-|---|---|---|
-| Codec blob on disk | 4 205 B | 11 213 B |
-| Reduction | — | **62.5%** |
-
-### Deferred GC element segments
-
-GC-typed element-segment initializers (`array.new` etc.) need the emitted
-CLR class to be *runtime-instantiable* (so `Activator.CreateInstance` works).
-Pre-bake the class is metadata-only and `CreateInstance` refuses with
-`ArgumentException("Type must be a type provided by the runtime.")`.
-
-Pipeline:
-
-1. During `Transpile`, `ModuleInit.RegisterElemSegment` is called eagerly
-   with placeholder `Value(ValType.Any)` for any segment whose initializer
-   contains `array.new`/`array.new_default`/`array.new_fixed`.
-2. The (segId, initializers[]) pairs land on
-   `TranspilationResult._pendingElemReeval`.
-3. `Bake()` calls `gcTypeEmitter.RemapEmittedToLoadedTypes(loadedAssembly)`
-   — replaces every `EmittedTypes[idx].ClrType` with the runtime-loaded
-   equivalent.
-4. Re-runs `EvaluateElemExprForBake` against each captured initializer and
-   calls `ModuleInit.UpdateElemSegment` to overwrite the placeholder.
-
-Same pattern via `GcTypeRegistry.RemapToLoadedTypes` for the runtime
-helpers (`ConvertStoreArray`, `ConvertStoreStruct`) that consume the
-registry post-Bake.
-
-### Emission targets
-
-`TranspilerOptions.Emission` selects between three modes:
-
-- **`Auto`** (default) — picks `AotLinked` when the module fits the
-  feasibility envelope (`IsAotLinkedAutoPromotable` in
-  `ModuleClassGenerator.cs`); falls back to `Standard` otherwise.
-  Saves ~50% on first-trial cold start and ~28% on warm cold start
-  for promoted modules — the codec stack
-  (`InitDataCodec.Decode`, `BinaryReader`, `InitializeFromData`)
-  never JITs and never runs.
-- **`Standard`** — Module ctor calls
-  `InitializationHelper.InitializeFromEmbedded` against the RVA-mapped
-  codec blob. Cross-process safe; works for any module shape. The
-  codec machinery (`InitDataCodec`, `InitRegistry`, `ModuleInit`)
-  ships in the consumer's binary.
-- **`AotLinked`** — Module ctor builds `ThinContext` directly from
-  inlined IL constants. No `__WACSInit` holder, no codec call, no
-  registry dependency. NativeAOT consumers can dead-strip the codec
-  machinery from the final native binary. Throws at transpile time
-  via `AssertAotLinkedFeasible` if the module shape requires the
-  codec stack — use `Auto` for the "AotLinked when feasible,
-  Standard otherwise" semantics.
-
-The `AotLinkedSavedDllOmitsCodecHolderType` test
-(`Wacs.Transpiler.Test/AotLinkedEmissionTests.cs`) is the trim-evidence
-assertion: confirms the saved AotLinked `.dll` references neither the
-`__WACSInit` holder type nor `InitializeFromEmbedded`.
-
-#### Auto promotion envelope
-
-`IsAotLinkedAutoPromotable` is stricter than `IsAotLinkedFeasible` —
-it only promotes shapes already covered by an existing AotLinked
-emission test, so a configuration that's feasible-but-not-tested
-falls back to Standard rather than risking silent miscompilation.
-
-Currently auto-promoted:
-
-| Shape | Coverage |
-|---|---|
-| Compute-only modules | ✅ |
-| Single memory + active data segments | ✅ |
-| Primitive globals (i32/i64/f32/f64) + null/funcref/externref globals | ✅ |
-| Tables + funcref active element segments + `call_indirect` | ✅ |
-| `ref.test` / `br_on_cast` on funcref | ✅ |
-| Passive data segments + `memory.init` | ✅ |
-| Passive funcref element segments + `table.init` | ✅ |
-| Multi-memory | ✅ |
-| Local exception tags | ✅ |
-| Imported functions (wired through `IImports`) | ✅ |
-
-Still rejected — fall back to `Standard`:
-
-- Imported memory / table / global / tag (linker integration)
-- GC global inits (`array.new`, `struct.new` initializers)
-- GC element values (`ref.i31`, `array.new` in element segments)
-- Modules with non-encodable element segment initializers
-  (`global.get` references, etc.)
-
-The Auto-fallback path is silent: if a module isn't promotable, it
-just transpiles to Standard and the consumer sees the codec ctor.
-`Emission = AotLinked` explicitly throws if the user pinned the
-target but the module is out of envelope — useful for whole-program
-NativeAOT builds where you want a build-time error rather than a
-silent fallback.
-
-#### What AotLinked emission emits
-
-The AotLinked ctor body, in order (see
-`ModuleClassGenerator.EmitAotLinkedCtorBody`):
-
-1. **Memory / Table / Global arrays** — `EmitMemoryArray`,
-   `EmitTablesArray`, `EmitGlobalsArray` allocate per-instance
-   `MemoryInstance[]` / `TableInstance[]` / `GlobalInstance[]` from
-   constant counts + per-slot `Newobj` + `EmitPrimitiveValue` for
-   the initial value (handles primitives, null refs, non-null
-   funcref/externref).
-2. **`new ThinContext(memories, tables, globals, null, null)`** —
-   the `ImportDelegates` and `FuncTable` slots are populated later.
-3. **`EmitDataSegmentCopies`** — for each active data segment, copy
-   from `__WACSAotData.Segment_N` (RVA-mapped) into the right
-   memory slot via `BulkHelpers.CopySegmentToMemory`.
-4. **`EmitElementSegmentCopies`** — for each active funcref/null
-   element segment, write the resolved Value into
-   `ctx.Tables[i].Elements[slot]`.
-5. **`EmitTypeHashArrays`** — populate `ctx.FuncTypeHashes`,
-   `FuncTypeSuperHashes`, `TypeHashes`, `TypeIsFunc` as IL-baked
-   constant arrays (consumed by `call_indirect` subtype checks +
-   `ref.test`/`ref.cast`).
-6. **`EmitActiveSegmentDrops`** — `ModuleInit.DropDataSegment` /
-   `DropElemSegment` for each active segment (WASM 3.0 §4.5.4
-   step 16).
-7. **`EmitSegmentBaseIds`** — stamp `ctx.DataSegmentBaseId` /
-   `ElemSegmentBaseId` from transpile-time constants.
-8. **`EmitInitDataIdStamp`** — `ctx.InitDataId = _initDataId`. Keys
-   into `MultiReturnMethodRegistry` (call_indirect dispatch for
-   multi-result funcs) and `GcTypeRegistry` (runtime GC type
-   lookups).
-9. **`EmitPassiveDataSegmentRegistrations`** — for each passive
-   data segment, `ModuleInit.RegisterDataSegmentAt(absoluteId,
-   span.ToArray())` so cross-process `memory.init` resolves.
-10. **`EmitPassiveElementSegmentRegistrations`** — same recipe for
-    element segments, encoded as `int[]` (`-1` = null, `>=0` =
-    funcIdx).
-11. **`EmitTagsArray`** — `ctx.Tags = new TagInstance[totalTags]`
-    with one fresh `TagInstance(null)` per local tag (identity-
-    based equality only).
-
-After `EmitAotLinkedCtorBody`, the ctor falls through to the shared
-post-init steps used by `Standard`:
-`EmitImportDelegateWiring`, `EmitFuncTablePopulation`,
-`EmitTypedDelegateShimsAndRegister`, `EmitCabiReallocCacheIfPresent`,
-`BindTableDelegates`, `_ctx` field assignment, start-fn invocation.
-
-### Direct-linked imports (component mode)
-
-Default import dispatch:
-
-```il
-ldarg.0
-ldfld   ctx.ImportDelegates
-ldc.i4  i
-ldelem.ref
-… box args …
-callvirt System.Delegate::DynamicInvoke
-```
-
-That works but pays the boxing + dictionary-style dispatch on every
-guest→host call. With a `HostPackageResolver` configured,
-`DirectLinkedImportEmit` recognizes typed `[WitSource]`-tagged interfaces and
-emits inline IL:
-
-```il
-ldarg.0
-ldfld   ctx.HostBundle
-callvirt T_HostBundle::get_TypedInterface()
-… push wasm args (with canonical-ABI lift if needed) …
-callvirt I_TypedInterface::Method(…)
-… store results to wasm linear memory at retArea (canonical-ABI lower) …
-```
-
-Direct-linked dispatch handles roughly the same shape matrix
-`wit-bindgen-csharp` does:
-
-| Shape | Notes |
-|---|---|
-| primitives | `i32` / `i64` / `f32` / `f64` + narrow ints + `bool` |
-| `string` | `cabi_realloc` + UTF-8 / UTF-16 / Latin1 encode per import option |
-| `byte[]` (`list<u8>`) | `cabi_realloc` + raw memcpy |
-| `Option<T>` | recursive on inner shape (incl. `Option<Option<X>>` / `Option<Result<X,Y>>`) |
-| `Result<TOk, TErr>` | each arm storable per the same rules |
-| resource handle (`own<R>` / `borrow<R>`) | `Resources.AllocateResource` (return) / `Resources.GetResource` (param) |
-| `list<T>` for primitive `T` / `string` / `byte[]` | outer `(ptr, count)` + per-element store |
-| `list<list<T>>` | three-level `cabi_realloc` (outer pair-array + per-sub buffers) |
-| `list<own<R>>` | per-element `AllocateResource` + `i32` handle |
-| `list<tuple<...>>` / `list<record<...>>` | per-element fields packed inline at the type's natural stride. Field types may be primitive / `string` / `byte[]` **or `own<R>`** — covers `wasi:filesystem/preopens.get-directories` (`list<tuple<own<descriptor>, string>>`), `wasi:cli/environment.get-environment` (`list<tuple<string, string>>`), and the broader env / args / headers / TCP `accept` "list of (resource-or-string, label)" shape class. |
-| `list<Option<X>>` / `list<Result<X, Y>>` | per-element variant store at outer-ptr + i*elemSize |
-| variants | `EmitVariantStoreAt` per-case payload encoding |
-
-Shapes outside that fall back to the delegate path silently.
-`CanEmitDirect` (in `DirectLinkedImportEmit.cs`) is the gate;
-the resolver-aware predicate variants
-(`IsTupleOfFlatFields` / `IsRecordOfFlatFields`) are what gate
-the resource-bearing aggregates.
-
-### `ThinContext` — the runtime hand-off slot
-
-`AOT/ThinContext.cs` is the runtime context the generated IL threads
-through every call. Fields:
-
-- `Memories` / `Tables` / `Globals` — the standalone allocation slots,
-  populated either from the codec or from inlined IL (AotLinked).
-- `ImportDelegates` / `FuncTable` — used by call-indirect / non-direct-
-  linked imports.
-- `Module` / `Store` — back-references to the interpreter side, populated
-  only when the assembly runs inside a `WasmRuntime` (mixed-mode). Null in
-  standalone runs.
-- `HostBundle` — direct-linked imports' typed bundle source.
-- `Resources` — slot for component-resource handle tables.
-- `InitDataId` — the transpile-time `InitRegistry` key for in-process fast
-  paths.
-
-Every transpiled function takes `ThinContext` as its first parameter.
-Functions that need cross-module state (call_indirect to imported
-functions, throw-into-host, etc.) read it from there; pure compute
-functions ignore it.
-
-### Codec format (`InitDataCodec`)
-
-`AOT/InitDataCodec.cs` implements a versioned binary format documented in
-`AOT/InitDataFormat.md`. Header carries an 8-byte `WACSINIT` magic + 1-byte
-major + 1-byte minor + 2-byte reserved. Body is a sequence of
-`(tag, length-prefixed-payload)` sections.
-
-Encoder produces `byte[]`; decoder accepts both `byte[]` (legacy) and
-`ReadOnlySpan<byte>` (zero-copy, used by the RVA path). Both routes share a
-private `DecodeFromStream(Stream)` helper — the span overload wraps the
-pinned span in `UnmanagedMemoryStream` via `fixed (byte* p = bytes)`. This is
-the only `unsafe` block in the lib.
-
-Forward compat: unknown section tags are skipped via `ms.Position = end`,
-so a v1.M decoder can read v1.N (N > M) files for any additive section
-extension. Bumping major is the breaking-change escape hatch.
-
-## Testing surface
-
-| Test class | What it covers |
-|---|---|
-| `TranspilerTests` | Per-wast `TranspileEachWastModuleNoCrash` smoke — every spec-test wasm transpiles without throwing. |
-| `AotSpecTests` | Full WebAssembly 3.0 spec test suite executed through the transpiler — assert-equiv with the interpreter. |
-| `AotLinkedEmissionTests` | AotLinked emission end-to-end + trim-evidence (saved `.dll` doesn't reference codec machinery). |
-| `CrossProcessLoadTests` | Save → wipe `InitRegistry`/`ModuleInit` → load via `AssemblyLoadContext` → invoke. Exercises the cross-process codec path that the in-process tests don't. |
-| `PeShapeTests` | PE-shape regression assertions: `__WACSInit.Data` field RVA non-zero, no large UTF-16 LE base64 run in the `.dll`, plus diagnostic prints (assembly size + cold-start timing). |
-| `ComponentTranspilerTests` | Component-mode emission — argv-parse `--emit-main`, named-WIT-type lookup, tuple-return / Result-return shapes. |
-| `DirectLinkedImportTests` | Component-mode inline-IL import dispatch matrix (primitives, strings, lists, options, results, resources). |
-| `BranchHintEmissionTests` | `metadata.code.branch_hint` custom-section consumption — `if`-arm reordering and `_coldTailEmissions`. |
-| `InitDataCodecTests` | Codec encode/decode round-trip for every section. |
-
-## Code map
-
-```
-Wacs.Transpiler.Lib/
-├── AOT/
-│   ├── ModuleTranspiler.cs        — orchestrator + TranspilationResult lifecycle (Bake)
-│   ├── FunctionCodegen.cs         — per-function IL emission driver, dispatches to emitters
-│   ├── ModuleClassGenerator.cs    — Module class shape: ctor, exports, memory props
-│   ├── InterfaceGenerator.cs      — IExports / IImports interface emission
-│   ├── GcTypeEmitter.cs           — WASM GC structs/arrays → CLR classes
-│   ├── DataSegmentEmitter.cs      — wasm data section walker; emits MemoryDecl + DataSegmentInfo
-│   ├── InitDataCodec.cs           — versioned binary serializer for ModuleInitData
-│   ├── InitDataFormat.md          — codec format spec
-│   ├── InitializationHelper.cs    — runtime init, GcTypeRegistry, ModuleInit
-│   ├── ModuleInit.cs              — runtime-side data/element segment registry
-│   ├── ThinContext.cs             — runtime context threaded through transpiled IL
-│   ├── ModuleLinker.cs            — multi-module composition (cross-module imports)
-│   ├── CilValidator.cs            — transpile-time CIL stack-shape validation
-│   ├── StackAnalysis.cs           — typed-stack tracking during emission
-│   ├── TranspilerOptions.cs       — public options surface (SIMD strategy, emission target, …)
-│   ├── MainEntryEmitter.cs        — emits Program.Main for core-WASM modules
-│   ├── Emitters/
-│   │   ├── NumericEmitter.cs      — i32/i64/f32/f64 + sign-ext + wrap
-│   │   ├── VariableEmitter.cs     — local.get/set/tee, global.get/set
-│   │   ├── MemoryEmitter.cs       — load/store + memory.size/grow
-│   │   ├── ControlEmitter.cs      — block/loop/if/br/br_table/return
-│   │   ├── CallEmitter.cs         — call/call_indirect/return_call*
-│   │   ├── TableRefEmitter.cs     — ref.* + table.*
-│   │   ├── BulkEmitter.cs         — 0xFC-prefix bulk memory/table + BulkHelpers runtime helper
-│   │   ├── AtomicEmitter.cs       — 0xFE-prefix shared-memory atomics
-│   │   ├── GcEmitter.cs           — 0xFB-prefix struct/array/i31/extern + ConvertStoreArray/Struct
-│   │   ├── SimdEmitter.cs         — 0xFD-prefix v128 (scalar + intrinsics paths)
-│   │   ├── SimdHelpers.cs         — scalar fallback implementations of v128 ops
-│   │   └── ExceptionEmitter.cs    — try_table/throw/throw_ref + WasmException
-│   └── Component/
-│       ├── ComponentTranspiler.cs       — component-model entry point
-│       ├── ComponentExportsEmit.cs      — emits ComponentExports static class with WIT-shaped methods
-│       ├── ExportInterfaceEmit.cs       — emits [WitSource]-tagged I{Iface} types
-│       ├── DirectLinkedImportEmit.cs    — inline IL import dispatch
-│       ├── HostPackageResolver.cs       — discovers (package, interface, item) bindings on host packages
-│       ├── ComponentMainEntryEmitter.cs — Program.Main for components
-│       ├── ComponentMainHost.cs         — argv parser + invoker shared by ComponentMain
-│       ├── ComponentImportStubs.cs      — DispatchProxy-based no-op IImports for components
-│       ├── ComponentAssemblyEmit.cs     — embeds ComponentMetadata.EmbeddedWitBytes
-│       └── TupleFieldAccess.cs          — Roslyn-compiled ItemPofN<…> helpers (PAB-Ldfld workaround)
-└── Hosting/
-    ├── TranspiledModuleLoader.cs  — public `Load(path|assembly, imports?, isolate?)` entry
-    ├── HostedRunner.cs            — runs an export through a TranspilationResult (used by --run path)
-    ├── ImportDispatcher.cs        — DispatchProxy factory for IImports proxies; throws on missing handler by default, lenient: true opts out
-    └── BindingLoader.cs           — IBindable assembly discovery (for --bind)
-```
-
-## Key invariants and constraints
-
-- **`Wacs.Core` stays at `net8.0;netstandard2.1`** — runtime-side public
-  surface. The transpiler-side projects (`Wacs.Transpiler.Lib`,
-  `Wacs.Transpiler`, `Wacs.Console`, `Wacs.Transpiler.Test`,
-  `Wacs.ComponentModel.Bindgen.Test`, `Wacs.Bench`) are at `net9.0` for
-  `PersistedAssemblyBuilder`.
-- **AOT compatibility is a hard requirement.** No runtime
-  `Reflection.Emit`, no `MakeGenericMethod` outside source-generators or
-  build-time code. The transpiler itself runs on the dev machine; the
-  generated assembly must be NativeAOT-friendly. Components emitted with
-  `Emission = AotLinked` can be dead-stripped of the codec stack.
-- **Transpile-time validation > runtime validation.** `CilValidator`,
-  `Debug.Assert` on `Value` construction, no sentinel types — the goal is
-  every transpile failure surfaces with a (module, instruction, reason)
-  triple at transpile time, never as `InvalidProgramException` at JIT.
-- **Symmetric API surfaces across engines.** A consumer who writes against
-  `WasmRuntime + ModuleInstance` (interpreter) can swap to a transpiled
-  `Module` class without API churn — same `IExports`, same `IImports`,
-  same memory model.
-- **The text and binary parsers must agree.** A bug in `BinaryModuleParser`
-  is mirrored in `TextModuleParser`; fixes go in the validator layer when
-  the gap is value-range. The transpiler trusts whatever `ModuleInstance`
-  the parse produces.
-
-## Performance characteristics
-
-Cold start of a 4 KB-data-segment saved `.dll`, measured by
-`PeShapeTests.Diagnostic_ColdStartFromSavedDll`:
-
-| Phase | Time |
-|---|---|
-| `AssemblyLoadContext.LoadFromAssemblyPath` | ~110 µs |
-| Module ctor (cross-process codec decode + memory init + segment copy) | ~3.3 ms |
-| First export call (read byte at offset 0) | ~150 µs |
-| **Total cold** | **~3.6 ms** |
-
-In-process transpile cold start is dominated by IL emission (Pass 2). For
-larger modules (CoreMark scale) IL emission dominates over PAB
-`Save`+`Load`. AotLinked emission elides the codec decode; for compute-only
-fixtures the Module ctor drops to sub-100 µs.
-
-### Auto vs Standard on fib(100) cold start
-
-`Wacs.Bench.Coldstart` numbers (post-warmup median for steady-state,
-first-trial for cold), µs:
-
-| Phase | Standard | AotLinked (Auto-promoted) | Δ |
-|---|---|---|---|
-| Activate (first) | 1715 | 765 | **−55%** |
-| Activate (steady) | 289 | 198 | **−32%** |
-| TOTAL (first) | 1981 | 989 | **−50%** |
-| TOTAL (steady) | 417 | 300 | **−28%** |
-
-Saved `.dll` size on the same fixture: 4 608 → 4 096 bytes
-(**−11%**) — the `__WACSInit` codec blob is gone.
-
-### Phase breakdown of an AotLinked Module ctor (post-warmup, fib)
-
-`PeShapeTests.Diagnostic_ProfileModuleCtor` decomposes the ctor.
-For fib (1 export, no funcref tables) post-warmup:
-
-| Phase | Time |
-|---|---|
-| AssemblyLoadContext.LoadFromAssemblyPath | ~15 µs |
-| `RuntimeHelpers.CreateSpan<byte>` over `__WACSInit.Data` (Standard) | ~4 µs |
-| `InitDataCodec.Decode(span)` (Standard, cross-process) | ~6 µs |
-| `InitializeFromData` (Standard, cross-process) | ~5 µs |
-| Activator.CreateInstance (full ctor) | ~150-300 µs |
-| Residual (FuncTable + delegate shims + BindTableDelegates) | ~130 µs |
-
-The codec stack is sub-30 µs even on the cross-process path under
-Standard — what AotLinked saves is the **first-trial JIT** of those
-methods, plus skipping their work entirely. The structural ~130 µs
-residual is the same under both emissions (FuncTable population
-is amortizable via static-template work that's been analyzed but
-not landed).
+For WASI Preview 2 host wiring, the natural pairing is
+[`WACS.WASI.Preview2.DependencyInjection`](https://www.nuget.org/packages/WACS.WASI.Preview2.DependencyInjection)'s
+`WasiPreview2RuntimeScope` — the same scope `wacs run --wasip2` uses internally.
+
+## What's inside
+
+- **`ModuleTranspiler`** — core wasm → CIL emitter. Walks parsed instruction stream,
+  emits CIL into a `TypeBuilder`, runs `CilValidator` at emit time
+- **`ComponentTranspiler`** — component-model variant; lifts/lowers canonical-ABI
+  aggregates, integrates with `HostPackageResolver` for direct-link host imports
+- **`TranspiledModuleLoader`** — load saved `.dll`s without `Reflection.Emit`. Suitable
+  for AOT targets
+- **`BindingLoader`** — `--bind` assembly resolution + `IBindable` activation
+- **`HostPackageResolver`** — typed `[WitSource]` interface discovery + AppDomain
+  fallback for impl-class lookups
+- **Engine knobs** — `--simd {scalar | intrinsics | interpreter}`, `--no-tail-calls`,
+  `--max-fn-size`, `--data-storage {compressed | raw | static}`,
+  `EmissionTarget.{Auto | Standard | AotLinked}`
+
+## Mixed-mode + cold-start
+
+Transpilation is opportunistic: any function the transpiler declines (e.g., very large
+bodies under `--max-fn-size`) falls back to the WACS interpreter for that function only,
+so the module still runs.
+
+Cold-start ranges from ~30–55 ms on a default `dotnet publish` to ~1 ms with
+`PublishReadyToRun` + saved-`.dll` flow, and 501 µs cold for a fully-NativeAOT-published
+consumer. Full breakdown in
+[`docs/COLDSTART.md`](https://github.com/kelnishi/WACS/blob/main/docs/COLDSTART.md).
+
+## Spec compliance
+
+Spec-equivalent to the WACS interpreter on the WebAssembly 3.0 test suite (473/473),
+verified continuously on macOS ARM64 and Linux x64.
+
+## Documentation
+
+- Top-level WACS [README — AOT Transpiler](https://github.com/kelnishi/WACS#aot-transpiler-wacstranspiler)
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+  — component-mode runtime requirements + host-package composition
+- [`docs/COLDSTART.md`](https://github.com/kelnishi/WACS/blob/main/docs/COLDSTART.md) —
+  startup cost across runtime / publish-flag combinations
+- [`Wacs.Transpiler.Lib/ARCHITECTURE.md`](https://github.com/kelnishi/WACS/blob/main/Wacs.Transpiler/Wacs.Transpiler.Lib/ARCHITECTURE.md)
+  — internal pipeline / design deep-dive
 
 ## License
 
-Apache 2.0 — see [LICENSE](https://github.com/kelnishi/WACS/blob/main/LICENSE).
+Apache-2.0

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -15,8 +15,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.8.11</Version>
-        <AssemblyVersion>0.8.11</AssemblyVersion>
+        <Version>0.8.12</Version>
+        <AssemblyVersion>0.8.12</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.7.2 fixes a re-instantiation bug where Module classes with active data segments would come up zeroed on the second `Activator.CreateInstance` because spec §4.5.4 segment-drop emptied the process-wide ModuleInit registry. Module ctors now restore from `ModuleInitData.SavedDataSegments` before each CopyDataSegment so every fresh instance sees its memory initialized. v0.7 retires Lokad.ILPack for PersistedAssemblyBuilder (.NET 9), moves WASM data segments + the codec blob to RVA-mapped initialized data (62.5% smaller than the prior base64-in-#US path, true zero-copy from PE pages to ModuleInitData via UnmanagedMemoryStream), and introduces EmissionTarget.Auto as the new default — promotes to AotLinked when the module fits a conservative envelope (compute / memory / globals / tables + active+passive segments / multi-memory / local tags / imported functions), falling back to Standard otherwise. ~50% first-trial cold-start cut on promoted modules. ImportDispatcher now throws on missing handlers by default (lenient: true opts out). v0.6 consumed the Branch Hinting proposal's metadata.code.branch_hint custom section. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="../Wacs.Transpiler/README.md" Pack="true" PackagePath="/" />
+        <None Include="README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/README.md
@@ -1,0 +1,94 @@
+# WACS.WASI.NN.DependencyInjection
+
+DI bundle + concrete resource impls for
+[`WACS.WASI.NN`](https://www.nuget.org/packages/WACS.WASI.NN). This is the package the
+transpiler-direct-link path needs at scope-construction time — without it,
+`[constructor]X` for wasi-nn resources falls back to delegate dispatch and returns handle
+0 to the guest.
+
+## Install
+
+```bash
+dotnet add package WACS.WASI.NN.DependencyInjection
+```
+
+For most wasi-nn workflows, install this package alongside
+[`WACS.WASI.Preview2.DependencyInjection`](https://www.nuget.org/packages/WACS.WASI.Preview2.DependencyInjection)
++ a backend (`WACS.WASI.NN.OnnxRuntime` / `WACS.WASI.NN.LlamaSharp` /
+`WACS.WASI.NN.MLNet`).
+
+## What's inside
+
+- **`WasiNNBundle`** — exposes WASI.NN's `[WitSource]` interfaces (`IGraphFuncs`,
+  `IInferenceFuncs`, `IErrorFuncs`) as properties that direct-link emit binds to
+- **`WasiPreview2NNBundle`** — composite bundle that forwards BOTH Preview 2 and WASI.NN
+  interfaces through one CLR object. Required when a component imports `wasi:cli/*` +
+  `wasi:nn/*` (the typical SLM / inference-CLI shape)
+- **Concrete resource impls** — `Tensor`, `Graph`, `GraphExecutionContext`, `Error` —
+  parameterless ctor + SourceGen-shape `void Create(args)` that
+  `Activator.CreateInstance(impl)` instantiates
+- **`AddWasiNN`** + **`AddWasiPreview2NNBundle`** service-collection extensions
+
+## Quick start — DI
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Wacs.WASI.Preview2.DependencyInjection;
+using Wacs.WASI.NN.DependencyInjection;
+using Wacs.WASI.NN.OnnxRuntime;
+using Wacs.WASI.NN.Types;
+
+var services = new ServiceCollection();
+services
+    .AddWasiPreview2()
+    .AddWasiNN(opts =>
+    {
+        opts.AddBackend(GraphEncoding.ONNX, new OnnxBackend());
+        // or:
+        // opts.Configuration.LoadByNameBackend = new LlamaSharpBackend(...);
+    })
+    .AddWasiPreview2NNBundle();   // composite for the single hostBundle slot
+
+using var sp = services.BuildServiceProvider();
+using var scope = sp.CreateScope();
+
+var linker = scope.ServiceProvider.GetRequiredService<Linker>();
+// linker.Runtime is the WasmRuntime ready for component instantiation
+```
+
+## Quick start — `WasiPreview2RuntimeScope` (one-shot)
+
+For most embedders the simpler path is `WasiPreview2RuntimeScope` from
+[`WACS.WASI.Preview2.DependencyInjection`](https://www.nuget.org/packages/WACS.WASI.Preview2.DependencyInjection),
+which auto-detects this package on the load path and registers the composite bundle
+without manual configuration:
+
+```csharp
+using var wasi = new WasiPreview2RuntimeScope(runtime,
+    preopens: new[] { ("./models", "/models") });
+// wasi.Bundle is automatically the composite when this DI sibling is loaded
+```
+
+Auto-wires `OnnxBackend` if `WACS.WASI.NN.OnnxRuntime` is loadable; auto-wires LlamaSharp
+into both `Backends[GGML]` and `LoadByNameBackend` if `WACS.WASI.NN.LlamaSharp` is
+loadable.
+
+## Why this is a separate package
+
+The typed resource interfaces (`ITensor`, `IGraph`, `IGraphExecutionContext`, `IError`)
+live in [`WACS.WASI.NN`](https://www.nuget.org/packages/WACS.WASI.NN) — they're what
+direct-link emit references at the import call site. The concrete impl classes here
+(`Tensor`, `Graph`, etc.) are what the transpiler instantiates via
+`Activator.CreateInstance(impl) + Create(args)` for `[constructor]X`. Both halves are
+needed; splitting them keeps the typed surface light when an embedder doesn't need the
+default impls.
+
+## Documentation
+
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+  — runtime requirements, host-package composition, end-to-end examples
+- Top-level WACS [README — Component Model & WASI Preview 2](https://github.com/kelnishi/WACS#component-model--wasi-preview-2)
+
+## License
+
+Apache-2.0

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/Wacs.WASI.NN.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/Wacs.WASI.NN.DependencyInjection.csproj
@@ -12,12 +12,23 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
-        <Version>0.2.1</Version>
+        <AssemblyVersion>0.2.2</AssemblyVersion>
+        <Version>0.2.2</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Wacs.WASI.NN\Wacs.WASI.NN.csproj" />

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/README.md
@@ -1,0 +1,118 @@
+# WACS.WASI.NN.LlamaSharp
+
+GGUF / llama.cpp backend for [`WACS.WASI.NN`](https://www.nuget.org/packages/WACS.WASI.NN).
+Implements `IBackend` for `graph-encoding.ggml` against
+[`LLamaSharp`](https://www.nuget.org/packages/LLamaSharp); GPU runtimes pluggable via
+LlamaSharp's backend NuGets (CPU default; CUDA / Vulkan / MacMetal swaps with no source
+change).
+
+Follows the WasmEdge wasi-nn GGUF convention:
+
+- Models resolved by **name** through `wasi:nn/graph.load-by-name(name)` — multi-GB
+  GGUFs aren't passed through the canonical-ABI byte-loader path
+- Input / output are **U8 tensors carrying UTF-8 prompt / response bytes**. No
+  tokenization or chat-template work in the guest — LlamaSharp does it all host-side
+
+## Install
+
+```bash
+dotnet add package WACS.WASI.NN.LlamaSharp
+```
+
+The package's bin ships its NuGet transitives + RID-specific native libs (via
+`<EnableDynamicLoading>true</EnableDynamicLoading>`), so `Assembly.LoadFrom` resolves
+everything from the LoadFromContext probe — no manual deps staging.
+
+## CLI quick start
+
+LlamaSharp isn't bundled with `WACS.Cli` by default (unlike OnnxRuntime — the natives
+are too chunky to ride along). Pass the explicit path to the backend's bin:
+
+```sh
+mkdir -p ./models
+huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct-GGUF \
+    qwen2.5-0.5b-instruct-q4_k_m.gguf --local-dir ./models
+
+export WACS_WASINN_GGUF_DIR="$(pwd)/models"
+
+# After dotnet build of this project's repo:
+LLAMA=$(realpath Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/bin/Release/net8.0/Wacs.WASI.NN.LlamaSharp.dll)
+
+wacs run my-llm.component.wasm --wasip2 --bind "$LLAMA"
+```
+
+`--bind` auto-pulls the WASI.NN typed surface + DI sibling onto host-packages when the
+identity starts with `Wacs.WASI.NN.`. The Preview 2 DI scope's auto-wire registers the
+backend in BOTH `Backends[GGML]` AND `LoadByNameBackend`; guests calling
+`wasi:nn/graph.load-by-name(...)` direct-link cleanly.
+
+The full chain (with under-the-hood walkthrough) lives at
+[`docs/COMPONENT_CHAINING.md#gguf-inference-example-llamasharp-backend`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md#gguf-inference-example-llamasharp-backend).
+
+## Embedder
+
+Interpreter / one-line:
+
+```csharp
+using Wacs.Core.Runtime;
+using Wacs.WASI.NN;
+using Wacs.WASI.NN.LlamaSharp;
+using Wacs.WASI.NN.Types;
+
+var registry = new Dictionary<string, string>
+{
+    ["qwen2.5-0.5b"] = "/path/to/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+};
+var backend = LlamaSharpBackend.FromPaths(registry);
+
+var runtime = new WasmRuntime();
+runtime.UseWasiNN(b =>
+{
+    b.AddBackend(GraphEncoding.GGML, backend);
+    b.Configuration.LoadByNameBackend = backend;   // route load-by-name
+});
+```
+
+For the transpiler-direct-link / DI flow, just `--bind <path>` — the Preview 2 DI scope
+auto-discovers and wires.
+
+## GPU backend swap
+
+Replace `LLamaSharp.Backend.Cpu` in the project's csproj with one of:
+
+- `LLamaSharp.Backend.Cuda12` — NVIDIA
+- `LLamaSharp.Backend.Vulkan` — cross-vendor GPU
+- `LLamaSharp.Backend.MacMetal` — Apple Silicon
+
+Then rebuild. The `EnableDynamicLoading` bin layout copies whichever backend NuGet's
+natives are pulled — no source change.
+
+## What it provides
+
+- **`LlamaSharpBackend : IBackend`** — implements `LoadGraphByName(name, target)` for
+  registry-resolved GGUF files. The byte-loader path
+  (`LoadGraph(builders, target)`) traps with `UnsupportedOperation` by design — see
+  class docs for why
+- **`LlamaSharpBackend.FromPaths(IDictionary<string,string>)`** — convenience static
+  factory for the simple "drop GGUFs in a directory" embedder flow
+- **`WasiNNLlamaSharpBindable : IBindable`** — parameterless adapter for `--bind`. Reads
+  `WACS_WASINN_GGUF_DIR`, scans `*.gguf`, registers each under its filename-sans-extension
+
+## Backend choice
+
+| Use case | Package |
+|---|---|
+| GGUF / llama.cpp generative LLMs (`load-by-name` flow) | **WACS.WASI.NN.LlamaSharp** (this) |
+| Standard ONNX inference | [`WACS.WASI.NN.OnnxRuntime`](https://www.nuget.org/packages/WACS.WASI.NN.OnnxRuntime) |
+| ONNX with ML.NET pipeline integration | [`WACS.WASI.NN.MLNet`](https://www.nuget.org/packages/WACS.WASI.NN.MLNet) |
+
+## Documentation
+
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+  — runtime requirements + GGUF example + chaining model
+- [`Wacs.WASI/Wacs.WASI.NN/README.md`](https://github.com/kelnishi/WACS/blob/main/Wacs.WASI/Wacs.WASI.NN/README.md)
+  — backend matrix
+
+## License
+
+Apache-2.0

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.LlamaSharp</AssemblyName>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
-        <Version>0.2.1</Version>
+        <AssemblyVersion>0.2.2</AssemblyVersion>
+        <Version>0.2.2</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;llm;llama;gguf;wacs</PackageTags>
@@ -31,7 +31,18 @@
              takes a different path (round-1 CLI csproj bundle).
              Gap 27 / round-22 verification. -->
         <EnableDynamicLoading>true</EnableDynamicLoading>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Wacs.WASI.NN\Wacs.WASI.NN.csproj" />

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/README.md
@@ -1,0 +1,92 @@
+# WACS.WASI.NN.MLNet
+
+ML.NET-flavored ONNX backend for [`WACS.WASI.NN`](https://www.nuget.org/packages/WACS.WASI.NN).
+Implements `IBackend` for `graph-encoding.onnx` against
+[`Microsoft.ML.OnnxTransformer`](https://www.nuget.org/packages/Microsoft.ML.OnnxTransformer)
+under an `MLContext` lifecycle — for embedders composing wasi-nn inference with the rest
+of an ML.NET pipeline (preprocessing transformers, custom predictors, IDataView /
+PredictionEngine).
+
+For raw tensor inference with no pipeline integration, prefer
+[`WACS.WASI.NN.OnnxRuntime`](https://www.nuget.org/packages/WACS.WASI.NN.OnnxRuntime) —
+it avoids the Microsoft.ML transitive surface (~70 MB lighter).
+
+## Install
+
+```bash
+dotnet add package WACS.WASI.NN.MLNet
+```
+
+The package's bin ships its NuGet transitives + RID-specific native libs (via
+`<EnableDynamicLoading>true</EnableDynamicLoading>`), so `Assembly.LoadFrom` resolves
+everything from the LoadFromContext probe.
+
+## CLI
+
+```sh
+# After dotnet build of this project's repo:
+MLNET=$(realpath Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/bin/Release/net8.0/Wacs.WASI.NN.MLNet.dll)
+
+wacs run my.component.wasm --wasip2 --bind "$MLNET" -d ./models::/models
+```
+
+`--bind` auto-pulls the WASI.NN typed surface + DI sibling onto host-packages when the
+identity starts with `Wacs.WASI.NN.`. The Preview 2 DI scope wires the ML.NET-backed ORT
+into the DI bundle's `WasiNNConfiguration.Backends[ONNX]`.
+
+## Embedder
+
+Interpreter / one-line:
+
+```csharp
+using Wacs.Core.Runtime;
+using Wacs.WASI.NN;
+using Wacs.WASI.NN.MLNet;
+using Wacs.WASI.NN.Types;
+
+var runtime = new WasmRuntime();
+runtime.UseWasiNN(b => b.AddBackend(GraphEncoding.ONNX, new MLNetBackend()));
+```
+
+## What it provides
+
+- **`MLNetBackend : IBackend`** — wraps ORT under `MLContext.Transforms.ApplyOnnxModel`
+  / `IDataView`, exposing the same `LoadGraph(builders, target)` /
+  `Compute(inputs)` shape as the bare ORT backend. Embedders who want the
+  ML.NET preprocessing surface get it; the rest of WACS doesn't notice
+- **`WasiNNMLNetBindable : IBindable`** — parameterless adapter for `--bind`
+- `[assembly: WasiHostPackage]`
+
+## Why ML.NET over bare ORT
+
+Use this backend when:
+
+- Your wasm guest is one stage in a longer ML.NET pipeline (custom transformers,
+  preprocessing, `IDataView` consumers) and you want them composed in one host-side
+  process
+- You're already bringing in `Microsoft.ML` for adjacent work — the marginal cost of
+  routing wasi-nn through `MLContext` is small
+- You want `MLContext.Log` / structured ML.NET diagnostics around the inference call
+
+For everything else — image classification, embeddings, encoder-only LLMs, raw tensor
+in / raw tensor out — bare
+[`WACS.WASI.NN.OnnxRuntime`](https://www.nuget.org/packages/WACS.WASI.NN.OnnxRuntime) is
+lighter and simpler.
+
+## Backend choice
+
+| Use case | Package |
+|---|---|
+| ONNX with ML.NET pipeline integration | **WACS.WASI.NN.MLNet** (this) |
+| Standard ONNX inference (lighter footprint) | [`WACS.WASI.NN.OnnxRuntime`](https://www.nuget.org/packages/WACS.WASI.NN.OnnxRuntime) |
+| GGUF / llama.cpp generative LLMs | [`WACS.WASI.NN.LlamaSharp`](https://www.nuget.org/packages/WACS.WASI.NN.LlamaSharp) |
+
+## Documentation
+
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+- [`Wacs.WASI/Wacs.WASI.NN/README.md`](https://github.com/kelnishi/WACS/blob/main/Wacs.WASI/Wacs.WASI.NN/README.md)
+  — backend matrix
+
+## License
+
+Apache-2.0

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.MLNet</AssemblyName>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
-        <Version>0.2.1</Version>
+        <AssemblyVersion>0.2.2</AssemblyVersion>
+        <Version>0.2.2</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;mlnet;wacs</PackageTags>
@@ -29,7 +29,18 @@
              verification: symmetric fix in case future
              embedders bind this MLNet backend. -->
         <EnableDynamicLoading>true</EnableDynamicLoading>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Wacs.WASI.NN\Wacs.WASI.NN.csproj" />

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/README.md
@@ -1,0 +1,80 @@
+# WACS.WASI.NN.OnnxRuntime
+
+ONNX Runtime backend for [`WACS.WASI.NN`](https://www.nuget.org/packages/WACS.WASI.NN).
+Implements `IBackend` for `graph-encoding.onnx` directly against
+[`Microsoft.ML.OnnxRuntime`](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime) — no
+ML.NET wrapper, just ORT.
+
+This is the default wasi-nn backend for the WACS CLI. `wacs run --wasip2 --wasi-nn`
+auto-loads it; embedders who don't want the ~50 MB of ORT native binaries can use one of
+the other backends instead.
+
+## Install
+
+```bash
+dotnet add package WACS.WASI.NN.OnnxRuntime
+```
+
+## CLI
+
+```sh
+# Bundled with WACS.Cli — works out of the box.
+wacs run my.component.wasm --wasip2 --wasi-nn -d ./models::/models
+```
+
+The Gemma 3 270M ONNX SLM is the canonical end-to-end test target:
+[`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md#end-to-end-example)
+walks through it.
+
+## Embedder
+
+Interpreter / one-line:
+
+```csharp
+using Wacs.Core.Runtime;
+using Wacs.WASI.NN;
+using Wacs.WASI.NN.OnnxRuntime;
+using Wacs.WASI.NN.Types;
+
+var runtime = new WasmRuntime();
+runtime.UseWasiNN(b => b.AddBackend(GraphEncoding.ONNX, new OnnxBackend()));
+```
+
+Transpiler-direct-link / DI:
+
+```csharp
+services
+    .AddWasiPreview2()
+    .AddWasiNN(b => b.AddBackend(GraphEncoding.ONNX, new OnnxBackend()))
+    .AddWasiPreview2NNBundle();
+```
+
+(`WasiPreview2RuntimeScope` auto-wires `OnnxBackend` when this assembly is on the load
+path — no explicit `AddBackend` needed.)
+
+## What it provides
+
+- **`OnnxBackend : IBackend`** — implements `LoadGraph(builders, target)` for byte-loaded
+  ONNX models. Suitable for the SLM / inference workflow where the guest reads model
+  bytes and passes them through `wasi:nn/graph.load`
+- **`WasiNNOnnxBindable : IBindable`** — parameterless adapter for `--bind`. Auto-pulled
+  by the CLI's `--wasi-nn` shorthand
+- `[assembly: WasiHostPackage]` — picked up by `runtime.AutoDiscoverHostPackages()`
+
+## Backend choice
+
+| Use case | Package |
+|---|---|
+| Standard ONNX inference (image classification, embeddings, encoder-only LLMs) | **WACS.WASI.NN.OnnxRuntime** (this) |
+| ONNX with ML.NET pipeline integration (preprocessing transformers, custom predictors) | [`WACS.WASI.NN.MLNet`](https://www.nuget.org/packages/WACS.WASI.NN.MLNet) |
+| GGUF / llama.cpp generative LLMs (`load-by-name` flow) | [`WACS.WASI.NN.LlamaSharp`](https://www.nuget.org/packages/WACS.WASI.NN.LlamaSharp) |
+
+## Documentation
+
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+- [`Wacs.WASI/Wacs.WASI.NN/README.md`](https://github.com/kelnishi/WACS/blob/main/Wacs.WASI/Wacs.WASI.NN/README.md)
+  — backend matrix + quick-start
+
+## License
+
+Apache-2.0

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/Wacs.WASI.NN.OnnxRuntime.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/Wacs.WASI.NN.OnnxRuntime.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OnnxRuntime</AssemblyName>
-        <AssemblyVersion>0.2.2</AssemblyVersion>
-        <Version>0.2.2</Version>
+        <AssemblyVersion>0.2.3</AssemblyVersion>
+        <Version>0.2.3</Version>
         <RepositoryType>git</RepositoryType>
         <!-- ONNX Runtime carries native binaries; restricting to
              net8.0 here is fine because ORT itself targets
@@ -24,7 +24,18 @@
              becomes important we can revisit. -->
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;onnx;wacs</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Wacs.WASI.NN\Wacs.WASI.NN.csproj" />

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
@@ -12,12 +12,16 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN</AssemblyName>
-        <AssemblyVersion>0.3.0</AssemblyVersion>
-        <Version>0.3.0</Version>
+        <AssemblyVersion>0.3.1</AssemblyVersion>
+        <Version>0.3.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
         <PackageTags>wasm;webassembly;wasi;nn;ml;wacs</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <!-- Persist source-gen output under obj/Generated for IDE
              navigation + debugging. Doesn't affect compilation. -->
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
@@ -73,6 +77,13 @@
         <InternalsVisibleTo Include="Wacs.WASI.NN.MLNet" />
         <InternalsVisibleTo Include="Wacs.WASI.NN.OnnxRuntime" />
         <InternalsVisibleTo Include="Wacs.WASI.NN.LlamaSharp" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/README.md
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/README.md
@@ -1,0 +1,102 @@
+# WACS.WASI.Preview2.DependencyInjection
+
+`Microsoft.Extensions.DependencyInjection` extensions for
+[`WACS.WASI.Preview2`](https://www.nuget.org/packages/WACS.WASI.Preview2). One-call
+registration of every WASI 0.2.3 subsystem default + a pre-wired `Linker`.
+
+Component-mode WASI Preview 2 hosts assemble a lot of moving pieces — typed `[WitSource]`
+interfaces per subsystem, the resource-handle registry, the Linker that fires every
+`*Bindings.BindToRuntime`, the composite bundle that exposes Preview 2 + WASI.NN through one
+CLR object. This package wires it all in idiomatic .NET DI form.
+
+## Install
+
+```bash
+dotnet add package WACS.WASI.Preview2.DependencyInjection
+```
+
+## Quick start — `WasiPreview2RuntimeScope` (one-shot embedder)
+
+The simplest path: one disposable that owns the DI scope, fires every binding's
+`BindToRuntime`, and resolves the composite bundle.
+
+```csharp
+using Wacs.Core.Runtime;
+using Wacs.WASI.Preview2.DependencyInjection;
+
+var runtime = new WasmRuntime();
+using var wasi = new WasiPreview2RuntimeScope(
+    runtime,
+    preopens: new[] { ("./models", "/models") });
+
+// wasi.Bundle      → composite hostBundle
+//                    (Preview2 + WASI.NN forwarding when the
+//                     WASI.NN.DependencyInjection sibling is on
+//                     the load path)
+// wasi.Resources   → single resource registry across subsystems
+// wasi.Runtime     → runtime, with every wasi:* binding wired
+
+// ... transpile the component, instantiate, invoke ...
+```
+
+`WasiPreview2RuntimeScope` is what `wacs run --wasip2` uses internally. It auto-discovers
+`Wacs.WASI.NN.DependencyInjection` when present and registers the
+`WasiPreview2NNBundle` composite — no extra config when chaining wasi-nn alongside.
+
+## Quick start — `IServiceCollection`
+
+For ASP.NET, generic-host worker services, or anywhere with an existing DI container:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Wacs.WASI.Preview2.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddWasiPreview2();   // every WASI 0.2.3 subsystem default registered
+
+// Override individual subsystems via DI's normal TryAdd semantics:
+services.AddSingleton<IOutgoingHandler>(_ =>
+    new HttpClientOutgoingHandler(new HttpClient { Timeout = ... }));
+services.AddSingleton<IEnvironment>(_ =>
+    new SandboxedEnvironment(envVars: ..., args: ..., cwd: ...));
+
+using var sp = services.BuildServiceProvider();
+using var scope = sp.CreateScope();
+
+var linker = scope.ServiceProvider.GetRequiredService<Linker>();
+// linker.Runtime is the WasmRuntime with every wasi:* import bound
+```
+
+`AddWasiPreview2(opts => opts.InstanceLifetime = ServiceLifetime.Scoped)` is the default —
+fits ASP.NET request-scoped wasm execution. Pass `Transient` for per-call construction or
+`Singleton` for single-component apps.
+
+## Composing with WASI.NN
+
+When [`WACS.WASI.NN.DependencyInjection`](https://www.nuget.org/packages/WACS.WASI.NN.DependencyInjection)
+is on the load path, the runtime scope auto-discovers it and registers the
+`WasiPreview2NNBundle` composite that forwards both Preview 2 and WASI.NN `[WitSource]`
+interface properties through one CLR object. The transpiler's direct-link IL casts to the
+composite type at the import call site; this package's auto-detection guarantees the
+expected type is present without any extra config.
+
+## What's included
+
+- Default impls for every WASI 0.2.3 subsystem: `cli` / `clocks` / `filesystem` / `http`
+  / `io` / `random` / `sockets`
+- `WasiPreview2Bundle` (single-package) and `WasiPreview2NNBundle` (composite) bundle
+  types
+- `WasiPreview2Resources` — the canonical resource registry direct-link emit looks up
+- `WasiPreview2RuntimeScope` — one-shot scope owning DI lifecycle, Linker resolution, and
+  composite-bundle discovery
+
+## Documentation
+
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+  — runtime requirements, host-package composition, end-to-end CLI / embedder examples
+- Sibling package [`WACS.WASI.Preview2`](https://www.nuget.org/packages/WACS.WASI.Preview2)'s
+  README for manual subsystem wiring (no DI), per-impl override patterns
+
+## License
+
+Apache-2.0

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
@@ -12,12 +12,23 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.1.4</AssemblyVersion>
-        <Version>0.1.4</Version>
+        <AssemblyVersion>0.1.5</AssemblyVersion>
+        <Version>0.1.5</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Wacs.WASI.Preview2\Wacs.WASI.Preview2.csproj" />

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2/Wacs.WASI.Preview2.csproj
@@ -12,11 +12,15 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2</AssemblyName>
-        <AssemblyVersion>0.4.0</AssemblyVersion>
-        <Version>0.4.0</Version>
+        <AssemblyVersion>0.4.1</AssemblyVersion>
+        <Version>0.4.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <!-- Persist source-gen output under obj/Generated for IDE
              navigation + debugging. Doesn't affect compilation. -->
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
@@ -94,6 +98,13 @@
     <ItemGroup>
         <EmbeddedResource Include="wit\**\*.wit"
                           LogicalName="wit/%(RecursiveDir)%(Filename)%(Extension)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="README.md">
+            <Pack>true</Pack>
+            <PackagePath/>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/Wacs.WASI/Wacs.WASI.Threads/Wacs.WASI.Threads/README.md
+++ b/Wacs.WASI/Wacs.WASI.Threads/Wacs.WASI.Threads/README.md
@@ -1,0 +1,68 @@
+# WACS.WASI.Threads
+
+`wasi-threads` host adapter for the
+[WACS WebAssembly runtime](https://github.com/kelnishi/WACS) — implements
+`wasi:thread-spawn` on top of `Wacs.Core`'s built-in atomics + `wait`/`notify` operations.
+Lets shared-memory wasm modules spawn worker threads against a real `System.Threading`
+backend.
+
+## Install
+
+```bash
+dotnet add package WACS.WASI.Threads
+```
+
+## Module requirements
+
+The wasm module must:
+
+1. Import or declare a **shared memory** (memory with the `shared` flag set).
+2. Export `wasi_thread_start (param i32 i32)` — the worker entry point. WACS calls
+   this with the thread ID (i32) and a user-supplied start argument (i32) per
+   wasi-threads' spec.
+
+## Quick start — interpreter / runtime extension
+
+```csharp
+using Wacs.Core.Runtime;
+using Wacs.WASI.Threads;
+
+var runtime = new WasmRuntime();
+runtime.UseWasiThreads();   // wires wasi:thread-spawn
+// (optionally chain other host packages: UseWasiPreview1 / UseWasiPreview2 / ...)
+
+var module = BinaryModuleParser.ParseWasm(File.OpenRead("threaded.wasm"));
+var inst = runtime.InstantiateModule(module);
+runtime.RegisterModule("app", inst);
+
+if (runtime.TryGetExportedFunction(("app", "_start"), out var addr))
+    runtime.CreateInvokerAction(addr).Invoke();
+```
+
+## Quick start — CLI
+
+```sh
+wacs run threaded.wasm --wasi-threads
+```
+
+`--wasi-threads` is shorthand for `--bind Wacs.WASI.Threads`. The CLI verifies the module
+declares shared memory and exports `wasi_thread_start` before instantiation; missing
+either trips a clear startup error.
+
+## What it provides
+
+- **`WasiThreadsBindable : IBindable`** — discovers `WACS_WASINN_GGUF_DIR`-style host
+  surface, wires `wasi:thread-spawn` against the shared runtime
+- **`runtime.UseWasiThreads()`** — chained extension method
+- **`[assembly: WasiHostPackage]`** marker so `runtime.AutoDiscoverHostPackages()` picks
+  this assembly up automatically when it's loaded into the AppDomain
+
+## Documentation
+
+- Top-level [WACS README — Threads](https://github.com/kelnishi/WACS#webassembly-feature-extensions)
+- [`docs/COMPONENT_CHAINING.md`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md)
+  for runtime-requirements composition with other WASI host packages
+
+## License
+
+Apache-2.0

--- a/Wacs.WASI/Wacs.WASI.Threads/Wacs.WASI.Threads/Wacs.WASI.Threads.csproj
+++ b/Wacs.WASI/Wacs.WASI.Threads/Wacs.WASI.Threads/Wacs.WASI.Threads.csproj
@@ -12,13 +12,21 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Threads</AssemblyName>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.2.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible>true</IsAotCompatible>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="README.md">
+        <Pack>true</Pack>
+        <PackagePath/>
+      </None>
+    </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
## Summary

NuGet.org's package listings render the package's `README.md` if the publishing csproj wires `<PackageReadmeFile>` and includes the file as a packed `<None>` item. 11 of our packages were missing one or both halves; this PR fixes them.

| Package | Status before | Status after |
|---|---|---|
| `WACS.ComponentModel` | no README, no wiring | new README + wiring |
| `WACS.ComponentModel.Bindgen.Lib` | no README, no wiring | new README + wiring |
| `WACS.WASI.NN` | README, no wiring | wiring added |
| `WACS.WASI.NN.DependencyInjection` | no README, no wiring | new README + wiring |
| `WACS.WASI.NN.OnnxRuntime` | no README, no wiring | new README + wiring |
| `WACS.WASI.NN.LlamaSharp` | no README, no wiring | new README + wiring |
| `WACS.WASI.NN.MLNet` | no README, no wiring | new README + wiring |
| `WACS.WASI.Preview2` | README, no wiring | wiring added |
| `WACS.WASI.Preview2.DependencyInjection` | no README, no wiring | new README + wiring |
| `WACS.WASI.Threads` | no README, no wiring | new README + wiring |
| `WACS.Transpiler.Lib` | csproj packed the **deprecated CLI tool's README** by relative path | new embedder-focused README at `Wacs.Transpiler.Lib/README.md`; the existing internal architecture doc moved to `Wacs.Transpiler.Lib/ARCHITECTURE.md` |

Each new README follows the same shape: what the package is, who should install it, install command, minimal quick-start (CLI + embedder where both apply), what's inside, links to deeper docs (top-level WACS README, [`docs/COMPONENT_CHAINING.md`](docs/COMPONENT_CHAINING.md), the family README under `Wacs.WASI/...`).

The `WACS.Transpiler.Lib` change is the most substantive — its csproj was previously packing `../Wacs.Transpiler/README.md`, which is the deprecated `wasm-transpile` CLI tool's deprecation notice. Embedder-API readers landed on a "this is deprecated" page when they consulted the package's NuGet listing. The new local `README.md` covers the embedder API, in-process / pre-compile / component-model flows, mixed-mode + cold-start trade-offs, and links to the existing 706-line architecture deep-dive (now at `ARCHITECTURE.md`).

## Verification

`dotnet pack` of three sample packages confirms the README is included in the produced `.nupkg`:

```sh
$ dotnet pack Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp -c Release -o /tmp/x
Successfully created package '/tmp/x/WACS.WASI.NN.LlamaSharp.0.2.2.nupkg'.

$ unzip -l /tmp/x/WACS.WASI.NN.LlamaSharp.0.2.2.nupkg | grep README
     4490  ...  README.md
```

Same for `WACS.WASI.NN.0.3.1.nupkg` (existing-README path) and `WACS.Transpiler.Lib.0.8.12.nupkg` (the retargeted-from-deprecated-tool-README path).

## Test plan

- [ ] Full WACS suite green (waiting on dotnet test of all projects in CI)
- [ ] AOT smoke green (`wacs aot --wasi fd_write-to-stdout.wasm` prints `hello`)
- [ ] Pre-existing failures (Wacs.Compilation.Test 2/62, Feature.Detect 4/22) verified pre-existing across rounds 14-22

## Versions

Patch-level bumps (README is metadata; no public-API or behavior change):

- `WACS.ComponentModel` 0.3.4 → 0.3.5
- `WACS.ComponentModel.Bindgen.Lib` 0.1.0 → 0.1.1
- `WACS.WASI.NN` 0.3.0 → 0.3.1
- `WACS.WASI.NN.DependencyInjection` 0.2.1 → 0.2.2
- `WACS.WASI.NN.OnnxRuntime` 0.2.2 → 0.2.3
- `WACS.WASI.NN.LlamaSharp` 0.2.1 → 0.2.2
- `WACS.WASI.NN.MLNet` 0.2.1 → 0.2.2
- `WACS.WASI.Preview2` 0.4.0 → 0.4.1
- `WACS.WASI.Preview2.DependencyInjection` 0.1.4 → 0.1.5
- `WACS.WASI.Threads` 0.2.0 → 0.2.1
- `WACS.Transpiler.Lib` 0.8.11 → 0.8.12

(Untouched: `WACS`, `WASI.Preview1`, `WACS.HostBindings.{Abstractions,SourceGen}`, `WACS.Cli`, `WACS.Transpiler` — all already had READMEs + wiring or are deprecated metapackages keeping their existing notice.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)