### PR TITLE
Gap 31: BuildOnnxGenAIConfigureCallback auto-wires the GenAI backend via --bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## WACS.Cli 1.5.24 / WACS.WASI.NN.OnnxRuntimeGenAI 0.1.1 / WACS.WASI.Preview2.DependencyInjection 0.1.8 — gap 31: `BuildOnnxGenAIConfigureCallback` auto-wires the GenAI backend via `--bind`
+
+`wasi-nn/WACS-GAPS.md` gap 31: the new `OnnxRuntimeGenAI` backend's
+`IBindable` was wiring its backend into a per-host
+`WasiNNConfiguration.LoadByNameBackend`, but the DI bundle's shared
+`WasiNNConfiguration` — the one `GraphFuncsImpl.LoadByName` consults
+under `--engine transpiler --wasip2` — stayed null because
+`WasiPreview2RuntimeScope.ReflectivelyAddWasiNN` had no auto-wire
+callback for GenAI. Same shape as gap 20 (LlamaSharp's registry-split,
+closed at round 14) and its TorchSharp sibling.
+
+Symptom from `run-llm.sh -v`:
+
+```
+loading model 'gemma-3-270m-it-genai' via wasi-nn graph.load-by-name…
+Error: "wasi-nn ErrorCode::NotFound: no named-model resolver
+       configured and no LoadByNameBackend wired"
+```
+
+### Fix
+
+- **`OnnxGenAIBackend.FromDirectories(IDictionary<string, string>)`**
+  (new static factory) — mirror of `TorchSharpBackend.FromPaths`. Takes
+  a name→directory map and constructs a backend with a lookup
+  resolver. Lets the scope's reflective auto-wire emit Linq.Expression
+  IL without threading a `Func<string, string?>` delegate type across
+  the assembly boundary.
+- **`WasiPreview2RuntimeScope.BuildOnnxGenAIConfigureCallback`** —
+  mirror of `BuildTorchSharpConfigureCallback`. Detects
+  `Wacs.WASI.NN.OnnxRuntimeGenAI.OnnxGenAIBackend`, builds an
+  env-driven registry from `$WACS_WASINN_GENAI_DIR` (subdirectory
+  scan for `genai_config.json`, matching `WasiNNOnnxGenAIBindable`'s
+  shape), and wires the backend into `LoadByNameBackend` ONLY —
+  leaves `Backends[ONNX]` for the regular `OnnxBackend` so
+  `graph.load(bytes)` keeps its byte-tensor I/O path and
+  `graph.load-by-name(<dir>)` routes to GenAI's KV-cached decode loop.
+- Plumbed into the existing `CombineCallbacks` chain alongside the
+  ONNX / LlamaSharp / TorchSharp callbacks.
+
+### Co-existence with the regular OnnxBackend
+
+Both backends register for `GraphEncoding.ONNX`. The GenAI backend
+claims `LoadByNameBackend` only, leaving `Backends[ONNX]` for the raw
+`OnnxBackend`. With both loaded:
+
+- `graph.load(bytes, ONNX)` → `OnnxBackend` (byte-loaded single-shot
+  tensor I/O)
+- `graph.load-by-name("model-dir")` → `OnnxGenAIBackend` (KV-cached
+  generative decoding)
+
+### Versions
+
+- `WACS.Cli` 1.5.23 → **1.5.24** (release event)
+- `WACS.WASI.NN.OnnxRuntimeGenAI` 0.1.0 → **0.1.1** (new
+  `FromDirectories` factory)
+- `WACS.WASI.Preview2.DependencyInjection` 0.1.7 → **0.1.8** (new
+  auto-wire callback)
+
+### Test plan
+
+- `Wacs.WASI.NN.OnnxRuntimeGenAI.Test` 8/8
+- `Wacs.WASI.Preview2.Test` 189/189
+- **Empirical** (user verification):
+  `BACKEND_DLL=Wacs.WASI.NN.OnnxRuntimeGenAI.dll
+  MODEL_NAME=gemma-3-270m-it-genai scripts/run-llm.sh` should resolve
+  the model directory and route through `GraphFuncsImpl.LoadByName` →
+  `OnnxGenAIBackend.LoadGraphByName` instead of returning NotFound.
+
 ## WACS.Cli 1.5.23 / WACS.Transpiler.Lib 0.8.15 / WACS 0.13.8 / WACS.WASI.NN 0.3.3 / WACS.WASI.Preview2.DependencyInjection 0.1.7 — fix unbounded leak: `[resource-drop]X` was a silent no-op under `--engine transpiler`
 
 User-reported regression: the wasi-nn SLM REPL grew the host process to

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.23</Version>
-    <AssemblyVersion>1.5.23</AssemblyVersion>
+    <Version>1.5.24</Version>
+    <AssemblyVersion>1.5.24</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIBackend.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIBackend.cs
@@ -100,6 +100,28 @@ namespace Wacs.WASI.NN.OnnxRuntimeGenAI
         }
 
         /// <summary>
+        /// Static factory matching the
+        /// <c>WasiPreview2RuntimeScope</c> auto-wire shape
+        /// (mirror of <c>TorchSharpBackend.FromPaths</c>):
+        /// take a name→directory map, build a resolver that looks
+        /// up by name. Lets the DI scope's reflective auto-wire
+        /// construct the backend without needing to thread a
+        /// <see cref="Func{T,TResult}"/> through Linq.Expressions
+        /// IL emission.
+        /// </summary>
+        public static OnnxGenAIBackend FromDirectories(
+            IDictionary<string, string> nameToDirectory)
+        {
+            if (nameToDirectory == null)
+                throw new ArgumentNullException(nameof(nameToDirectory));
+            var registry = new Dictionary<string, string>(
+                nameToDirectory, StringComparer.OrdinalIgnoreCase);
+            return new OnnxGenAIBackend(
+                name => registry.TryGetValue(name, out var dir)
+                    ? dir : null);
+        }
+
+        /// <summary>
         /// Exposes <see cref="GraphEncoding.ONNX"/> since the
         /// underlying model is in ONNX format (just packaged with
         /// GenAI's directory layout). The bindable wires this

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OnnxRuntimeGenAI</AssemblyName>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <Version>0.1.0</Version>
+        <AssemblyVersion>0.1.1</AssemblyVersion>
+        <Version>0.1.1</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;onnx;genai;llm;gemma;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.1.7</AssemblyVersion>
-        <Version>0.1.7</Version>
+        <AssemblyVersion>0.1.8</AssemblyVersion>
+        <Version>0.1.8</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
@@ -245,8 +245,9 @@ namespace Wacs.WASI.Preview2.DependencyInjection
             var onnxCallback = BuildOnnxConfigureCallback(nnAsm!);
             var llamaCallback = BuildLlamaSharpConfigureCallback(nnAsm!);
             var torchCallback = BuildTorchSharpConfigureCallback(nnAsm!);
+            var genaiCallback = BuildOnnxGenAIConfigureCallback(nnAsm!);
             var configureDelegate = CombineCallbacks(
-                onnxCallback, llamaCallback, torchCallback);
+                onnxCallback, llamaCallback, torchCallback, genaiCallback);
 
             // services.AddWasiNN(configure) — configure runs
             // BEFORE TryAddSingleton(opts.Configuration), so each
@@ -612,6 +613,145 @@ namespace Wacs.WASI.Preview2.DependencyInjection
             var actionType = typeof(Action<>).MakeGenericType(optsType);
             return Expression.Lambda(actionType, block, optsParam)
                 .Compile();
+        }
+
+        // Sibling of BuildLlamaSharpConfigureCallback /
+        // BuildTorchSharpConfigureCallback for the
+        // OnnxRuntime-GenAI backend (generative LLMs in GenAI
+        // directory format: genai_config.json + tokenizer.json +
+        // model.onnx + weights). Detects
+        // `Wacs.WASI.NN.OnnxRuntimeGenAI.OnnxGenAIBackend`, builds
+        // an env-driven registry from $WACS_WASINN_GENAI_DIR
+        // (mirroring WasiNNOnnxGenAIBindable's subdirectory scan
+        // for genai_config.json), and wires the backend into
+        // `LoadByNameBackend` ONLY — leaves `Backends[ONNX]` to
+        // the regular OnnxBackend so `graph.load(bytes)` and
+        // `graph.load-by-name(directory)` route to the right
+        // place when both packages are present.
+        //
+        // Returns null when:
+        //   - Wacs.WASI.NN.OnnxRuntimeGenAI isn't loadable (the
+        //     common `wacs run --wasip2 --wasi-nn` case);
+        //   - OnnxGenAIBackend / FromDirectories factory /
+        //     LoadByNameBackend property can't be resolved;
+        //   - FromDirectories throws.
+        // Closes gap 31 (wasi-nn/WACS-GAPS.md).
+        private static Delegate? BuildOnnxGenAIConfigureCallback(
+            Assembly nnAsm)
+        {
+            var optsType = nnAsm.GetType(
+                "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
+            if (optsType == null) return null;
+
+            var addBackend = optsType.GetMethod("AddBackend");
+            if (addBackend == null) return null;
+            var addBackendParams = addBackend.GetParameters();
+            if (addBackendParams.Length != 2) return null;
+            var backendIfaceType = addBackendParams[1].ParameterType;
+
+            var genaiAsm = TryLoadAssembly(
+                "Wacs.WASI.NN.OnnxRuntimeGenAI");
+            if (genaiAsm == null) return null;  // not an error.
+
+            var genaiBackendType = genaiAsm.GetType(
+                "Wacs.WASI.NN.OnnxRuntimeGenAI.OnnxGenAIBackend");
+            if (genaiBackendType == null)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: Wacs.WASI.NN.OnnxRuntimeGenAI is loadable "
+                    + "but OnnxGenAIBackend type wasn't found. "
+                    + "wasi-nn GenAI guests will see NotFound errors.");
+                return null;
+            }
+
+            var fromDirs = genaiBackendType.GetMethod(
+                "FromDirectories",
+                BindingFlags.Public | BindingFlags.Static);
+            if (fromDirs == null)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: OnnxGenAIBackend.FromDirectories(IDictionary"
+                    + "<string,string>) static factory not found. "
+                    + "Cannot auto-wire OnnxRuntimeGenAI; embedders "
+                    + "should construct OnnxGenAIBackend directly "
+                    + "via AddWasiNN(b => b.AddBackend(...)).");
+                return null;
+            }
+
+            var registry = BuildGenAIRegistryFromEnv();
+
+            object? genaiBackend;
+            try { genaiBackend = fromDirs.Invoke(null, new object?[] { registry }); }
+            catch (Exception ex)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: OnnxGenAIBackend.FromDirectories failed: "
+                    + ex.GetType().Name + ": " + ex.Message
+                    + ". wasi-nn GenAI guests will see NotFound "
+                    + "errors. Check that the Microsoft.ML.OnnxRuntimeGenAI "
+                    + "native library is on the load path.");
+                return null;
+            }
+            if (genaiBackend == null) return null;
+
+            var configProp = optsType.GetProperty("Configuration");
+            if (configProp == null) return null;
+            var configType = configProp.PropertyType;
+            var loadByNameProp = configType.GetProperty("LoadByNameBackend");
+            if (loadByNameProp == null
+                || loadByNameProp.GetSetMethod() == null)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: WasiNNConfiguration.LoadByNameBackend "
+                    + "property missing or read-only; cannot route "
+                    + "GenAI graph.load-by-name through OnnxGenAIBackend.");
+                return null;
+            }
+
+            // GenAI backend takes the LoadByNameBackend slot only —
+            // leaves Backends[ONNX] for the regular OnnxBackend so
+            // `graph.load(bytes)` keeps its byte-tensor I/O path
+            // while `graph.load-by-name(<dir>)` routes to GenAI's
+            // KV-cached decode loop.
+            var optsParam = Expression.Parameter(optsType, "opts");
+            var configAccess = Expression.Property(optsParam, configProp);
+            var assign = Expression.Assign(
+                Expression.Property(configAccess, loadByNameProp),
+                Expression.Constant(genaiBackend,
+                    loadByNameProp.PropertyType));
+            var actionType = typeof(Action<>).MakeGenericType(optsType);
+            return Expression.Lambda(actionType, assign, optsParam)
+                .Compile();
+        }
+
+        // Mirrors WasiNNOnnxGenAIBindable's env-driven scan:
+        // read $WACS_WASINN_GENAI_DIR, enumerate first-level
+        // subdirectories containing `genai_config.json`, register
+        // each under its directory name. Fail-soft on IO error.
+        private static IDictionary<string, string>
+            BuildGenAIRegistryFromEnv()
+        {
+            var dir = Environment.GetEnvironmentVariable(
+                "WACS_WASINN_GENAI_DIR");
+            var registry = new Dictionary<string, string>(
+                StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(dir)) return registry;
+            try
+            {
+                if (!Directory.Exists(dir)) return registry;
+                foreach (var modelDir in Directory.EnumerateDirectories(dir))
+                {
+                    var configPath = Path.Combine(
+                        modelDir, "genai_config.json");
+                    if (!File.Exists(configPath)) continue;
+                    var name = Path.GetFileName(modelDir);
+                    if (!string.IsNullOrEmpty(name))
+                        registry[name!] = modelDir;
+                }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+            return registry;
         }
 
         // Mirrors WasiNNTorchSharpBindable's env-driven scan:


### PR DESCRIPTION
## Summary

`wasi-nn/WACS-GAPS.md` gap 31: the new `OnnxRuntimeGenAI` backend's `IBindable` was wiring its backend into a per-host `WasiNNConfiguration.LoadByNameBackend`, but the DI bundle's shared `WasiNNConfiguration` — the one `GraphFuncsImpl.LoadByName` consults under `--engine transpiler --wasip2` — stayed null because `WasiPreview2RuntimeScope.ReflectivelyAddWasiNN` had no auto-wire callback for GenAI. Same shape as gap 20 (LlamaSharp's registry-split, closed at round 14) and its TorchSharp sibling.

**Base:** `revert-gap-31-direct-push` (PR #136) — once that merges to main, this PR rebases onto main and stacks cleanly.

User-facing symptom from `run-llm.sh -v`:

```
loading model 'gemma-3-270m-it-genai' via wasi-nn graph.load-by-name…
Error: "wasi-nn ErrorCode::NotFound: no named-model resolver
       configured and no LoadByNameBackend wired"
```

## Fix

- **`OnnxGenAIBackend.FromDirectories(IDictionary<string, string>)`** (new static factory) — mirror of `TorchSharpBackend.FromPaths`. Takes a name→directory map and constructs the backend with a lookup resolver. Lets the scope's reflective auto-wire emit Linq.Expression IL without threading a `Func<string, string?>` delegate type across the assembly boundary.
- **`WasiPreview2RuntimeScope.BuildOnnxGenAIConfigureCallback`** — mirror of `BuildTorchSharpConfigureCallback`. Detects `Wacs.WASI.NN.OnnxRuntimeGenAI.OnnxGenAIBackend`, builds an env-driven registry from `$WACS_WASINN_GENAI_DIR` (subdirectory scan for `genai_config.json`, matching `WasiNNOnnxGenAIBindable`'s shape), and wires the backend into `LoadByNameBackend` ONLY — leaves `Backends[ONNX]` for the regular `OnnxBackend` so `graph.load(bytes)` keeps its byte-tensor I/O path and `graph.load-by-name(<dir>)` routes to GenAI's KV-cached decode loop.
- Plumbed into the existing `CombineCallbacks` chain alongside the ONNX / LlamaSharp / TorchSharp callbacks.

## Co-existence with the regular OnnxBackend

Both backends register for `GraphEncoding.ONNX`. The GenAI backend claims `LoadByNameBackend` only:

- `graph.load(bytes, ONNX)` → `OnnxBackend` (byte-loaded single-shot tensor I/O)
- `graph.load-by-name("model-dir")` → `OnnxGenAIBackend` (KV-cached generative decoding)

## Versions

- `WACS.Cli` 1.5.23 → **1.5.24** (release event)
- `WACS.WASI.NN.OnnxRuntimeGenAI` 0.1.0 → **0.1.1** (new `FromDirectories` factory)
- `WACS.WASI.Preview2.DependencyInjection` 0.1.7 → **0.1.8** (new auto-wire callback)

## Test plan

- [x] `Wacs.WASI.NN.OnnxRuntimeGenAI.Test` 8/8
- [x] `Wacs.WASI.Preview2.Test` 189/189
- [x] Release build clean
- [ ] **Empirical** (user verification after merge): `BACKEND_DLL=Wacs.WASI.NN.OnnxRuntimeGenAI.dll MODEL_NAME=gemma-3-270m-it-genai scripts/run-llm.sh` should resolve the model directory and route through `GraphFuncsImpl.LoadByName` → `OnnxGenAIBackend.LoadGraphByName` instead of returning NotFound

🤖 Generated with [Claude Code](https://claude.com/claude-code)