### PR TITLE
WASI.NN family cascade-bump for the 0.3.4 WITX ABI fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## WACS.WASI.NN family — cascade bump to advertise the 0.3.4 WITX-ABI fix
+
+Repackages all six WASI.NN sibling backends so their `.nuspec` declares the
+fixed `WACS.WASI.NN >= 0.3.4` dependency floor. The previous release tag
+(`WACS-WASI-NN-v0.3.5` → `WACS.WASI.NN 0.3.4`) shipped the WITX-ABI fix on
+the top-level package but skip-dup'd every sibling, so each sibling's
+live manifest still advertised a pre-0.3.4 floor. Consumers were
+silently protected by NuGet's range-resolution picking the latest 0.3.4,
+but anyone pinning a sibling exactly would have stayed on the stale
+floor. Point-bumping each sibling makes the cascade explicit.
+
+| Sibling                            | Before | After |
+|------------------------------------|-------:|------:|
+| `WACS.WASI.NN.DependencyInjection` |  0.2.2 | 0.2.3 |
+| `WACS.WASI.NN.LlamaSharp`          |  0.2.2 | 0.2.3 |
+| `WACS.WASI.NN.MLNet`               |  0.2.2 | 0.2.3 |
+| `WACS.WASI.NN.OnnxRuntime`         |  0.3.0 | 0.3.1 |
+| `WACS.WASI.NN.OnnxRuntimeGenAI`    |  0.1.3 | 0.1.4 |
+| `WACS.WASI.NN.TorchSharp`          |  0.1.1 | 0.1.2 |
+
+No code changes — each sibling re-packs with the new
+`WACS.WASI.NN 0.3.4` `ProjectReference` already on `main` and inherits
+the WITX 0.6 ABI fix transparently. See the prior changelog entry for
+the actual `set_input` / `compute` signature change.
+
 ## WACS.WASI.NN 0.3.4 — align WITX `set_input` / `compute` with bytecodealliance wasi-nn 0.6 ABI
 
 The legacy `wasi_ephemeral_nn` core-module binding in `WitxBindings.cs`

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/Wacs.WASI.NN.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.DependencyInjection/Wacs.WASI.NN.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.2.2</AssemblyVersion>
-        <Version>0.2.2</Version>
+        <AssemblyVersion>0.2.3</AssemblyVersion>
+        <Version>0.2.3</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.LlamaSharp</AssemblyName>
-        <AssemblyVersion>0.2.2</AssemblyVersion>
-        <Version>0.2.2</Version>
+        <AssemblyVersion>0.2.3</AssemblyVersion>
+        <Version>0.2.3</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;llm;llama;gguf;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.MLNet</AssemblyName>
-        <AssemblyVersion>0.2.2</AssemblyVersion>
-        <Version>0.2.2</Version>
+        <AssemblyVersion>0.2.3</AssemblyVersion>
+        <Version>0.2.3</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;mlnet;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/Wacs.WASI.NN.OnnxRuntime.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/Wacs.WASI.NN.OnnxRuntime.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OnnxRuntime</AssemblyName>
-        <AssemblyVersion>0.3.0</AssemblyVersion>
-        <Version>0.3.0</Version>
+        <AssemblyVersion>0.3.1</AssemblyVersion>
+        <Version>0.3.1</Version>
         <RepositoryType>git</RepositoryType>
         <!-- ONNX Runtime carries native binaries; restricting to
              net8.0 here is fine because ORT itself targets

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OnnxRuntimeGenAI</AssemblyName>
-        <AssemblyVersion>0.1.3</AssemblyVersion>
-        <Version>0.1.3</Version>
+        <AssemblyVersion>0.1.4</AssemblyVersion>
+        <Version>0.1.4</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;onnx;genai;llm;gemma;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.TorchSharp/Wacs.WASI.NN.TorchSharp.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.TorchSharp/Wacs.WASI.NN.TorchSharp.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.TorchSharp</AssemblyName>
-        <AssemblyVersion>0.1.1</AssemblyVersion>
-        <Version>0.1.1</Version>
+        <AssemblyVersion>0.1.2</AssemblyVersion>
+        <Version>0.1.2</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;pytorch;torchsharp;libtorch;wacs</PackageTags>


### PR DESCRIPTION
## Summary

The previous release (`WACS.WASI.NN 0.3.4`, tag `WACS-WASI-NN-v0.3.5`) shipped the WITX-ABI fix on the top-level package but `skip-dup`'d every sibling because their csproj versions hadn't bumped. Their live manifests on NuGet therefore still advertise a pre-0.3.4 `WACS.WASI.NN` dependency floor. Consumers are protected in practice — NuGet range-resolves the floor up to the latest 0.3.4 — but the cascade is invisible at the `.nuspec` layer.

This PR point-bumps each sibling so every manifest declares the new floor.

| Sibling | Before | After |
|---|---:|---:|
| `WACS.WASI.NN.DependencyInjection` | 0.2.2 | 0.2.3 |
| `WACS.WASI.NN.LlamaSharp` | 0.2.2 | 0.2.3 |
| `WACS.WASI.NN.MLNet` | 0.2.2 | 0.2.3 |
| `WACS.WASI.NN.OnnxRuntime` | 0.3.0 | 0.3.1 |
| `WACS.WASI.NN.OnnxRuntimeGenAI` | 0.1.3 | 0.1.4 |
| `WACS.WASI.NN.TorchSharp` | 0.1.1 | 0.1.2 |

No code changes. Each sibling already `ProjectReference`s `Wacs.WASI.NN 0.3.4` on `main`, so the rebuild inherits the WITX 0.6 `set_input` / `compute` fix transparently.

## Test plan

- [x] `dotnet build` on every bumped sibling — 0 errors
- [x] CHANGELOG entry references the prior fix entry rather than restating the ABI change
- [ ] Post-merge: push a new `WACS-WASI-NN-v*` tag to trigger the family release workflow; expect 6 new NuGet artifacts + the top-level skip-dup

🤖 Generated with [Claude Code](https://claude.com/claude-code)