### PR TITLE
GenAI gaps 32 + 33: provider clear + chat template — first verified end-to-end run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## WACS.Cli 1.5.25 / WACS.WASI.NN.OnnxRuntimeGenAI 0.1.2 — first end-to-end verified GenAI run
+
+The first empirical end-to-end pass through `WACS.WASI.NN.OnnxRuntimeGenAI`
+on osx-arm64 against `gemma-3-270m-it-genai` surfaced two real gaps. Both
+closed; the model now generates coherent output through the documented
+`--bind` invocation.
+
+```
+$ echo -e "What is 2+2?\n/bye" | scripts/run-llm.sh
+>>> 2 + 2 = 4
+```
+
+### Gap 32 — `genai_config.json` declares an unsupported provider
+
+`Model(dir)` rejects model directories whose `genai_config.json` lists
+provider names not compiled into the platform's GenAI dylib. Pre-built
+HuggingFace exports often declare `nnapi` (Android NNAPI) by default —
+on macOS this trips:
+
+```
+Unknown provider name 'nnapi'. Currently supported values are
+'DML' / 'QNN' / 'OpenVINO' / 'SNPE' / 'XNNPACK' / 'WEBNN' / 'WebGPU'
+/ 'AZURE' / 'JS' / 'VitisAI' / 'CoreML' / 'NvTensorRtRtx' / 'MIGraphX'.
+```
+
+**Fix:** `OnnxGenAIBackend.LoadGraphByName` now loads via
+`Config(dir)` → `ClearProviders()` → `Model(config)` (instead of the
+direct `Model(dir)` ctor). The model-declared provider list is stripped
+and GenAI falls back to its platform default — CPU on macOS, matching
+the regular `OnnxBackend`'s opt-in posture for hardware acceleration.
+The `Config` is held for the `OnnxGenAIGraph`'s lifetime (some 0.x
+GenAI builds share native state between `Model` and its source
+`Config`). Embedders that want CoreML / CUDA / DirectML opt in
+explicitly via a future `OnnxGenAIBackendOptions` provider knob.
+
+### Gap 33 — instruction-tuned models need their chat template
+
+`OnnxGenAIContext.GenerateFromPrompt` was passing the raw UTF-8 prompt
+straight into `Tokenizer.Encode`. For instruction-tuned models
+(Gemma 3 IT, Llama 3 Instruct, Qwen 2.5 Instruct, Phi-4 Mini Instruct,
+…) the prompt needs to be wrapped in the model's turn markers
+(`<start_of_turn>user\n...<end_of_turn>\n<start_of_turn>model\n` for
+Gemma) for the decode loop to produce coherent text. Without it,
+gemma-3-270m-it generated ~500 tokens of `2?2?2?2? just once? essen??…`
+gibberish.
+
+**Fix:** `GenerateFromPrompt` now calls
+`Tokenizer.ApplyChatTemplate(null, messages, null, add_generation_prompt: true)`
+before `Tokenizer.Encode`. Passing `null` for the template string makes
+GenAI consume the model's bundled `chat_template.jinja`. `messages` is
+a JSON array of `{role, content}` records built via
+`System.Text.Json.JsonSerializer.Serialize` (an earlier attempt with
+`JsonEncodedText.Encode` produced unquoted content fields → invalid
+JSON → silent fallback to raw prompt → gibberish; documented inline so
+the regression doesn't recur). Falls back to the raw prompt only if
+`ApplyChatTemplate` throws — base (non-instruct) models work fine
+without a template and we don't want to break them.
+
+### Versions
+
+- `WACS.Cli` 1.5.24 → **1.5.25** (release event)
+- `WACS.WASI.NN.OnnxRuntimeGenAI` 0.1.1 → **0.1.2** (gap 32 +
+  gap 33 fixes)
+
+### Verified
+
+- Direct probe through `Microsoft.ML.OnnxRuntimeGenAI` (no WACS layer)
+  confirms `Config(dir).ClearProviders()` + `ApplyChatTemplate(null, …)`
+  is the right sequence; replicated in `OnnxGenAIBackend.LoadGraphByName`
+  and `OnnxGenAIContext.GenerateFromPrompt`.
+- `wacs run --wasip2 --bind Wacs.WASI.NN.OnnxRuntimeGenAI.dll` end-to-end
+  against `gemma-3-270m-it-genai`:
+  - `What is 2+2?` → `2 + 2 = 4`
+  - `What is the capital of France?` → `The capital of France is Paris.`
+  - `Write a haiku about WebAssembly.` → coherent multi-stanza output
+    (small model loops near `max_length` with greedy decoding, expected)
+- `Wacs.WASI.NN.OnnxRuntimeGenAI.Test` 8/8
+
 ## WACS.Cli 1.5.24 / WACS.WASI.NN.OnnxRuntimeGenAI 0.1.1 / WACS.WASI.Preview2.DependencyInjection 0.1.8 — gap 31: `BuildOnnxGenAIConfigureCallback` auto-wires the GenAI backend via `--bind`
 
 `wasi-nn/WACS-GAPS.md` gap 31: the new `OnnxRuntimeGenAI` backend's

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.5.24</Version>
-    <AssemblyVersion>1.5.24</AssemblyVersion>
+    <Version>1.5.25</Version>
+    <AssemblyVersion>1.5.25</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIBackend.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIBackend.cs
@@ -177,18 +177,42 @@ namespace Wacs.WASI.NN.OnnxRuntimeGenAI
                     + "model_builder.py script or fetch a pre-built "
                     + "ONNX directory from Hugging Face.");
 
+            GenAI.Config? config = null;
             GenAI.Model? model = null;
             GenAI.Tokenizer? tokenizer = null;
             try
             {
-                model = new GenAI.Model(dir);
+                // Load through Config so we can override the
+                // execution-provider list. Pre-built HuggingFace
+                // models often declare provider preferences (e.g.,
+                // `nnapi` on Android-targeted exports) that aren't
+                // compiled into every platform's GenAI native lib;
+                // GenAI's Model(dir) ctor rejects the load with
+                // "Unknown provider name '<X>'" when an unsupported
+                // provider is hard-coded in genai_config.json.
+                // ClearProviders strips the model-declared list so
+                // GenAI picks the platform default — CPU on macOS,
+                // matching the OnnxBackend's opt-in posture for
+                // hardware acceleration. Embedders that want CoreML
+                // / CUDA / DirectML opt in explicitly through
+                // OnnxGenAIBackendOptions (follow-up).
+                config = new GenAI.Config(dir);
+                config.ClearProviders();
+                model = new GenAI.Model(config);
                 tokenizer = new GenAI.Tokenizer(model);
-                return new OnnxGenAIGraph(model, tokenizer, _options);
+                // Config is owned by the Model after construction;
+                // dispose-on-success would yank state from under the
+                // generation loop. Keep it alive for the graph's
+                // lifetime by transferring ownership.
+                var owned = config;
+                config = null;
+                return new OnnxGenAIGraph(model, tokenizer, _options, owned);
             }
             catch (Exception ex)
             {
                 tokenizer?.Dispose();
                 model?.Dispose();
+                config?.Dispose();
                 throw new WasiNNException(
                     ErrorCode.RuntimeError,
                     $"OnnxGenAIBackend: failed to load model "

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIContext.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIContext.cs
@@ -83,10 +83,59 @@ namespace Wacs.WASI.NN.OnnxRuntimeGenAI
             string prompt = Encoding.UTF8.GetString(
                 input.Tensor.Data.Span);
 
+            // Apply the model's chat template before tokenizing.
+            // Instruction-tuned chat models (Gemma 3 IT, Llama 3
+            // Instruct, Qwen Instruct, Phi-4 Mini Instruct, …)
+            // need the prompt wrapped in their turn markers
+            // (e.g., `<start_of_turn>user\n...<end_of_turn>\n<start_of_turn>model\n`)
+            // for the decode loop to produce coherent output. Raw
+            // text input produces gibberish.
+            //
+            // GenAI's Tokenizer.ApplyChatTemplate(template, messages,
+            // tools, add_generation_prompt) consumes the model's
+            // chat_template.jinja when the first arg is null and the
+            // model directory has one. Messages is a JSON array of
+            // {role, content}; we send a single user turn here.
+            // add_generation_prompt=true appends the assistant-turn
+            // opener so the model continues into a reply rather
+            // than starting a fresh user turn.
+            //
+            // If ApplyChatTemplate fails (model dir lacks a
+            // template, or the template uses Jinja features GenAI
+            // can't render), fall back to the raw prompt — base
+            // (non-instruct) models work fine without templating
+            // and we don't want to break them.
+            string templated;
+            try
+            {
+                // Build the messages JSON via JsonSerializer.Serialize
+                // so the prompt string is properly quoted and escaped
+                // (including embedded quotes / newlines / control
+                // chars). Earlier hand-built JSON via JsonEncodedText
+                // produced unquoted content fields, which silently
+                // failed ApplyChatTemplate inside GenAI and dropped
+                // us through the catch into the raw-prompt fallback —
+                // gemma-3 IT then generated several hundred tokens of
+                // ?-pattern gibberish because no chat template framed
+                // the user turn.
+                var messages = new[] { new { role = "user", content = prompt } };
+                var messagesJson = System.Text.Json.JsonSerializer
+                    .Serialize(messages);
+                templated = _graph.Tokenizer.ApplyChatTemplate(
+                    template_str: null!,
+                    messages: messagesJson,
+                    tools: null!,
+                    add_generation_prompt: true);
+            }
+            catch
+            {
+                templated = prompt;
+            }
+
             int[] promptTokens;
             try
             {
-                using var promptSeqs = _graph.Tokenizer.Encode(prompt);
+                using var promptSeqs = _graph.Tokenizer.Encode(templated);
                 // Tokenizer.Encode returns Sequences indexed by
                 // batch — we always send one prompt, so [0] is it.
                 promptTokens = promptSeqs[0].ToArray();

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIGraph.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/OnnxGenAIGraph.cs
@@ -25,18 +25,28 @@ namespace Wacs.WASI.NN.OnnxRuntimeGenAI
         internal GenAI.Tokenizer Tokenizer { get; }
         internal OnnxGenAIBackendOptions Options { get; }
 
+        // Config is held when the graph was loaded through the
+        // override-providers path (Config(dir) -> ClearProviders ->
+        // Model(config)). GenAI's Model copies the Config state at
+        // construction but the underlying native handle is shared
+        // with the Model in some 0.x builds; keep the Config alive
+        // for the Model's lifetime to be safe. Null when the graph
+        // was loaded via the simpler Model(dir) path.
+        private readonly GenAI.Config? _config;
         private bool _disposed;
 
         public OnnxGenAIGraph(
             GenAI.Model model,
             GenAI.Tokenizer tokenizer,
-            OnnxGenAIBackendOptions options)
+            OnnxGenAIBackendOptions options,
+            GenAI.Config? config = null)
         {
             Model = model ?? throw new ArgumentNullException(nameof(model));
             Tokenizer = tokenizer
                 ?? throw new ArgumentNullException(nameof(tokenizer));
             Options = options
                 ?? throw new ArgumentNullException(nameof(options));
+            _config = config;
         }
 
         public IBackendContext CreateContext()
@@ -52,6 +62,7 @@ namespace Wacs.WASI.NN.OnnxRuntimeGenAI
             _disposed = true;
             Tokenizer.Dispose();
             Model.Dispose();
+            _config?.Dispose();
         }
     }
 }

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OnnxRuntimeGenAI</AssemblyName>
-        <AssemblyVersion>0.1.1</AssemblyVersion>
-        <Version>0.1.1</Version>
+        <AssemblyVersion>0.1.2</AssemblyVersion>
+        <Version>0.1.2</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;onnx;genai;llm;gemma;wacs</PackageTags>


### PR DESCRIPTION
## Summary

First empirical end-to-end pass through `Wacs.WASI.NN.OnnxRuntimeGenAI` on osx-arm64 against `gemma-3-270m-it-genai` surfaced two real gaps. Both closed in this PR; the model now produces coherent output through the documented `--bind` invocation.

```
$ echo -e "What is 2+2?\n/bye" | scripts/run-llm.sh
>>> 2 + 2 = 4
```

## Gap 32 — `genai_config.json` declares unsupported provider

`Model(dir)` rejects HuggingFace exports whose `genai_config.json` hardcodes a provider name not compiled into the platform GenAI dylib. `gemma-3-270m-it-genai` declares `nnapi` (Android NNAPI):

```
Unknown provider name 'nnapi'. Currently supported values are
'DML' / 'QNN' / 'OpenVINO' / 'SNPE' / 'XNNPACK' / 'WEBNN' / 'WebGPU'
/ 'AZURE' / 'JS' / 'VitisAI' / 'CoreML' / 'NvTensorRtRtx' / 'MIGraphX'.
```

**Fix:** Load via `Config(dir)` → `ClearProviders()` → `Model(config)`. The model-declared provider list is stripped; GenAI falls back to its platform default (CPU on macOS). Embedders that want hardware acceleration opt in explicitly through `OnnxGenAIBackendOptions` (follow-up). `Config` is held for the `OnnxGenAIGraph`'s lifetime (some 0.x GenAI builds share native state between `Model` and its source `Config`).

## Gap 33 — instruction-tuned models need their chat template

`OnnxGenAIContext.GenerateFromPrompt` was passing the raw UTF-8 prompt straight into `Tokenizer.Encode`. Gemma-3-IT (and any other instruction-tuned model) needs the prompt wrapped in turn markers (`<start_of_turn>user\n...<end_of_turn>\n<start_of_turn>model\n` for Gemma) for the decode loop to produce coherent text. Without it, gemma-3-270m-it generated ~500 tokens of `2?2?2?2? just once? essen??...` gibberish.

**Fix:** `GenerateFromPrompt` now calls `Tokenizer.ApplyChatTemplate(null, messages, null, add_generation_prompt: true)` before `Tokenizer.Encode`. Passing `null` for the template string consumes the model's bundled `chat_template.jinja`. `messages` is a JSON array of `{role, content}` records built via `JsonSerializer.Serialize`. Falls back to the raw prompt only if `ApplyChatTemplate` throws (base / non-instruct models work without templating and we don't want to break them).

**Bonus regression-resistance:** an earlier attempt with `JsonEncodedText.Encode` produced unquoted content fields → invalid JSON → silent fallback to raw prompt → gibberish. The inline comment in `GenerateFromPrompt` documents that trap so the regression doesn't recur.

## Versions

- `WACS.Cli` 1.5.24 → **1.5.25** (release event)
- `WACS.WASI.NN.OnnxRuntimeGenAI` 0.1.1 → **0.1.2** (gap 32 + gap 33 fixes)

## Test plan

- [x] `Wacs.WASI.NN.OnnxRuntimeGenAI.Test` 8/8
- [x] Direct GenAI probe confirms `Config(dir).ClearProviders()` + `ApplyChatTemplate(null, ...)` is the right sequence; replicated in the host wrappers
- [x] `wacs run --wasip2 --bind Wacs.WASI.NN.OnnxRuntimeGenAI.dll` end-to-end against `gemma-3-270m-it-genai`:
  - `What is 2+2?` → `2 + 2 = 4`
  - `What is the capital of France?` → `The capital of France is Paris.`
  - `Write a haiku about WebAssembly.` → coherent multi-stanza output (small model loops near `max_length` with greedy decoding, expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)