### PR TITLE
Gap 30: BindBackendLoadContext for transitive-dep DllImports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## WACS.Cli 1.5.21 / WACS.Transpiler.Lib 0.8.14 — gap 30: `BindBackendLoadContext` for transitive-dep DllImports
+
+Round-25 verification (`wasi-nn/WACS-GAPS.md` round 25) found that the gap-28 fix —
+`NativeLibrary.SetDllImportResolver(asm, …)` keyed on the `--bind`'d assembly — only
+fires for DllImports declared **inside that assembly**. Real-world backends declare
+their `[DllImport]`s in a transitive NuGet (TorchSharp.dll, LLamaSharp.dll, …), not in
+the bind asm itself. So the per-asm resolver was a no-op for the actual hot-path,
+and the round-25 demo (`wacs run --wasip2 --bind <Wacs.WASI.NN.TorchSharp.dll>`) still
+required manual native staging into `Wacs.Console`'s `runtimes/<rid>/native/` to
+work — the documented one-line UX was broken.
+
+The proper fix is a load-context-level hook: `BindingLoader.LoadAssembly` now
+constructs a custom `BindBackendLoadContext : AssemblyLoadContext` whose
+`LoadUnmanagedDll(name)` override fires for every P/Invoke from any assembly in the
+context — bind asm, upstream NuGet wrappers, deep transitive deps. The override
+defers to `AssemblyDependencyResolver.ResolveUnmanagedDllToPath` first (deps.json-
+driven RID-aware lookup, the standard .NET 8 plugin pattern), then falls back to a
+bind-dir `runtimes/<rid>/native/` probe (with coarser-RID + flat-bin fallbacks).
+Empirically verified: `wacs run target/wasm32-wasip2/release/wasi-nn-torch.wasm
+--wasip2 --bind <Wacs.WASI.NN.TorchSharp.dll>` runs the XOR MLP end-to-end with no
+`DYLD_FALLBACK_LIBRARY_PATH` and no manual `runtimes/` staging.
+
+### What landed
+
+- **`BindingLoader.LoadAssembly`** — file-path branch now memoizes
+  `path -> Assembly` through a `ConcurrentDictionary` and uses
+  `BindBackendLoadContext` instead of `Assembly.LoadFrom`. Memoization ensures
+  the load-then-bind double-pass in `RunHandler.PreloadBindAssemblies` +
+  `ApplyBindings` returns the same `Assembly` instance both times — without it,
+  a fresh `AssemblyLoadContext` per call would yield distinct `Type` identities
+  and break `IBindable` matching against the host's interface.
+- **`BindBackendLoadContext.Load`** — defers to the default context for
+  any assembly already loaded by the host (host-shared types like `IBindable`,
+  `IBackend`, `Wacs.Core` runtime types). Without this short-circuit, the deps.json
+  resolver would happily return private paths for those assemblies (since
+  `EnableDynamicLoading=true` bundles them) and we'd load duplicates with split
+  `Type` identities.
+- **`BindBackendLoadContext.LoadUnmanagedDll`** — deps.json-driven resolution
+  first (handles the standard "managed library 'TorchSharp' P/Invokes
+  'LibTorchSharp', which lives at `runtimes/<rid>/native/libLibTorchSharp.dylib`"
+  case), then explicit probes of `<bind-dir>/runtimes/<rid>/native/` plus coarser
+  RIDs plus the flat bind dir.
+- **Per-asm `SetDllImportResolver`** retained as a complementary hook — still
+  useful when the bind asm itself declares direct `[DllImport]`s.
+
+### What this means for the wasi-nn family
+
+| Backend | Encoding | `wacs run --wasip2 --bind <…>` (no env, no manual staging) |
+|---|---|---|
+| `Wacs.WASI.NN.OnnxRuntime` | `Onnx` | already worked (CLI bundles ORT) |
+| `Wacs.WASI.NN.LlamaSharp` | `GGML` | works (LLamaSharp's own `NativeLibrary.Load` walks the LoadFrom dir's `runtimes/`) |
+| `Wacs.WASI.NN.TorchSharp` | `PyTorch` | **now works post-gap-30** — same one-line invocation |
+| `Wacs.WASI.NN.MLNet` | (TBD) | not exercised |
+
+### Verified
+
+- `Wacs.Transpiler.Test` 775/776 (1 skip)
+- `Wacs.WASI.NN.TorchSharp.Test` 8/8
+- `Wacs.WASI.NN.LlamaSharp.Test` 8/8 + 2 skip
+- `Wacs.WASI.NN.OnnxRuntime.Test` 10/10
+- `Wacs.WASI.NN.MLNet.Test` 7/7
+- End-to-end XOR MLP under `--bind` produces sigmoid outputs `0.0000 / 1.0000 /
+  0.9994 / 0.0000` — numerically identical to the round-24 verification, but with
+  no env-var workarounds and no manual staging.
+
+### Versions
+
+- `WACS.Transpiler.Lib` 0.8.13 → **0.8.14** (gap-30 `BindBackendLoadContext`)
+- `WACS.Cli` 1.5.20 → **1.5.21** (release event)
+
 ## WACS.Cli 1.5.20 / WACS.Transpiler.Lib 0.8.13 / WACS.WASI.NN.TorchSharp 0.1.1 / WACS.WASI.Preview2.DependencyInjection 0.1.6 — new wasi-nn backend: TorchSharp / PyTorch (+ gaps 28/29 native-lib ergonomics)
 
 A fourth wasi-nn backend covering `graph-encoding.pytorch`. Same packaging shape as

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.20</Version>
-    <AssemblyVersion>1.5.20</AssemblyVersion>
+    <Version>1.5.21</Version>
+    <AssemblyVersion>1.5.21</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Hosting/BindingLoader.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Hosting/BindingLoader.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Loader;
 using Wacs.Core.Runtime;
 
 namespace Wacs.Transpiler.Hosting
@@ -67,41 +68,151 @@ namespace Wacs.Transpiler.Hosting
         /// </summary>
         public static Assembly LoadAssembly(string nameOrPath)
         {
-            Assembly asm;
-            string? loadFromPath = null;
             if (File.Exists(nameOrPath))
             {
-                loadFromPath = Path.GetFullPath(nameOrPath);
-                asm = Assembly.LoadFrom(loadFromPath);
-            }
-            else
-            {
-                try { asm = Assembly.Load(nameOrPath); }
-                catch (Exception ex)
+                var fullPath = Path.GetFullPath(nameOrPath);
+                // Memoize by absolute path so repeat calls (e.g.,
+                // RunHandler's load-then-bind double-pass: preload
+                // for AppDomain visibility, then ApplyBindings
+                // re-resolves) return the same Assembly instance —
+                // a fresh AssemblyLoadContext per call would yield
+                // distinct Type identities and break IBindable
+                // matching against the host-loaded interface.
+                var asm = _bindContexts.GetOrAdd(fullPath, static p =>
                 {
-                    throw new FileNotFoundException(
-                        "binding assembly not found as file or name: "
-                        + nameOrPath + " (" + ex.Message + ")");
-                }
-                // Native-lib resolver also helps for assemblies
-                // resolved by name when their location is a real
-                // file path (e.g., side-by-side install).
-                if (!string.IsNullOrEmpty(asm.Location)
-                    && File.Exists(asm.Location))
-                    loadFromPath = asm.Location;
+                    var ctx = new BindBackendLoadContext(p);
+                    return ctx.LoadFromAssemblyPath(p);
+                });
+                // Per-assembly resolver is still useful when the
+                // bind asm itself has direct [DllImport] (rare, but
+                // costs nothing to register). LoadUnmanagedDll on
+                // BindBackendLoadContext is the catch-all for every
+                // DllImport from any assembly in the context —
+                // including transitive deps like TorchSharp.dll
+                // (gap 30 / round-25-verification).
+                RegisterNativeResolver(asm, fullPath);
+                return asm;
             }
-            // Register a P/Invoke resolver that probes the
-            // backend's own runtimes/<rid>/native/ subdir for
-            // DllImports issued by the loaded assembly. Without
-            // this, --bind <path-to-backend.dll> trips
-            // "Unable to load shared library 'X'" on the first
-            // DllImport because the standard resolver only probes
-            // the application's runtimes/ tree, not arbitrary
-            // LoadFrom'd assemblies' bundled natives. Gap 28 /
-            // round-24 verification.
-            if (loadFromPath != null)
-                RegisterNativeResolver(asm, loadFromPath);
-            return asm;
+            Assembly nameAsm;
+            try { nameAsm = Assembly.Load(nameOrPath); }
+            catch (Exception ex)
+            {
+                throw new FileNotFoundException(
+                    "binding assembly not found as file or name: "
+                    + nameOrPath + " (" + ex.Message + ")");
+            }
+            // Native-lib resolver also helps for assemblies
+            // resolved by name when their location is a real
+            // file path (e.g., side-by-side install). Name-loaded
+            // assemblies live in the default context, so the
+            // LoadContext-level hook isn't available — the
+            // per-assembly resolver is the best we can do.
+            if (!string.IsNullOrEmpty(nameAsm.Location)
+                && File.Exists(nameAsm.Location))
+                RegisterNativeResolver(nameAsm, nameAsm.Location);
+            return nameAsm;
+        }
+
+        // Memoize path -> Assembly so repeat LoadAssembly calls on
+        // the same path yield the same Assembly instance (same
+        // Type identities). Without this, the second LoadAssembly
+        // would create a new BindBackendLoadContext, load the
+        // assembly afresh, and IBindable types from the two loads
+        // wouldn't match the host's IBindable interface in a
+        // type-equality check.
+        private static readonly ConcurrentDictionary<string, Assembly>
+            _bindContexts = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Custom <see cref="AssemblyLoadContext"/> for backends
+        /// loaded via <c>--bind &lt;path&gt;</c>. The
+        /// <see cref="LoadUnmanagedDll"/> override probes the
+        /// backend's own <c>runtimes/&lt;rid&gt;/native/</c>
+        /// subdirectory for every P/Invoke from any assembly in
+        /// the context (the bind asm itself, the upstream NuGet
+        /// wrapper like <c>TorchSharp.dll</c>, and any deeper
+        /// transitive deps), then falls back to the default
+        /// resolver. This is the load-context-level hook that
+        /// gap 30 / round-25-verification identified as the
+        /// missing piece — per-assembly
+        /// <see cref="NativeLibrary.SetDllImportResolver"/>
+        /// only fires for DllImports declared in that one
+        /// assembly, but most real backends declare their
+        /// <c>[DllImport]</c>s in a transitive NuGet, not the
+        /// bind asm itself.
+        ///
+        /// <para><see cref="Load"/> defers to
+        /// <see cref="AssemblyDependencyResolver"/> which honors
+        /// the bind asm's <c>.deps.json</c>; managed deps not
+        /// covered by the resolver fall through to the default
+        /// load context (which handles host-shared assemblies
+        /// like Wacs.Core, Wacs.Transpiler.Lib, etc., preserving
+        /// type identity across the boundary).</para>
+        /// </summary>
+        private sealed class BindBackendLoadContext : AssemblyLoadContext
+        {
+            private readonly AssemblyDependencyResolver _depsResolver;
+            private readonly string _bindDir;
+            private readonly string _rid;
+
+            public BindBackendLoadContext(string assemblyPath)
+                : base(name: "WacsBind:" + Path.GetFileName(assemblyPath),
+                       isCollectible: false)
+            {
+                _depsResolver = new AssemblyDependencyResolver(assemblyPath);
+                _bindDir = Path.GetDirectoryName(assemblyPath)!;
+                _rid = RuntimeInformation.RuntimeIdentifier;
+            }
+
+            protected override Assembly? Load(AssemblyName assemblyName)
+            {
+                // Defer to the default context for assemblies the
+                // host has already loaded — preserves type identity
+                // across the boundary so IBindable/IBackend
+                // references in the bind asm match the host's
+                // copies. Without this, deps.json-driven
+                // ResolveAssemblyToPath would happily return a
+                // private path (since EnableDynamicLoading bundles
+                // host-shared deps too) and we'd load a duplicate.
+                foreach (var loaded in Default.Assemblies)
+                {
+                    if (loaded.GetName().Name == assemblyName.Name)
+                        return null;
+                }
+                var path = _depsResolver.ResolveAssemblyToPath(assemblyName);
+                return path != null ? LoadFromAssemblyPath(path) : null;
+            }
+
+            protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+            {
+                // .deps.json-driven resolution first — handles the
+                // "managed library 'TorchSharp' P/Invokes
+                // 'LibTorchSharp', which lives at
+                // runtimes/<rid>/native/libLibTorchSharp.dylib"
+                // mapping that the NuGet RID story is built around.
+                var path = _depsResolver.ResolveUnmanagedDllToPath(
+                    unmanagedDllName);
+                if (path != null
+                    && NativeLibrary.TryLoad(path, out var h1))
+                    return h1;
+                // Fallback: explicit probe of the bind-dir's
+                // runtimes/<rid>/native/ subdirectory in case the
+                // deps.json doesn't list the lib (e.g., it's a
+                // dlopen target of a libtorch_cpu.dylib that .NET
+                // doesn't know about, or the project doesn't ship
+                // a deps.json). Walks coarser RIDs and the flat
+                // bind dir last.
+                var probes = new List<string>
+                {
+                    Path.Combine(_bindDir, "runtimes", _rid, "native"),
+                };
+                foreach (var coarser in CoarserRids(_rid))
+                    probes.Add(Path.Combine(_bindDir, "runtimes",
+                        coarser, "native"));
+                probes.Add(_bindDir);
+                var handle = ResolveFromProbes(unmanagedDllName, probes);
+                return handle != IntPtr.Zero ? handle : IntPtr.Zero;
+            }
         }
 
         // P/Invoke probe paths populated by EnableDynamicLoading

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -15,8 +15,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.8.13</Version>
-        <AssemblyVersion>0.8.13</AssemblyVersion>
+        <Version>0.8.14</Version>
+        <AssemblyVersion>0.8.14</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.7.2 fixes a re-instantiation bug where Module classes with active data segments would come up zeroed on the second `Activator.CreateInstance` because spec §4.5.4 segment-drop emptied the process-wide ModuleInit registry. Module ctors now restore from `ModuleInitData.SavedDataSegments` before each CopyDataSegment so every fresh instance sees its memory initialized. v0.7 retires Lokad.ILPack for PersistedAssemblyBuilder (.NET 9), moves WASM data segments + the codec blob to RVA-mapped initialized data (62.5% smaller than the prior base64-in-#US path, true zero-copy from PE pages to ModuleInitData via UnmanagedMemoryStream), and introduces EmissionTarget.Auto as the new default — promotes to AotLinked when the module fits a conservative envelope (compute / memory / globals / tables + active+passive segments / multi-memory / local tags / imported functions), falling back to Standard otherwise. ~50% first-trial cold-start cut on promoted modules. ImportDispatcher now throws on missing handlers by default (lenient: true opts out). v0.6 consumed the Branch Hinting proposal's metadata.code.branch_hint custom section. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>


### PR DESCRIPTION
## Summary

Round-25 verification (`wasi-nn/WACS-GAPS.md` round 25) found that the gap-28 fix — `NativeLibrary.SetDllImportResolver(asm, …)` keyed on the `--bind`'d assembly — only fires for DllImports declared **inside that assembly**. Real-world backends declare their `[DllImport]`s in a transitive NuGet (`TorchSharp.dll`, `LLamaSharp.dll`), not in the bind asm itself, so the per-asm resolver was a no-op for the actual hot-path.

The documented one-line UX

```
wacs run --wasip2 --bind <Wacs.WASI.NN.TorchSharp.dll> wasi-nn-torch.wasm
```

still tripped `Unable to load shared library 'LibTorchSharp'` and required manual native staging into `Wacs.Console`'s `runtimes/<rid>/native/` to work.

## Fix shape

`BindingLoader.LoadAssembly`'s file-path branch now constructs a custom `BindBackendLoadContext : AssemblyLoadContext` per absolute path (memoized via `ConcurrentDictionary<string, Assembly>`).

- **`LoadUnmanagedDll(name)`** — the load-context-level hook. Fires for **every** P/Invoke from **any** assembly in the context: bind asm, upstream NuGet wrappers (`TorchSharp.dll`'s `[DllImport("LibTorchSharp")]`), deep transitive deps. Defers to `AssemblyDependencyResolver.ResolveUnmanagedDllToPath` first (deps.json-driven RID-aware lookup — the standard .NET 8 plugin pattern), then falls back to a bind-dir `runtimes/<rid>/native/` probe with coarser-RID + flat-dir fallbacks.
- **`Load(AssemblyName)`** — defers to the default context for any assembly already loaded by the host (host-shared types like `IBindable`, `IBackend`). Without this short-circuit, the deps.json resolver would return private paths (since `EnableDynamicLoading=true` bundles host-shared deps) and we'd load duplicates with split `Type` identities.
- **Path memoization** — repeat `LoadAssembly` calls on the same path return the same `Assembly` instance. Without it, the load-then-bind double-pass in `RunHandler.PreloadBindAssemblies` + `ApplyBindings` would create two contexts and `IBindable` discovery on the second load would yield types not equal to the first.
- **Per-asm `SetDllImportResolver`** retained as a complementary hook — still useful when the bind asm itself declares direct `[DllImport]`s, costs nothing.

## Empirical verification

```
$ unset DYLD_FALLBACK_LIBRARY_PATH
$ ls Wacs.Console/Wacs.Console/bin/Release/net9.0/runtimes/osx-arm64/native/
libonnxruntime.dylib  # only the bundled ORT — no torch natives
$ TORCH=.../Wacs.WASI.NN.TorchSharp/bin/Release/net8.0/Wacs.WASI.NN.TorchSharp.dll
$ WACS_WASINN_TORCH_DIR=.../models \
  wacs run target/wasm32-wasip2/release/wasi-nn-torch.wasm --wasip2 --bind "$TORCH"
loading TorchScript 'xor-mlp' (host resolves via $WACS_WASINN_TORCH_DIR)…
ready — xor-mlp via wasi-nn (TorchSharp / libtorch).

  XOR(0, 0) -> sigmoid=0.0000  pred=0  expected=0  OK
  XOR(0, 1) -> sigmoid=1.0000  pred=1  expected=1  OK
  XOR(1, 0) -> sigmoid=0.9994  pred=1  expected=1  OK
  XOR(1, 1) -> sigmoid=0.0000  pred=0  expected=0  OK

all cases pass
```

## Test plan

- [x] `Wacs.Transpiler.Test` 775/776 (1 skip, pre-existing)
- [x] `Wacs.WASI.NN.TorchSharp.Test` 8/8
- [x] `Wacs.WASI.NN.LlamaSharp.Test` 8/8 + 2 skip
- [x] `Wacs.WASI.NN.OnnxRuntime.Test` 10/10
- [x] `Wacs.WASI.NN.MLNet.Test` 7/7
- [x] AOT smoke (`wacs aot --wasi fd_write-to-stdout.wasm` → native binary prints `hello`)
- [x] **End-to-end gap-30 verification**: XOR MLP TorchScript runs through `--bind` with no env vars and no manual native staging

## Versions

- `WACS.Transpiler.Lib` 0.8.13 → **0.8.14** (`BindBackendLoadContext`)
- `WACS.Cli` 1.5.20 → **1.5.21** (release event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)