### PR TITLE
README: title "WACS (WebAssembly CSharp Toolchain)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WACS (C# WebAssembly Interpreter)
+# WACS (WebAssembly CSharp Toolchain)
 
 **Project status**
 &nbsp;![CI](https://github.com/kelnishi/WACS/actions/workflows/ci.yml/badge.svg?branch=main)


### PR DESCRIPTION
## Summary

The acronym actually spells out: W-A-C-S = **W**eb**A**ssembly **C****S**harp. Surfaces that in the title and replaces "Interpreter" with "Toolchain" to match the recent repo-description rewrite — interpreter undersells the project now that the AOT transpiler, NativeAOT builder, component-model bindgen, and inspect/bindgen verbs all ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)