### PR TITLE
Fix unbounded wasi-nn leak: [resource-drop]X was a silent no-op under --engine transpiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## WACS.Cli 1.5.22 / WACS 0.13.8 / WACS.WASI.NN 0.3.3 / WACS.WASI.Preview2.DependencyInjection 0.1.7 — wasi-nn cross-table resource-drop fix (massive leak in transpiler + --wasi-nn)
+
+`WACS_DIAG_MEMORY=1` data from the SLM REPL revealed +12.67 GiB of managed
+heap growth across 106 token-generation steps, matching almost exactly the
+sum of returned logits-tensor byte sizes (~26 MiB → ~227 MiB per turn). The
+leak traces to a resource-table mismatch:
+
+- The transpiler / wasip2 direct-link path allocates host-imported tensor
+  handles through `WasiPreview2Resources.AllocateResource` →
+  `ResourceContext.TableFor(typeof(ITensor)).Allocate(...)`.
+- The interpreter binding's `[resource-drop]tensor` handler drops from
+  `WasiNNHost.Tensors` — a **different** table.
+- Result: every tensor allocated during a direct-link compute call stays
+  pinned in the direct-link table forever, holding its byte buffer alive.
+  For the Gemma 3 270M SLM that's ~26-230 MiB of FP32 logits per token, no
+  KV cache, multiplied by every token generated for the lifetime of the
+  process.
+
+### Fix shape
+
+- **`WasmRuntime.ExternalResourceDrop`** (new public `Action<Type, int>?`) —
+  cross-binding hook for releasing handles outside an `IBindable`'s own
+  resource tables.
+- **`WasiPreview2Resources.FreeResource(Type, int)`** (new method) —
+  drops a handle from `_context.TableFor(type)`. Idempotent.
+- **`WasiPreview2RuntimeScope` ctor** sets
+  `Runtime.ExternalResourceDrop = (t, h) => Resources.FreeResource(t, h)`
+  after `Resources` is resolved, so every wasi-nn `[resource-drop]X`
+  handler can release entries from the direct-link table too.
+- **`WitBindings.BindError` / `BindTensor` / `BindGraph` / `BindInference`**
+  augment the existing `host.X.Drop(h)` call with
+  `runtime.ExternalResourceDrop?.Invoke(typeof(Nn.IX), h)` — additive, so
+  the interpreter-only path is unchanged and the wrong-table call returns
+  false silently.
+
+Hook is per-runtime (not global), so different component instances don't
+share a drop hook.
+
+### Versions
+
+- `WACS` (Wacs.Core) 0.13.7 → **0.13.8** (new public `WasmRuntime.ExternalResourceDrop`)
+- `WACS.WASI.NN` 0.3.2 → **0.3.3** (drop handlers call the runtime hook)
+- `WACS.WASI.Preview2.DependencyInjection` 0.1.6 → **0.1.7** (new
+  `WasiPreview2Resources.FreeResource` + scope wires the hook)
+- `WACS.Cli` 1.5.22 (no version bump — already at this version from the
+  diag-memory PR)
+
+### Test plan
+
+- `Wacs.WASI.NN.Test` 21/21
+- `Wacs.WASI.NN.OnnxRuntime.Test` 10/10
+- `Wacs.WASI.Preview2.Test` 189/189
+- **Empirical verification**: re-run the SLM REPL with `WACS_DIAG_MEMORY=1`;
+  managed heap should plateau instead of climbing linearly with turn count.
+
 ## WACS.Cli 1.5.22 / WACS.WASI.NN 0.3.2 — `WACS_DIAG_MEMORY` per-compute memory snapshots
 
 Diagnostic hook for the "RSS climbs across a long-running chat REPL" pattern.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,61 +1,131 @@
 # Changelog
 
-## WACS.Cli 1.5.22 / WACS 0.13.8 / WACS.WASI.NN 0.3.3 / WACS.WASI.Preview2.DependencyInjection 0.1.7 — wasi-nn cross-table resource-drop fix (massive leak in transpiler + --wasi-nn)
+## WACS.Cli 1.5.23 / WACS.Transpiler.Lib 0.8.15 / WACS 0.13.8 / WACS.WASI.NN 0.3.3 / WACS.WASI.Preview2.DependencyInjection 0.1.7 — fix unbounded leak: `[resource-drop]X` was a silent no-op under `--engine transpiler`
 
-`WACS_DIAG_MEMORY=1` data from the SLM REPL revealed +12.67 GiB of managed
-heap growth across 106 token-generation steps, matching almost exactly the
-sum of returned logits-tensor byte sizes (~26 MiB → ~227 MiB per turn). The
-leak traces to a resource-table mismatch:
+User-reported regression: the wasi-nn SLM REPL grew the host process to
+~40 GiB before crashing with `mutex lock failed`. `WACS_DIAG_MEMORY=1`
+(added below) showed +12.67 GiB managed-heap growth across 106 token
+steps, matching almost exactly the sum of per-call output sizes
+(~26 MiB → ~227 MiB FP32 logits per token, autoregressive, no KV cache).
 
-- The transpiler / wasip2 direct-link path allocates host-imported tensor
-  handles through `WasiPreview2Resources.AllocateResource` →
-  `ResourceContext.TableFor(typeof(ITensor)).Allocate(...)`.
-- The interpreter binding's `[resource-drop]tensor` handler drops from
-  `WasiNNHost.Tensors` — a **different** table.
-- Result: every tensor allocated during a direct-link compute call stays
-  pinned in the direct-link table forever, holding its byte buffer alive.
-  For the Gemma 3 270M SLM that's ~26-230 MiB of FP32 logits per token, no
-  KV cache, multiplied by every token generated for the lifetime of the
-  process.
+### What was actually leaking
 
-### Fix shape
+Each `ctx.compute()` returned a `list<(string, own<tensor>)>` that the
+transpiler lowered into resource handles allocated through
+`WasiPreview2Resources.AllocateResource(typeof(Nn.ITensor), …)`. When
+the guest dropped the handles at end-of-turn the host should have
+released them, but they piled up forever.
 
-- **`WasmRuntime.ExternalResourceDrop`** (new public `Action<Type, int>?`) —
-  cross-binding hook for releasing handles outside an `IBindable`'s own
-  resource tables.
-- **`WasiPreview2Resources.FreeResource(Type, int)`** (new method) —
-  drops a handle from `_context.TableFor(type)`. Idempotent.
-- **`WasiPreview2RuntimeScope` ctor** sets
-  `Runtime.ExternalResourceDrop = (t, h) => Resources.FreeResource(t, h)`
-  after `Resources` is resolved, so every wasi-nn `[resource-drop]X`
-  handler can release entries from the direct-link table too.
-- **`WitBindings.BindError` / `BindTensor` / `BindGraph` / `BindInference`**
-  augment the existing `host.X.Drop(h)` call with
-  `runtime.ExternalResourceDrop?.Invoke(typeof(Nn.IX), h)` — additive, so
-  the interpreter-only path is unchanged and the wrong-table call returns
-  false silently.
+### Two-stage diagnosis (recorded in the diag.log lineage)
 
-Hook is per-runtime (not global), so different component instances don't
-share a drop hook.
+**Stage 1 — cross-table mismatch hypothesis.** Initial theory:
+the interpreter binding `[resource-drop]tensor` drops from
+`WasiNNHost.Tensors` (one resource table), but the transpiler
+direct-link path allocates into
+`ResourceContext.TableFor(typeof(ITensor))` (a different table). Wired
+a cross-binding hook (`WasmRuntime.ExternalResourceDrop` →
+`WasiPreview2Resources.FreeResource`) so the interpreter `[resource-
+drop]X` handler dropped from both tables. **Result: leak rate roughly
+unchanged**. The hook was right; the binding it bridged from was the
+wrong layer.
+
+**Stage 2 — the binding was never invoked.** Added split counters
+(`drops[interp=X ext=Y]`) to the diag output. Result: `interp=0` across
+130 turns. The WitBindings `[resource-drop]X` delegate **never fires**
+under `--engine transpiler`. Traced into the transpiler:
+
+```csharp
+// ComponentMainHost.cs (before this PR):
+var importsStub = ImportDispatcher.Create(importsType,
+    new Dictionary<string, Func<object?[], object?>>(),  // EMPTY
+    lenient: true);                                       // silent no-op
+```
+
+Every `[resource-drop]X` call from the guest hit an empty handler
+dictionary, fell through `lenient: true`, and returned `default(void)`
+without touching the host. The runtime's entity-binding table — where
+WitBindings registered the drop handlers — was bypassed entirely. The
+wasm thought drops succeeded; the host never saw them.
+
+### The fix
+
+`ComponentMainHost` now walks the imports interface's
+`[WacsImportNames]` assembly metadata and auto-registers a handler for
+every `[resource-drop]X` import:
+
+1. For each entry whose name starts with `[resource-drop]`, split the
+   module name into `(package, interface)` and the entity name into
+   the bare resource name.
+2. Resolve the CLR resource interface type by scanning loaded
+   assemblies for one whose `[WitSource]` attribute matches
+   `(Package, Interface, Item)`.
+3. Register a handler that calls
+   `WasiPreview2Resources.FreeResource(typeof(IX), handle)` on the
+   dropped handle.
+
+Generic across **all** host-imported resources — wasi-nn (tensor,
+graph, context, error), wasi:io/streams, wasi:filesystem/types, wasi:io/poll,
+and anything else the transpiler emits a stub for. No per-resource code.
+
+The stage-1 hook (`WasmRuntime.ExternalResourceDrop`,
+`WasiPreview2Resources.FreeResource`) stays — it's now defense-in-depth
+for the rare case where an `IBindable` other than the transpiler
+direct-link path allocates into one table and routes drops through
+another.
+
+### What the SLM REPL looks like now
+
+193 token-generation steps, no crash. Per-turn output: 14 MiB → 332 MiB
+(autoregressive prompt growth is unchanged; that's a guest decode-loop
+property, not a leak). Per-turn managed-heap and RSS:
+
+| | Before fix (turn 130) | After fix (turn 193) |
+|---|---|---|
+| Managed heap | **27.07 GiB** (+24.83 GiB from turn 1) | **1.03 GiB** (−1.21 GiB) |
+| RSS | 6.60 GiB | 6.57 GiB |
+| Gen2 collections | 12 (stalled — heap was rooted) | 164 (healthy) |
+| Outcome | crashed | still running |
+
+Managed heap is now smaller than the turn-1 baseline because Gen2
+finally reclaims the LOH allocations once the resource-table roots are
+released.
+
+### What also landed in this PR
+
+- **`WACS_DIAG_MEMORY=1` instrumentation** — per-compute stderr snapshot
+  (`rss`, `managed`, `gc[g0/g1/g2]`, `in`/`out` bytes, `drops[interp,ext]`,
+  duration). The diagnostic surface that found this; useful for any
+  future "RSS climbs across a long-running REPL" report. Hooks both the
+  interpreter (`WitBindings.compute`, `WitxBindings.compute`) and the
+  direct-link path (`GraphExecutionContext.Compute`). Off by default,
+  zero overhead in the negative path.
+- **Stage-1 cross-table hook** — `WasmRuntime.ExternalResourceDrop` +
+  `WasiPreview2Resources.FreeResource` + `WitBindings.[resource-drop]X`
+  handlers wired through both tables. Architecturally correct even
+  though it didn't fire for the SLM workload.
 
 ### Versions
 
-- `WACS` (Wacs.Core) 0.13.7 → **0.13.8** (new public `WasmRuntime.ExternalResourceDrop`)
-- `WACS.WASI.NN` 0.3.2 → **0.3.3** (drop handlers call the runtime hook)
-- `WACS.WASI.Preview2.DependencyInjection` 0.1.6 → **0.1.7** (new
-  `WasiPreview2Resources.FreeResource` + scope wires the hook)
-- `WACS.Cli` 1.5.22 (no version bump — already at this version from the
-  diag-memory PR)
+- `WACS.Cli` 1.5.22 → **1.5.23**
+- `WACS.Transpiler.Lib` 0.8.14 → **0.8.15** (`ComponentMainHost` auto-
+  registers `[resource-drop]X` handlers — the actual fix)
+- `WACS` (Wacs.Core) 0.13.7 → **0.13.8** (`WasmRuntime.ExternalResourceDrop`
+  cross-binding hook)
+- `WACS.WASI.NN` 0.3.2 → **0.3.3** (WitBindings drop handlers call the
+  cross-binding hook + `WACS_DIAG_MEMORY` instrumentation)
+- `WACS.WASI.Preview2.DependencyInjection` 0.1.6 → **0.1.7**
+  (`WasiPreview2Resources.FreeResource` + scope wires the hook)
 
 ### Test plan
 
 - `Wacs.WASI.NN.Test` 21/21
 - `Wacs.WASI.NN.OnnxRuntime.Test` 10/10
 - `Wacs.WASI.Preview2.Test` 189/189
-- **Empirical verification**: re-run the SLM REPL with `WACS_DIAG_MEMORY=1`;
-  managed heap should plateau instead of climbing linearly with turn count.
+- `Wacs.Transpiler.Test` 775/776 (1 pre-existing skip)
+- **Empirical**: SLM REPL ran 193 turns clean; managed heap plateaued
+  near 1 GiB instead of climbing past 27 GiB.
 
-## WACS.Cli 1.5.22 / WACS.WASI.NN 0.3.2 — `WACS_DIAG_MEMORY` per-compute memory snapshots
+
 
 Diagnostic hook for the "RSS climbs across a long-running chat REPL" pattern.
 When `WACS_DIAG_MEMORY=1` is set in the environment, every guest-triggered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## WACS.Cli 1.5.22 / WACS.WASI.NN 0.3.2 — `WACS_DIAG_MEMORY` per-compute memory snapshots
+
+Diagnostic hook for the "RSS climbs across a long-running chat REPL" pattern.
+When `WACS_DIAG_MEMORY=1` is set in the environment, every guest-triggered
+`compute()` call writes a single stderr line with the process RSS, GC managed
+heap, GC collection counts, input/output byte totals, and wall-clock duration:
+
+```
+[wacs-diag-memory] turn=1 rss=523.4MiB (+0B) managed=18.2MiB (+0B) gc[g0=4 g1=2 g2=1] in=120B out=384B took=8.21s
+[wacs-diag-memory] turn=2 rss=541.7MiB (+18.3MiB) managed=18.4MiB (+0.2MiB) gc[g0=6 g1=3 g2=1] in=520B out=412B took=8.94s
+[wacs-diag-memory] turn=3 rss=560.1MiB (+36.7MiB) managed=18.6MiB (+0.4MiB) gc[g0=9 g1=4 g2=1] in=945B out=380B took=9.32s
+```
+
+The `(+X)` deltas are vs the first observed turn — fast visual scan for
+"which counter is climbing how fast". Distinguishing the three growth
+patterns:
+
+- **RSS grows with input** — expected; the guest is accumulating conversation
+  history and re-feeding it each turn. Cap via the guest's prompt-truncation
+  policy or, for the GenAI backend, `WACS_WASINN_GENAI_MAX_LENGTH`.
+- **Managed grows without input** — host-side reference retention (canonical-
+  ABI lift copying pinned somewhere). Open a bug with the snapshot.
+- **RSS grows without managed or input** — native fragmentation (macOS's
+  `libsystem_malloc` doesn't decommit freed regions back to the OS, common
+  with repeated large allocations + frees) or backend-internal native cache.
+
+Hooks both the WIT (`graph-execution-context.compute`) and the WITX (legacy
+preview1) binding compute call sites. Off by default — zero overhead in the
+negative path (Enabled is read once into a static readonly bool).
+
+### Versions
+
+- `WACS.WASI.NN` 0.3.1 → **0.3.2** (new `MemoryDiagnostics` internal helper +
+  per-compute hooks in `WitBindings` / `WitxBindings`)
+- `WACS.Cli` 1.5.21 → **1.5.22** (release event)
+
 ## WACS.Cli 1.5.21 / WACS.Transpiler.Lib 0.8.14 — gap 30: `BindBackendLoadContext` for transitive-dep DllImports
 
 Round-25 verification (`wasi-nn/WACS-GAPS.md` round 25) found that the gap-28 fix —

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.22</Version>
-    <AssemblyVersion>1.5.22</AssemblyVersion>
+    <Version>1.5.23</Version>
+    <AssemblyVersion>1.5.23</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.21</Version>
-    <AssemblyVersion>1.5.21</AssemblyVersion>
+    <Version>1.5.22</Version>
+    <AssemblyVersion>1.5.22</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.Core/Wacs.Core/Runtime/WasmRuntimeBinding.cs
+++ b/Wacs.Core/Wacs.Core/Runtime/WasmRuntimeBinding.cs
@@ -27,6 +27,31 @@ namespace Wacs.Core.Runtime
 {
     public partial class WasmRuntime
     {
+        /// <summary>
+        /// Optional cross-binding hook for releasing resource
+        /// handles allocated outside an <c>IBindable</c>'s own
+        /// resource tables. Used by the transpiler / wasip2
+        /// direct-link path, where component-model resources
+        /// (e.g. wasi-nn tensors) get allocated in
+        /// <c>WasiPreview2Resources</c> / <c>ResourceContext</c>
+        /// but the interpreter binding's <c>[resource-drop]X</c>
+        /// only knows about the <c>IBindable</c>'s local table.
+        /// Without this hook, large host-owned resources allocated
+        /// during direct-link compute calls (e.g. multi-hundred-MiB
+        /// logits tensors in the SLM workflow) accumulate in the
+        /// direct-link table forever — the leak shows up as
+        /// unbounded managed-heap growth across compute calls.
+        ///
+        /// <para>Set by the runtime-scope construction
+        /// (<c>WasiPreview2RuntimeScope</c>) once the direct-link
+        /// resources object is available. <c>IBindable</c>-side
+        /// drop handlers call <c>ExternalResourceDrop?.Invoke(...)</c>
+        /// after dropping from their own table — whichever table
+        /// holds the entry actually releases it; the off-table
+        /// call returns false silently.</para>
+        /// </summary>
+        public Action<Type, int>? ExternalResourceDrop { get; set; }
+
         public void RegisterModule(string moduleName, ModuleInstance moduleInstance)
         {
             _registeredModules[moduleName] = moduleInstance;

--- a/Wacs.Core/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.13.7</AssemblyVersion>
-    <Version>0.13.7</Version>
+    <AssemblyVersion>0.13.8</AssemblyVersion>
+    <Version>0.13.8</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter. v0.13 introduces selectable linear-memory storage: ManagedArray (byte[], default, ~2 GiB) or NativePointer (NativeMemory.AllocZeroed, no 2 GiB cap) via RuntimeOptions.MemoryStorage. NativePointer + (memory i64) lifts the cap to WasmMaxPages64 (2^48), unlocking memory64 modules end-to-end through the interpreter and transpiler. Memory-op bounds checks moved to a wrap-safe unsigned form covering memory32 and memory64. v0.12 brought the in-process WAT/WAST parser to full parity with the binary parser — every wast in the WebAssembly spec testsuite (SIMD, GC, relaxed-SIMD, hex-float edge cases) round-trips identically through both pipelines, dropping the wasm-tools / wast2json CI dependency. v0.12.1 tracks the wasm-3.0 spec submodule to tip d7aada5: inclusive memory page-count limit (PRs #105/#106/#108), tail-call to imported host functions (PR #1872), `array.new_data` bounds (PR #1881), malformed memop reserved bits (PRs #1886/#1936), table64 u64 limits (PR #104), `(module definition …)` validate-only support, u32 offset enforcement on memory32, and `;;` line-comment CR termination.</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/ComponentMainHost.cs
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/AOT/Component/ComponentMainHost.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Wacs.ComponentModel.Runtime;
+using Wacs.HostBindings;
 using Wacs.HostBindings.Abstractions;
 using Wacs.Transpiler.Cli;
 
@@ -80,8 +82,21 @@ namespace Wacs.Transpiler.AOT.Component
                 // dispatcher's default loud-throw behavior because we
                 // intentionally want fall-through here.
                 var importsType = ctorParams[0].ParameterType;
+                // Auto-register handlers for every wasm import named
+                // `[resource-drop]X` so host-owned resources allocated
+                // through the direct-link path actually get released
+                // when the guest drops the handle. Without these
+                // handlers the dispatcher's `lenient: true` swallows
+                // every drop call, the host's resource table never
+                // shrinks, and large host resources (e.g. wasi-nn
+                // tensor byte buffers) accumulate for the lifetime
+                // of the component instance. Empirically: the SLM
+                // workflow's per-token logits tensors leak GiB of
+                // managed heap; see wasi-nn/WACS-GAPS.md round 27.
+                var dropHandlers = BuildResourceDropHandlers(
+                    importsType, prebuiltResources);
                 var importsStub = ImportDispatcher.Create(importsType,
-                    new Dictionary<string, Func<object?[], object?>>(),
+                    dropHandlers,
                     lenient: true);
 
                 // Bundle (host functions) + resources (handle
@@ -517,6 +532,145 @@ namespace Wacs.Transpiler.AOT.Component
         {
             try { return Assembly.Load(name); }
             catch { return null; }
+        }
+
+        /// <summary>
+        /// Walk the imports interface's assembly-level
+        /// <c>WacsImportNames</c> for every <c>[resource-drop]X</c>
+        /// import; resolve the CLR resource interface type via
+        /// <c>[WitSource]</c>; register a handler that routes the
+        /// dropped handle through
+        /// <c>WasiPreview2Resources.FreeResource(typeof(IX), handle)</c>.
+        /// Without this, the dispatcher's <c>lenient: true</c> path
+        /// silently no-ops every drop call and host-owned resources
+        /// (wasi-nn tensors, wasi:io streams, …) leak.
+        ///
+        /// <para>The handler is reflective on
+        /// <see cref="WasiPreview2Resources"/> because this assembly
+        /// (Wacs.Transpiler.Lib) doesn't reference Preview2.DI. The
+        /// caller already has it in <paramref name="resources"/> via
+        /// the same reflective path that resolves the bundle.</para>
+        /// </summary>
+        private static Dictionary<string, Func<object?[], object?>>
+            BuildResourceDropHandlers(
+                Type importsInterface, object? resources)
+        {
+            var result = new Dictionary<string, Func<object?[], object?>>();
+            if (resources == null) return result;
+
+            // FreeResource(Type, int) is the entry point. Resolve
+            // once; the handlers below close over the MethodInfo.
+            var freeResource = resources.GetType().GetMethod(
+                "FreeResource",
+                new[] { typeof(Type), typeof(int) });
+            if (freeResource == null) return result;
+
+            var asm = importsInterface.Assembly;
+
+            // Decode every [WacsImportNames] attribute on the assembly
+            // into (methodName, module, name) entries.
+            var entries = new List<(string MethodName, string Module, string Name)>();
+            foreach (var attr in asm.GetCustomAttributes<WacsImportNamesAttribute>())
+                entries.AddRange(WacsImportNamesAttribute.Decode(attr.Mapping));
+
+            // Resolver cache so we don't re-scan AppDomain for every
+            // resource (some components have ~8 [resource-drop]s).
+            var typeCache = new Dictionary<string, Type?>(
+                StringComparer.Ordinal);
+
+            foreach (var (methodName, module, name) in entries)
+            {
+                if (!name.StartsWith("[resource-drop]",
+                        StringComparison.Ordinal))
+                    continue;
+                var resourceName = name.Substring(
+                    "[resource-drop]".Length);
+
+                if (!TrySplitModule(module,
+                        out var package, out var ifaceName))
+                    continue;
+
+                var cacheKey = package + "::" + ifaceName + "::" + resourceName;
+                if (!typeCache.TryGetValue(cacheKey, out var resourceType))
+                {
+                    resourceType = FindResourceType(
+                        package, ifaceName!, resourceName);
+                    typeCache[cacheKey] = resourceType;
+                }
+                if (resourceType == null) continue;
+
+                var capturedType = resourceType;
+                result[methodName] = args =>
+                {
+                    if (args == null || args.Length == 0
+                        || args[0] is not int h)
+                        return null;
+                    freeResource.Invoke(resources,
+                        new object[] { capturedType, h });
+                    return null;
+                };
+            }
+            return result;
+        }
+
+        // Split a wasm import-module name into (package, interface).
+        // `wasi:nn/tensor@0.2.0-rc-2024-10-28` →
+        //   package = "wasi:nn@0.2.0-rc-2024-10-28"
+        //   iface   = "tensor"
+        private static bool TrySplitModule(string module,
+            out string? package, out string? iface)
+        {
+            package = null; iface = null;
+            int slash = module.IndexOf('/');
+            if (slash <= 0 || slash == module.Length - 1) return false;
+            int at = module.IndexOf('@', slash);
+            string ns = module.Substring(0, slash);
+            string ifaceLocal, version;
+            if (at < 0)
+            {
+                ifaceLocal = module.Substring(slash + 1);
+                version = "";
+            }
+            else
+            {
+                ifaceLocal = module.Substring(
+                    slash + 1, at - slash - 1);
+                version = module.Substring(at);
+            }
+            package = ns + version;
+            iface = ifaceLocal;
+            return true;
+        }
+
+        // Find the CLR interface type whose [WitSource] matches the
+        // given (package, interface, resource) triple. Walks loaded
+        // assemblies because the resource interface lives in a
+        // different assembly than the transpiled module (typically
+        // a Wacs.WASI.NN.* or Wacs.WASI.Preview2 sibling).
+        private static Type? FindResourceType(
+            string package, string iface, string resource)
+        {
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] types;
+                try { types = asm.GetTypes(); }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    types = ex.Types.Where(t => t != null)!
+                        .Cast<Type>().ToArray();
+                }
+                foreach (var t in types)
+                {
+                    if (!t.IsInterface) continue;
+                    var attr = t.GetCustomAttribute<WitSourceAttribute>();
+                    if (attr == null) continue;
+                    if (attr.Package == package
+                        && attr.Interface == iface
+                        && attr.Item == resource)
+                        return t;
+                }
+            }
+            return null;
         }
 
         // Reflectively register an OnnxBackend for graph-encoding.onnx

--- a/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
+++ b/Wacs.Transpiler/Wacs.Transpiler.Lib/Wacs.Transpiler.Lib.csproj
@@ -15,8 +15,8 @@
         <!-- Package identity -->
         <PackageId>WACS.Transpiler.Lib</PackageId>
         <Title>WACS Transpiler (Library)</Title>
-        <Version>0.8.14</Version>
-        <AssemblyVersion>0.8.14</AssemblyVersion>
+        <Version>0.8.15</Version>
+        <AssemblyVersion>0.8.15</AssemblyVersion>
         <Authors>Kelvin Nishikawa</Authors>
         <Copyright>(c) 2026 Kelvin Nishikawa</Copyright>
         <Description>Library API for WACS.Transpiler — programmatic ahead-of-time WebAssembly-to-.NET IL transpilation, plus seamless loading of saved transpiled assemblies. v0.7.2 fixes a re-instantiation bug where Module classes with active data segments would come up zeroed on the second `Activator.CreateInstance` because spec §4.5.4 segment-drop emptied the process-wide ModuleInit registry. Module ctors now restore from `ModuleInitData.SavedDataSegments` before each CopyDataSegment so every fresh instance sees its memory initialized. v0.7 retires Lokad.ILPack for PersistedAssemblyBuilder (.NET 9), moves WASM data segments + the codec blob to RVA-mapped initialized data (62.5% smaller than the prior base64-in-#US path, true zero-copy from PE pages to ModuleInitData via UnmanagedMemoryStream), and introduces EmissionTarget.Auto as the new default — promotes to AotLinked when the module fits a conservative envelope (compute / memory / globals / tables + active+passive segments / multi-memory / local tags / imported functions), falling back to Standard otherwise. ~50% first-trial cold-start cut on promoted modules. ImportDispatcher now throws on missing handlers by default (lenient: true opts out). v0.6 consumed the Branch Hinting proposal's metadata.code.branch_hint custom section. v0.5 added the AotLinked emission target, stable AssemblyName, and the [WacsTranspiledImports] / [WacsImportNames] emission used by WACS.HostBindings.SourceGen.</Description>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/GraphExecutionContext.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/GraphExecutionContext.cs
@@ -61,7 +61,15 @@ namespace Wacs.WASI.NN.DependencyInjection
                         new Wacs.WASI.NN.Types.Tensor(dims, ty, data));
                 }
 
-                var outputs = _backendCtx.Compute(bridged);
+                // Goes through MemoryDiagnostics so the transpiler
+                // / wasip2 direct-link path emits per-call snapshots
+                // when WACS_DIAG_MEMORY=1 — matches the interpreter
+                // WIT / WITX hooks in Wacs.WASI.NN. Without this the
+                // direct-link path silently skips the diagnostics
+                // (it bypasses the interpreter's BindHostFunction
+                // wiring entirely).
+                var outputs = MemoryDiagnostics.RunWithDiagnostics(
+                    _backendCtx, bridged);
                 var result = new (string, Nn.ITensor)[outputs.Count];
                 for (int i = 0; i < outputs.Count; i++)
                 {

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/MemoryDiagnostics.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/MemoryDiagnostics.cs
@@ -1,0 +1,173 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using Wacs.WASI.NN.Types;
+
+namespace Wacs.WASI.NN
+{
+    /// <summary>
+    /// Per-call memory + timing instrumentation around each
+    /// <see cref="IBackendContext.Compute"/> invocation. Gated on
+    /// <c>WACS_DIAG_MEMORY=1</c> in the environment; off by default
+    /// (zero overhead in the negative path — the binding layer
+    /// reads <see cref="Enabled"/> once and skips the snapshot
+    /// hot loop).
+    ///
+    /// <para>Used to diagnose growth patterns when a long-running
+    /// host (e.g., a chat REPL) sees RSS climb across conversation
+    /// turns: the per-call counters distinguish
+    ///   <list type="bullet">
+    ///     <item><b>RSS growth that matches input growth</b> —
+    ///       expected: the guest is accumulating history</item>
+    ///     <item><b>Managed-heap growth without input growth</b> —
+    ///       host-side reference retention (canonical-ABI lift
+    ///       copies pinned somewhere)</item>
+    ///     <item><b>RSS growth without managed or input growth</b>
+    ///       — native fragmentation (libsystem_malloc on macOS
+    ///       doesn't decommit) or backend-internal native cache</item>
+    ///   </list>
+    /// </para>
+    ///
+    /// <para>Output goes to stderr so a piped stdout still gets
+    /// just the model's text. Format is stable for grep-based
+    /// post-processing.</para>
+    /// </summary>
+    internal static class MemoryDiagnostics
+    {
+        internal static readonly bool Enabled = ParseEnabled(
+            Environment.GetEnvironmentVariable("WACS_DIAG_MEMORY"));
+
+        private static int _turn;
+        private static long _baselineRss = -1;
+        private static long _baselineManaged = -1;
+
+        /// <summary>
+        /// Wrap an <see cref="IBackendContext.Compute"/> call with
+        /// memory + timing snapshot logging when
+        /// <see cref="Enabled"/> is true. Snapshot points: RSS,
+        /// managed heap, GC generation counts, input/output byte
+        /// totals, wall-clock duration.
+        /// </summary>
+        public static IReadOnlyList<NamedTensor> RunWithDiagnostics(
+            IBackendContext context,
+            IReadOnlyList<NamedTensor> inputs)
+        {
+            if (!Enabled) return context.Compute(inputs);
+
+            var sw = Stopwatch.StartNew();
+            IReadOnlyList<NamedTensor>? outputs = null;
+            try
+            {
+                outputs = context.Compute(inputs);
+                return outputs;
+            }
+            finally
+            {
+                sw.Stop();
+                EmitSnapshot(inputs, outputs, sw.Elapsed.TotalSeconds);
+            }
+        }
+
+        private static void EmitSnapshot(
+            IReadOnlyList<NamedTensor> inputs,
+            IReadOnlyList<NamedTensor>? outputs,
+            double durationSec)
+        {
+            int turn = Interlocked.Increment(ref _turn);
+
+            long rss = 0;
+            try
+            {
+                using var proc = Process.GetCurrentProcess();
+                proc.Refresh();
+                rss = proc.WorkingSet64;
+            }
+            catch { /* counters degrade gracefully if RSS unavailable */ }
+
+            long managed = GC.GetTotalMemory(forceFullCollection: false);
+
+            // Capture the first turn's snapshot as a baseline so
+            // subsequent turns can report a delta — much easier to
+            // read at a glance than the absolute number across 50
+            // conversation turns.
+            if (_baselineRss < 0) _baselineRss = rss;
+            if (_baselineManaged < 0) _baselineManaged = managed;
+            long rssDelta = rss - _baselineRss;
+            long managedDelta = managed - _baselineManaged;
+
+            long inBytes = 0, outBytes = 0;
+            for (int i = 0; i < inputs.Count; i++)
+                inBytes += inputs[i].Tensor.Data.Length;
+            if (outputs != null)
+                for (int i = 0; i < outputs.Count; i++)
+                    outBytes += outputs[i].Tensor.Data.Length;
+
+            int gen0 = GC.CollectionCount(0);
+            int gen1 = GC.CollectionCount(1);
+            int gen2 = GC.CollectionCount(2);
+
+            // Single-line format, grep-friendly. All bytes in
+            // human-readable form except input/output (small,
+            // exact byte counts are more useful for correlating
+            // against guest prompt sizes).
+            var line = string.Format(
+                CultureInfo.InvariantCulture,
+                "[wacs-diag-memory] turn={0} rss={1} (+{2}) managed={3} (+{4}) "
+                + "gc[g0={5} g1={6} g2={7}] in={8}B out={9}B took={10:F2}s",
+                turn,
+                FormatBytes(rss),
+                FormatBytesDelta(rssDelta),
+                FormatBytes(managed),
+                FormatBytesDelta(managedDelta),
+                gen0, gen1, gen2,
+                inBytes, outBytes,
+                durationSec);
+
+            try { Console.Error.WriteLine(line); }
+            catch { /* stderr closed; nothing to do */ }
+        }
+
+        private static string FormatBytes(long b)
+        {
+            if (b < 1024L) return b + "B";
+            if (b < 1024L * 1024L) return (b / 1024.0).ToString(
+                "F1", CultureInfo.InvariantCulture) + "KiB";
+            if (b < 1024L * 1024L * 1024L) return (b / (1024.0 * 1024.0))
+                .ToString("F1", CultureInfo.InvariantCulture) + "MiB";
+            return (b / (1024.0 * 1024.0 * 1024.0)).ToString(
+                "F2", CultureInfo.InvariantCulture) + "GiB";
+        }
+
+        private static string FormatBytesDelta(long b)
+        {
+            // Signed form so the reader sees "+0.5MiB" or "-0.1MiB"
+            // without parsing.
+            if (b < 0) return "-" + FormatBytes(-b);
+            return "+" + FormatBytes(b);
+        }
+
+        private static bool ParseEnabled(string? s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            switch (s.Trim().ToLowerInvariant())
+            {
+                case "1":
+                case "true":
+                case "yes":
+                case "on":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/MemoryDiagnostics.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/MemoryDiagnostics.cs
@@ -51,6 +51,19 @@ namespace Wacs.WASI.NN
         private static long _baselineManaged = -1;
 
         /// <summary>
+        /// Counter incremented by the wasi-nn binding's
+        /// <c>[resource-drop]X</c> handler whenever the cross-table
+        /// <see cref="Wacs.Core.Runtime.WasmRuntime.ExternalResourceDrop"/>
+        /// hook actually fires. Logged with each per-compute
+        /// snapshot so a stuck zero proves the hook isn't wired
+        /// (build doesn't include the v0.3.3 fix, or
+        /// <c>WasiPreview2RuntimeScope</c> wasn't invoked); a
+        /// growing count proves drops are happening but maybe to
+        /// the wrong table.
+        /// </summary>
+        internal static int ExternalDropInvocations;
+
+        /// <summary>
         /// Wrap an <see cref="IBackendContext.Compute"/> call with
         /// memory + timing snapshot logging when
         /// <see cref="Enabled"/> is true. Snapshot points: RSS,
@@ -119,10 +132,12 @@ namespace Wacs.WASI.NN
             // human-readable form except input/output (small,
             // exact byte counts are more useful for correlating
             // against guest prompt sizes).
+            int extDrops = ExternalDropInvocations;
             var line = string.Format(
                 CultureInfo.InvariantCulture,
-                "[wacs-diag-memory] turn={0} rss={1} (+{2}) managed={3} (+{4}) "
-                + "gc[g0={5} g1={6} g2={7}] in={8}B out={9}B took={10:F2}s",
+                "[wacs-diag-memory] turn={0} rss={1} ({2}) managed={3} ({4}) "
+                + "gc[g0={5} g1={6} g2={7}] in={8}B out={9}B "
+                + "ext-drops={10} took={11:F2}s",
                 turn,
                 FormatBytes(rss),
                 FormatBytesDelta(rssDelta),
@@ -130,6 +145,7 @@ namespace Wacs.WASI.NN
                 FormatBytesDelta(managedDelta),
                 gen0, gen1, gen2,
                 inBytes, outBytes,
+                extDrops,
                 durationSec);
 
             try { Console.Error.WriteLine(line); }

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/MemoryDiagnostics.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/MemoryDiagnostics.cs
@@ -51,15 +51,21 @@ namespace Wacs.WASI.NN
         private static long _baselineManaged = -1;
 
         /// <summary>
-        /// Counter incremented by the wasi-nn binding's
-        /// <c>[resource-drop]X</c> handler whenever the cross-table
+        /// Counter incremented every time a wasi-nn
+        /// <c>[resource-drop]X</c> interpreter binding fires
+        /// (regardless of whether the cross-table hook is wired).
+        /// A stuck zero proves the binding itself isn't being
+        /// invoked — i.e., the wasm component's resource-drop
+        /// import is being satisfied through some other code
+        /// path that bypasses the runtime's entity-binding table.
+        /// </summary>
+        internal static int InterpreterDropInvocations;
+
+        /// <summary>
+        /// Counter incremented when the cross-table
         /// <see cref="Wacs.Core.Runtime.WasmRuntime.ExternalResourceDrop"/>
-        /// hook actually fires. Logged with each per-compute
-        /// snapshot so a stuck zero proves the hook isn't wired
-        /// (build doesn't include the v0.3.3 fix, or
-        /// <c>WasiPreview2RuntimeScope</c> wasn't invoked); a
-        /// growing count proves drops are happening but maybe to
-        /// the wrong table.
+        /// hook actually fires (a subset of the above — only counts
+        /// when the binding fires AND ExternalResourceDrop is wired).
         /// </summary>
         internal static int ExternalDropInvocations;
 
@@ -132,12 +138,13 @@ namespace Wacs.WASI.NN
             // human-readable form except input/output (small,
             // exact byte counts are more useful for correlating
             // against guest prompt sizes).
+            int interpDrops = InterpreterDropInvocations;
             int extDrops = ExternalDropInvocations;
             var line = string.Format(
                 CultureInfo.InvariantCulture,
                 "[wacs-diag-memory] turn={0} rss={1} ({2}) managed={3} ({4}) "
                 + "gc[g0={5} g1={6} g2={7}] in={8}B out={9}B "
-                + "ext-drops={10} took={11:F2}s",
+                + "drops[interp={10} ext={11}] took={12:F2}s",
                 turn,
                 FormatBytes(rss),
                 FormatBytesDelta(rssDelta),
@@ -145,7 +152,7 @@ namespace Wacs.WASI.NN
                 FormatBytesDelta(managedDelta),
                 gen0, gen1, gen2,
                 inBytes, outBytes,
-                extDrops,
+                interpDrops, extDrops,
                 durationSec);
 
             try { Console.Error.WriteLine(line); }

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN</AssemblyName>
-        <AssemblyVersion>0.3.2</AssemblyVersion>
-        <Version>0.3.2</Version>
+        <AssemblyVersion>0.3.3</AssemblyVersion>
+        <Version>0.3.3</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
@@ -77,6 +77,11 @@
         <InternalsVisibleTo Include="Wacs.WASI.NN.MLNet" />
         <InternalsVisibleTo Include="Wacs.WASI.NN.OnnxRuntime" />
         <InternalsVisibleTo Include="Wacs.WASI.NN.LlamaSharp" />
+        <!-- DependencyInjection's GraphExecutionContext wraps
+             IBackendContext.Compute for the transpiler / wasip2
+             direct-link path; it needs MemoryDiagnostics to emit
+             per-call snapshots from that path too. -->
+        <InternalsVisibleTo Include="Wacs.WASI.NN.DependencyInjection" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN</AssemblyName>
-        <AssemblyVersion>0.3.1</AssemblyVersion>
-        <Version>0.3.1</Version>
+        <AssemblyVersion>0.3.2</AssemblyVersion>
+        <Version>0.3.2</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
@@ -107,8 +107,12 @@ namespace Wacs.WASI.NN
                 (_, h) =>
                 {
                     host.Errors.Drop(h);
-                    runtime.ExternalResourceDrop?.Invoke(
-                        typeof(Nn.IError), h);
+                    if (runtime.ExternalResourceDrop != null)
+                    {
+                        runtime.ExternalResourceDrop(typeof(Nn.IError), h);
+                        System.Threading.Interlocked.Increment(
+                            ref MemoryDiagnostics.ExternalDropInvocations);
+                    }
                 });
         }
 
@@ -176,8 +180,12 @@ namespace Wacs.WASI.NN
                 (_, h) =>
                 {
                     host.Tensors.Drop(h);
-                    runtime.ExternalResourceDrop?.Invoke(
-                        typeof(Nn.ITensor), h);
+                    if (runtime.ExternalResourceDrop != null)
+                    {
+                        runtime.ExternalResourceDrop(typeof(Nn.ITensor), h);
+                        System.Threading.Interlocked.Increment(
+                            ref MemoryDiagnostics.ExternalDropInvocations);
+                    }
                 });
         }
 
@@ -267,8 +275,12 @@ namespace Wacs.WASI.NN
                 (_, h) =>
                 {
                     host.Graphs.Drop(h);
-                    runtime.ExternalResourceDrop?.Invoke(
-                        typeof(Nn.IGraph), h);
+                    if (runtime.ExternalResourceDrop != null)
+                    {
+                        runtime.ExternalResourceDrop(typeof(Nn.IGraph), h);
+                        System.Threading.Interlocked.Increment(
+                            ref MemoryDiagnostics.ExternalDropInvocations);
+                    }
                 });
         }
 
@@ -315,8 +327,13 @@ namespace Wacs.WASI.NN
                 (_, h) =>
                 {
                     host.Contexts.Drop(h);
-                    runtime.ExternalResourceDrop?.Invoke(
-                        typeof(Nn.IGraphExecutionContext), h);
+                    if (runtime.ExternalResourceDrop != null)
+                    {
+                        runtime.ExternalResourceDrop(
+                            typeof(Nn.IGraphExecutionContext), h);
+                        System.Threading.Interlocked.Increment(
+                            ref MemoryDiagnostics.ExternalDropInvocations);
+                    }
                 });
         }
 

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
@@ -272,7 +272,8 @@ namespace Wacs.WASI.NN
                                 ErrorCode.InvalidArgument,
                                 $"invalid execution-context handle {ctxHandle}");
                         var inputs = ReadNamedTensorList(ctx, host, inPtr, inLen);
-                        var outputs = bctx.Compute(inputs);
+                        var outputs = MemoryDiagnostics.RunWithDiagnostics(
+                            bctx, inputs);
                         WriteResultNamedTensorListOk(ctx, host, alloc, retArea, outputs);
                     }
                     catch (WasiNNException e)

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
@@ -97,9 +97,19 @@ namespace Wacs.WASI.NN
                 });
 
             // [resource-drop]error(self: own<error>)
+            // The transpiler-direct-link path allocates handles in
+            // WasiPreview2Resources.AllocateResource(typeof(IError),
+            // ...) rather than host.Errors — different table. Drop
+            // from both so whichever table holds the entry actually
+            // releases it. Off-table drops return false silently.
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (ErrorsNs, "[resource-drop]error"),
-                (_, h) => host.Errors.Drop(h));
+                (_, h) =>
+                {
+                    host.Errors.Drop(h);
+                    runtime.ExternalResourceDrop?.Invoke(
+                        typeof(Nn.IError), h);
+                });
         }
 
         // ----------------------------------------------------
@@ -156,10 +166,19 @@ namespace Wacs.WASI.NN
                     WriteU8List(ctx, alloc, retArea, t.Data.Span);
                 });
 
-            // [resource-drop]tensor(self)
+            // [resource-drop]tensor(self) — see [resource-drop]error
+            // comment above re: drop-from-both-tables rationale.
+            // For the SLM workflow this is the critical hook:
+            // logits tensors are ~26-230 MiB each, allocated on the
+            // direct-link path, and never freed without it.
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (TensorNs, "[resource-drop]tensor"),
-                (_, h) => host.Tensors.Drop(h));
+                (_, h) =>
+                {
+                    host.Tensors.Drop(h);
+                    runtime.ExternalResourceDrop?.Invoke(
+                        typeof(Nn.ITensor), h);
+                });
         }
 
         // ----------------------------------------------------
@@ -241,10 +260,16 @@ namespace Wacs.WASI.NN
                     }
                 });
 
-            // [resource-drop]graph(self)
+            // [resource-drop]graph(self) — see [resource-drop]error
+            // comment re: drop-from-both-tables rationale.
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (GraphNs, "[resource-drop]graph"),
-                (_, h) => host.Graphs.Drop(h));
+                (_, h) =>
+                {
+                    host.Graphs.Drop(h);
+                    runtime.ExternalResourceDrop?.Invoke(
+                        typeof(Nn.IGraph), h);
+                });
         }
 
         // ----------------------------------------------------
@@ -283,10 +308,16 @@ namespace Wacs.WASI.NN
                     }
                 });
 
-            // [resource-drop]graph-execution-context(self)
+            // [resource-drop]graph-execution-context(self) — see
+            // [resource-drop]error comment re: drop-from-both-tables.
             runtime.BindHostFunction<Action<ExecContext, int>>(
                 (InferenceNs, "[resource-drop]graph-execution-context"),
-                (_, h) => host.Contexts.Drop(h));
+                (_, h) =>
+                {
+                    host.Contexts.Drop(h);
+                    runtime.ExternalResourceDrop?.Invoke(
+                        typeof(Nn.IGraphExecutionContext), h);
+                });
         }
 
         // ====================================================

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitBindings.cs
@@ -106,6 +106,8 @@ namespace Wacs.WASI.NN
                 (ErrorsNs, "[resource-drop]error"),
                 (_, h) =>
                 {
+                    System.Threading.Interlocked.Increment(
+                        ref MemoryDiagnostics.InterpreterDropInvocations);
                     host.Errors.Drop(h);
                     if (runtime.ExternalResourceDrop != null)
                     {
@@ -179,6 +181,8 @@ namespace Wacs.WASI.NN
                 (TensorNs, "[resource-drop]tensor"),
                 (_, h) =>
                 {
+                    System.Threading.Interlocked.Increment(
+                        ref MemoryDiagnostics.InterpreterDropInvocations);
                     host.Tensors.Drop(h);
                     if (runtime.ExternalResourceDrop != null)
                     {
@@ -274,6 +278,8 @@ namespace Wacs.WASI.NN
                 (GraphNs, "[resource-drop]graph"),
                 (_, h) =>
                 {
+                    System.Threading.Interlocked.Increment(
+                        ref MemoryDiagnostics.InterpreterDropInvocations);
                     host.Graphs.Drop(h);
                     if (runtime.ExternalResourceDrop != null)
                     {
@@ -326,6 +332,8 @@ namespace Wacs.WASI.NN
                 (InferenceNs, "[resource-drop]graph-execution-context"),
                 (_, h) =>
                 {
+                    System.Threading.Interlocked.Increment(
+                        ref MemoryDiagnostics.InterpreterDropInvocations);
                     host.Contexts.Drop(h);
                     if (runtime.ExternalResourceDrop != null)
                     {

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitxBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitxBindings.cs
@@ -195,7 +195,8 @@ namespace Wacs.WASI.NN
                         var named = new List<NamedTensor>(state.Inputs.Count);
                         foreach (var kv in state.Inputs)
                             named.Add(new NamedTensor(kv.Key.ToString(), kv.Value));
-                        var outputs = state.Context.Compute(named);
+                        var outputs = MemoryDiagnostics.RunWithDiagnostics(
+                            state.Context, named);
                         state.Outputs.Clear();
                         for (int i = 0; i < outputs.Count; i++)
                         {

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.1.6</AssemblyVersion>
-        <Version>0.1.6</Version>
+        <AssemblyVersion>0.1.7</AssemblyVersion>
+        <Version>0.1.7</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2Resources.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2Resources.cs
@@ -78,5 +78,30 @@ namespace Wacs.WASI.Preview2.DependencyInjection
             var table = _context.TableFor(resourceInterface);
             return table.Allocate(instance);
         }
+
+        /// <summary>
+        /// Release a handle previously returned by
+        /// <see cref="AllocateResource"/>. Disposes the held
+        /// instance if it implements <see cref="IDisposable"/>.
+        /// Returns true when the handle was registered. Idempotent
+        /// — re-dropping returns false rather than throwing,
+        /// matching the canonical-ABI semantics.
+        ///
+        /// <para>Cross-package wiring: the wasi-nn DI scope
+        /// hooks this into <c>WasiNNHost.ExternalResourceDrop</c>
+        /// so the interpreter's <c>[resource-drop]X</c> binding
+        /// can release entries the direct-link path put here.
+        /// Without that bridge, host-imported resources allocated
+        /// during a transpiler-direct-link compute pile up in the
+        /// table forever — for the SLM workflow that's GBs of
+        /// per-token logits tensors.</para>
+        /// </summary>
+        public bool FreeResource(Type resourceInterface, int handle)
+        {
+            if (resourceInterface == null)
+                throw new ArgumentNullException(nameof(resourceInterface));
+            var table = _context.TableFor(resourceInterface);
+            return table.Drop(handle);
+        }
     }
 }

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
@@ -168,6 +168,22 @@ namespace Wacs.WASI.Preview2.DependencyInjection
 
             Resources = sp.GetRequiredService<WasiPreview2Resources>();
             Bundle = ResolveBundle(sp);
+
+            // Wire the cross-binding resource-drop hook so the
+            // interpreter's [resource-drop]X handlers (registered
+            // earlier when IBindable BindToRuntime calls fired)
+            // also release handles allocated through the
+            // direct-link path's WasiPreview2Resources table. The
+            // SLM workflow allocates ~26-230 MiB logits tensors
+            // per token through the direct-link compute call; the
+            // interpreter binding's host.Tensors.Drop is a no-op
+            // for those handles, so without this hook every token
+            // leaks its logits tensor for the lifetime of the
+            // component instance. Setter is idempotent — repeat
+            // scope construction (typically one per component
+            // instance) just rewires to the latest Resources.
+            Runtime.ExternalResourceDrop =
+                (t, h) => Resources.FreeResource(t, h);
         }
 
         private static object ResolveBundle(IServiceProvider sp)


### PR DESCRIPTION
## Summary

User-reported regression: the wasi-nn SLM REPL grew the host process to ~40 GiB before crashing with `mutex lock failed`. This PR carries the full diagnosis arc plus the fix.

## What was actually leaking

Each `ctx.compute()` returned host-imported tensor handles (`own<tensor>`). The transpiler lowered them into resource-table entries holding ~26-230 MiB FP32 logits buffers per token (autoregressive, no KV cache). When the guest dropped the handles at end-of-turn, the host should have released them — but they piled up forever.

## Two-stage diagnosis

**Stage 1 — cross-table mismatch hypothesis.** Initial theory: the interpreter binding `[resource-drop]tensor` drops from `WasiNNHost.Tensors`, but the transpiler direct-link path allocates into `ResourceContext.TableFor(typeof(ITensor))`. Wired a cross-binding hook (`WasmRuntime.ExternalResourceDrop` → `WasiPreview2Resources.FreeResource`) so the interpreter handler dropped from both tables. **Result: leak rate roughly unchanged.** The hook was right; the binding it bridged from was the wrong layer.

**Stage 2 — the binding was never invoked.** Added split counters (`drops[interp=X ext=Y]`) to the `WACS_DIAG_MEMORY` output. Result: `interp=0` across 130 turns. The WitBindings `[resource-drop]X` delegate **never fires** under `--engine transpiler`. Traced into the transpiler:

```csharp
// ComponentMainHost.cs (before this PR):
var importsStub = ImportDispatcher.Create(importsType,
    new Dictionary<string, Func<object?[], object?>>(),  // EMPTY
    lenient: true);                                       // silent no-op
```

Every `[resource-drop]X` call from the guest hit an empty handler dictionary, fell through `lenient: true`, and returned `default(void)` without touching the host. The runtime's entity-binding table — where WitBindings registered the drop handlers — was bypassed entirely.

## The fix

`ComponentMainHost` now walks the imports interface's `[WacsImportNames]` assembly metadata and auto-registers a handler for every `[resource-drop]X` import:

1. For each entry whose name starts with `[resource-drop]`, split the module name into `(package, interface)` and the entity name into the bare resource name.
2. Resolve the CLR resource interface type by scanning loaded assemblies for one whose `[WitSource]` attribute matches `(Package, Interface, Item)`.
3. Register a handler that calls `WasiPreview2Resources.FreeResource(typeof(IX), handle)` on the dropped handle.

Generic across **all** host-imported resources — wasi-nn (tensor, graph, context, error), wasi:io/streams, wasi:filesystem/types, wasi:io/poll, and anything else the transpiler emits a stub for.

The stage-1 cross-table hook stays as defense-in-depth for the rare case where an `IBindable` other than the transpiler direct-link path allocates into one table and routes drops through another.

## What the SLM REPL looks like now

| | Before fix (turn 130) | After fix (turn 193) |
|---|---|---|
| Managed heap | **27.07 GiB** (+24.83 GiB from turn 1) | **1.03 GiB** (−1.21 GiB) |
| RSS | 6.60 GiB | 6.57 GiB |
| Gen2 collections | 12 (stalled — heap was rooted) | 164 (healthy) |
| Outcome | crashed @ `mutex lock failed` | still running |

Managed heap is now smaller than turn-1 baseline because Gen2 finally reclaims the LOH allocations.

## What also landed in this PR

- **`WACS_DIAG_MEMORY=1` instrumentation** — per-compute stderr snapshot (`rss`, `managed`, `gc[g0/g1/g2]`, `in`/`out` bytes, `drops[interp,ext]`, duration). The diagnostic surface that found this. Hooks both interpreter and direct-link compute paths. Off by default, zero overhead in the negative path.
- **Stage-1 cross-table hook** — `WasmRuntime.ExternalResourceDrop` + `WasiPreview2Resources.FreeResource` + WitBindings `[resource-drop]X` handlers wired through both tables.

## Versions

- `WACS.Cli` 1.5.22 → **1.5.23**
- `WACS.Transpiler.Lib` 0.8.14 → **0.8.15** (`ComponentMainHost` auto-registers `[resource-drop]X` handlers — the actual fix)
- `WACS` (Wacs.Core) 0.13.7 → **0.13.8** (`WasmRuntime.ExternalResourceDrop` cross-binding hook)
- `WACS.WASI.NN` 0.3.2 → **0.3.3** (WitBindings drop handlers call the cross-binding hook + `WACS_DIAG_MEMORY` instrumentation)
- `WACS.WASI.Preview2.DependencyInjection` 0.1.6 → **0.1.7** (`WasiPreview2Resources.FreeResource` + scope wires the hook)

## Test plan

- [x] `Wacs.WASI.NN.Test` 21/21
- [x] `Wacs.WASI.NN.OnnxRuntime.Test` 10/10
- [x] `Wacs.WASI.Preview2.Test` 189/189
- [x] `Wacs.Transpiler.Test` 775/776 (1 pre-existing skip)
- [x] **Empirical**: user ran the SLM REPL for 193 turns clean; managed heap plateaued near 1 GiB instead of climbing past 27 GiB

🤖 Generated with [Claude Code](https://claude.com/claude-code)