### PR TITLE
WASI.NN 0.3.5: fix WITX retArea wire format (payload@0, errno via return)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## WACS.WASI.NN 0.3.5 — WITX retArea wire format: payload at offset 0, errno via return value
+
+PR #142 (0.3.4) aligned the `set_input` / `compute` arg count + errno
+convention to the bytecodealliance `wasi-nn 0.6` ABI, but missed a
+deeper retArea-layout mismatch in the four data-returning calls
+(`load`, `load_by_name`, `init_execution_context`, `get_output`).
+
+WACS was writing `errno @ retArea+0, payload @ retArea+4` and always
+returning `0` from the function. The 0.6 crate's generated FFI shim
+expects exactly the opposite: errno is the function's `i32` return
+value, and `retArea` is a buffer sized for the payload alone — the
+crate reads the payload from `retArea+0` via `ptr::read`.
+
+End-to-end consequence: the model loaded host-side, but the `Graph`
+handle returned to the guest was always 0 (the errno value sitting at
+retArea+0). Every subsequent call cascaded:
+
+- `load_by_name(name)` → returns `Graph { handle: 0 }`
+- `init_execution_context(graph=0)` → `InvalidArgument` (handle 0 is
+  the null sentinel in the WACS ResourceTable)
+- `set_input(ctx=junk, ...)` → `InvalidArgument` (ctx lookup miss)
+
+Now corrected. All four retArea-using calls write the payload at
+`retArea+0` and use the function's `i32` return value as the errno:
+
+| Call | Payload at retArea+0 | Errno |
+|---|---|---|
+| `load` | graph handle (i32) | return value |
+| `load_by_name` | graph handle (i32) | return value |
+| `init_execution_context` | graph-execution-context handle (i32) | return value |
+| `get_output` | written-byte count (i32) | return value |
+| `set_input` | — | return value (PR #142) |
+| `compute` | — | return value (PR #142) |
+
+`WriteWitxOk` / `WriteWitxErr` helpers deleted (no callers).
+
+### Verification
+
+Live witx guest (`wasi-nn-llm-witx`, built against `wasi-nn = "0.6"`,
+running through `wacs run --bind WACS.WASI.NN.LlamaSharp.dll`) now
+produces real LLM output on Qwen2.5 0.5B Instruct Q4_K_M GGUF —
+`load_by_name` → `init_execution_context` → `set_input` →
+`compute` → `get_output` all return errno=0, generated tokens stream
+back through the guest's REPL.
+
+`Wacs.WASI.NN.Test` suite: 21/21 pass.
+
 ## WACS.WASI.NN family — cascade bump to advertise the 0.3.4 WITX-ABI fix
 
 Repackages all six WASI.NN sibling backends so their `.nuspec` declares the

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/README.md
@@ -46,6 +46,19 @@ identity starts with `Wacs.WASI.NN.`. The Preview 2 DI scope's auto-wire registe
 backend in BOTH `Backends[GGML]` AND `LoadByNameBackend`; guests calling
 `wasi:nn/graph.load-by-name(...)` direct-link cleanly.
 
+For **wasi-p1 WITX guests** (e.g. Rust `wasi-nn = "0.6"` compiled for `wasm32-wasip1`),
+drop `--wasip2` and pass the model name via `-e` since Preview 1 doesn't auto-forward
+host env vars:
+
+```sh
+wacs run my-witx-guest.wasm --bind "$LLAMA" \
+    -e MODEL_NAME=qwen2.5-0.5b-instruct-q4_k_m
+```
+
+`WACS_WASINN_GGUF_DIR` is read by the bindable on the .NET host side (via
+`Environment.GetEnvironmentVariable`), so a plain shell `export` for it is enough on
+either ABI path.
+
 The full chain (with under-the-hood walkthrough) lives at
 [`docs/COMPONENT_CHAINING.md#gguf-inference-example-llamasharp-backend`](https://github.com/kelnishi/WACS/blob/main/docs/COMPONENT_CHAINING.md#gguf-inference-example-llamasharp-backend).
 

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/README.md
@@ -23,13 +23,23 @@ LlamaSharp's llama.cpp runtime).
 
 ## Quick start
 
-**CLI (zero code):**
+**CLI (zero code) — wasi-p2 component path:**
 
 ```sh
 wacs run my.component.wasm --wasip2 --wasi-nn -d ./models
 # --wasi-nn loads Wacs.WASI.NN.OnnxRuntime; bundled with the CLI.
 # Component auto-dispatches wasi:cli/run@<version>#run.
 ```
+
+**CLI — wasi-p1 WITX core-wasm path** (guests built against `wasi-nn = "0.6"` for `wasm32-wasip1`):
+
+```sh
+wacs run my-witx-guest.wasm \
+    --bind /path/to/Wacs.WASI.NN.LlamaSharp.dll \
+    -e MODEL_NAME=qwen2.5-0.5b-instruct-q4_k_m
+```
+
+Drop `--wasip2`; WITX guests import `wasi_ephemeral_nn.*` directly. WASI Preview 1 does not auto-forward the host's process environment, so pass each var the guest reads via `std::env::var` with `-e KEY=VALUE`. (On `--wasip2`, host env auto-forwards through `wasi:cli/environment.get-environment`; a plain `export` is enough.) See [`docs/WASI_NN_USAGE.md`](https://github.com/kelnishi/WACS/blob/main/docs/WASI_NN_USAGE.md) for the full invocation reference.
 
 **Embedder one-liner (interpreter path):**
 

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN</AssemblyName>
-        <AssemblyVersion>0.3.4</AssemblyVersion>
-        <Version>0.3.4</Version>
+        <AssemblyVersion>0.3.5</AssemblyVersion>
+        <Version>0.3.5</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitxBindings.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/WitxBindings.cs
@@ -18,19 +18,19 @@ namespace Wacs.WASI.NN
     /// Legacy core-module ABI binding for <c>wasi_ephemeral_nn</c>,
     /// targeting the bytecodealliance <c>wasi-nn 0.6</c> wire format
     /// that ships in the upstream Rust crate. Six imports, indexed
-    /// inputs / outputs, plain i32 handles, u16 errnos.
+    /// inputs / outputs, plain i32 handles.
     ///
-    /// <para>The errno encoding splits across two conventions, matching
-    /// what the 0.6 crate emits:
+    /// <para>Errno is uniformly the function's <c>i32</c> return value
+    /// across all six calls (matching what the 0.6 crate's generated
+    /// FFI shims read). Calls returning data take a trailing retArea
+    /// pointer that's sized exactly for the payload type — no errno
+    /// field; the crate reads the payload from retArea+0 via
+    /// <c>ptr::read</c> when errno==0:
     /// <list type="bullet">
-    /// <item>Data-returning calls (<c>load</c>, <c>load_by_name</c>,
-    /// <c>init_execution_context</c>, <c>get_output</c>) take a
-    /// trailing <c>retArea</c> i32 pointer. Host writes the errno
-    /// to retArea+0 and the payload to retArea+4; the function's
-    /// own i32 result is unused (always 0).</item>
-    /// <item>Void-Ok calls (<c>set_input</c>, <c>compute</c>) carry
-    /// no payload, so the errno collapses to the function's i32
-    /// return value — no retArea pointer.</item>
+    /// <item><c>load</c> / <c>load_by_name</c> → retArea is i32 graph handle</item>
+    /// <item><c>init_execution_context</c> → retArea is i32 execution-context handle</item>
+    /// <item><c>get_output</c> → retArea is i32 written-byte count</item>
+    /// <item><c>set_input</c> / <c>compute</c> → no retArea (void-Ok)</item>
     /// </list></para>
     ///
     /// <para>Memory layout helpers (all little-endian):
@@ -66,9 +66,13 @@ namespace Wacs.WASI.NN
 
         // load(builder: graph_builder_array, encoding: graph_encoding,
         //      target: execution_target) -> expected<graph, nn_errno>
-        // Wire form: (i32 builder_array_ptr, i32 builder_array_len,
-        //             i32 encoding, i32 target, i32 retArea) -> i32 errno
-        // retArea: u16 errno @0, then graph handle at +4 on success.
+        // bytecodealliance wasi-nn 0.6 ABI:
+        //   (i32 builder_array_ptr, i32 builder_array_len, i32 encoding,
+        //    i32 target, i32 retArea) -> i32 errno
+        // retArea is sized for a Graph handle (i32). On success (errno=0),
+        // the host writes the i32 handle to retArea+0. The crate reads
+        // the handle from retArea+0 via ptr::read; errno is the function
+        // return value, not in retArea.
         private static void BindLoad(WasmRuntime runtime, WasiNNHost host)
         {
             runtime.BindHostFunction<Func<ExecContext, int, int, int, int, int, int>>(
@@ -83,20 +87,19 @@ namespace Wacs.WASI.NN
                         var backend = host.ResolveBackend(enc);
                         var graph = backend.LoadGraph(builders, tgt);
                         var handle = host.Graphs.Allocate(graph);
-                        WriteWitxOk(ctx, retArea);
-                        ctx.WriteI32LE(retArea + 4, handle);
+                        ctx.WriteI32LE(retArea, handle);
                         return 0;
                     }
                     catch (WasiNNException e)
                     {
-                        WriteWitxErr(ctx, retArea, e.Code);
-                        return 0;
+                        return (int)(ushort)e.Code.ToWitx();
                     }
                 });
         }
 
         // load_by_name(name: string) -> expected<graph, nn_errno>
-        // Wire form: (i32 name_ptr, i32 name_len, i32 retArea) -> i32 errno
+        //   Wire: (i32 name_ptr, i32 name_len, i32 retArea) -> i32 errno
+        //   retArea+0: i32 graph handle on success.
         private static void BindLoadByName(WasmRuntime runtime, WasiNNHost host)
         {
             runtime.BindHostFunction<Func<ExecContext, int, int, int, int>>(
@@ -108,20 +111,20 @@ namespace Wacs.WASI.NN
                         var name = ReadString(ctx, namePtr, nameLen);
                         var graph = host.LoadGraphByNameDispatch(name);
                         var handle = host.Graphs.Allocate(graph);
-                        WriteWitxOk(ctx, retArea);
-                        ctx.WriteI32LE(retArea + 4, handle);
+                        ctx.WriteI32LE(retArea, handle);
                         return 0;
                     }
                     catch (WasiNNException e)
                     {
-                        WriteWitxErr(ctx, retArea, e.Code);
-                        return 0;
+                        return (int)(ushort)e.Code.ToWitx();
                     }
                 });
         }
 
         // init_execution_context(graph: graph)
         //   -> expected<graph_execution_context, nn_errno>
+        //   Wire: (i32 graph_handle, i32 retArea) -> i32 errno
+        //   retArea+0: i32 graph_execution_context handle on success.
         private static void BindInitExecutionContext(WasmRuntime runtime, WasiNNHost host)
         {
             runtime.BindHostFunction<Func<ExecContext, int, int, int>>(
@@ -137,14 +140,12 @@ namespace Wacs.WASI.NN
                         var bctx = graph.CreateContext();
                         var ctxHandle = host.Contexts.Allocate(bctx);
                         host.WitxContextState[ctxHandle] = new WitxContextState(bctx);
-                        WriteWitxOk(ctx, retArea);
-                        ctx.WriteI32LE(retArea + 4, ctxHandle);
+                        ctx.WriteI32LE(retArea, ctxHandle);
                         return 0;
                     }
                     catch (WasiNNException e)
                     {
-                        WriteWitxErr(ctx, retArea, e.Code);
-                        return 0;
+                        return (int)(ushort)e.Code.ToWitx();
                     }
                 });
         }
@@ -242,7 +243,9 @@ namespace Wacs.WASI.NN
         // get_output(context: graph_execution_context, index: u32,
         //            out_buffer: ptr<u8>, out_buffer_max_size: buffer_size)
         //   -> expected<buffer_size, nn_errno>
-        // retArea: u16 errno @0, written-byte-count u32 at +4.
+        //   Wire: (i32 ctx, i32 index, i32 out_buffer, i32 max_size,
+        //          i32 retArea) -> i32 errno
+        //   retArea+0: i32 written-byte count on success.
         private static void BindGetOutput(WasmRuntime runtime, WasiNNHost host)
         {
             runtime.BindHostFunction<Func<ExecContext, int, int, int, int, int, int>>(
@@ -271,14 +274,12 @@ namespace Wacs.WASI.NN
                         var mem = ctx.Memory();
                         for (int i = 0; i < span.Length; i++)
                             mem[outPtr + i] = span[i];
-                        WriteWitxOk(ctx, retArea);
-                        ctx.WriteI32LE(retArea + 4, span.Length);
+                        ctx.WriteI32LE(retArea, span.Length);
                         return 0;
                     }
                     catch (WasiNNException e)
                     {
-                        WriteWitxErr(ctx, retArea, e.Code);
-                        return 0;
+                        return (int)(ushort)e.Code.ToWitx();
                     }
                 });
         }
@@ -383,31 +384,6 @@ namespace Wacs.WASI.NN
                     ErrorCode.InvalidArgument,
                     $"unknown WITX tensor_type {wireValue}"),
             };
-        }
-
-        // ---- retArea writers ----
-
-        // expected<T, nn_errno> on success: errno=0 in the first
-        // u16 of the retArea. The actual T then sits at offset
-        // matching the result's payload alignment (max(2, align_of<T>)).
-        // For graph / context / buffer_size returns the payload
-        // alignment is 4, so the i32 sits at +4. Only the four
-        // data-returning calls use retArea — set_input and compute
-        // collapse the empty-Ok / errno case onto the function's
-        // i32 return value (no retArea pointer in their wire form).
-        private static void WriteWitxOk(ExecContext ctx, int retArea)
-        {
-            ctx.WriteI32LE(retArea, 0);
-        }
-
-        private static void WriteWitxErr(ExecContext ctx, int retArea, ErrorCode code)
-        {
-            // Witx errno discriminant goes in the first u16. We
-            // write 32 bits but only the low 16 are meaningful;
-            // the high 16 is reserved padding (some compilers
-            // would zero-fill it, others leave it undefined —
-            // we explicitly zero).
-            ctx.WriteI32LE(retArea, (int)(ushort)code.ToWitx());
         }
 
         private static int ReadI32LE(byte[] mem, int offset)

--- a/docs/WASI_NN_USAGE.md
+++ b/docs/WASI_NN_USAGE.md
@@ -108,6 +108,22 @@ Not needed for `load-by-name` backends (the model never enters wasm linear memor
 
 The transpiler engine direct-links wasi-nn imports for ~10× lower per-call overhead. The interpreter engine uses delegate-dispatched `BindHostFunction` handlers — slower per call but no JIT warmup. Default is **transpiler** for `--wasip2`; both paths share the same backend implementations.
 
+### Plain core wasm (wasm32-wasip1 / WITX)
+
+Guests built against the legacy `wasi_ephemeral_nn` WITX ABI (typically Rust crates pinned to `wasi-nn = "0.6"` and compiled for `--target wasm32-wasip1`) drop the `--wasip2` flag entirely:
+
+```sh
+wacs run my-witx-guest.wasm \
+    --bind <path-to-Wacs.WASI.NN.X.dll> \
+    -e MODEL_NAME=my-model
+```
+
+The same `--bind` + backend env-var pattern works — WACS's `WasiNNHost.BindToRuntime` wires both ABIs (`wasi:nn/*` WIT and `wasi_ephemeral_nn` WITX) onto the runtime, so a WITX guest reaches the same backend the WIT guest would.
+
+> **Gotcha — pass guest env vars with `-e`, not `export`:** WASI Preview 1 has no host-env-inheritance convention, so `wacs run` does **not** auto-forward the host's process environment to the guest. Pass each var the guest needs to read via `std::env::var` with `-e KEY=VALUE` (or `--env`, comma-separated). The wasi-p2 dispatch path auto-forwards host env via `wasi:cli/environment.get-environment`, so on `--wasip2` an `export MODEL_NAME=...` is enough.
+
+Host-side env vars consumed by the backend itself (e.g. `WACS_WASINN_GGUF_DIR`, `WACS_WASINN_TORCH_DIR`, `WACS_WASINN_GENAI_DIR`) are read by the .NET process via `Environment.GetEnvironmentVariable` — those just need a plain shell `export` on either path.
+
 ---
 
 ## Environment variables


### PR DESCRIPTION
## Summary

PR #142 (WACS.WASI.NN 0.3.4) aligned `set_input` / `compute` arg counts + errno-as-return to the bytecodealliance `wasi-nn 0.6` ABI. But it kept the prior `retArea` layout for the four **data-returning** calls (`load`, `load_by_name`, `init_execution_context`, `get_output`):

| | Was | Should be (per `wasi-nn 0.6` crate's generated FFI shim) |
|---|---|---|
| retArea+0 | errno (u16 in i32 cell) | payload (i32) |
| retArea+4 | payload (i32) | — |
| function return | always 0 | errno (i32) |

The 0.6 crate reads the payload from `retArea+0` via `ptr::read` on a `MaybeUninit<T>` buffer sized for the payload **alone** — no errno field. Errno is uniformly the i32 return value.

## Symptom

Reported in `wasi-nn/WACS-GAPS.md` gap 32. The model loaded host-side correctly, but the `Graph` handle returned to the guest was always **0** — the errno value (which is 0 on success) was being read by the crate as the handle. Then:

- `load_by_name("qwen2.5...")` returned `Graph { handle: 0 }`
- `init_execution_context(graph=0)` → `InvalidArgument` (handle 0 is the null sentinel in `ResourceTable`)
- `set_input(ctx=<junk>, …)` → `InvalidArgument` (ctx lookup miss)
- Every subsequent call cascaded; guest exited with "direct set_input errno 1"

## Fix

All four retArea-using calls now write the payload at `retArea+0` and return the errno as the function's i32 result:

| Call | Payload at retArea+0 | Errno |
|---|---|---|
| `load` | graph handle (i32) | return value |
| `load_by_name` | graph handle (i32) | return value |
| `init_execution_context` | graph-execution-context handle (i32) | return value |
| `get_output` | written-byte count (i32) | return value |
| `set_input` | — | return value (PR #142) |
| `compute` | — | return value (PR #142) |

`WriteWitxOk` / `WriteWitxErr` helpers deleted — no callers.

## Verification

Live witx guest (`wasi-nn-llm-witx`, built against `wasi-nn = "0.6"`) running through `wacs run --bind WACS.WASI.NN.LlamaSharp.dll` now produces real LLM output on Qwen2.5 0.5B Instruct Q4_K_M GGUF — full `load_by_name` → `init_execution_context` → `set_input` → `compute` → `get_output` cycle, all errno=0, generated tokens stream back through the REPL.

`Wacs.WASI.NN.Test` suite: 21/21 pass.

## Test plan

- [x] `dotnet test Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.Test` → 21/21 pass
- [x] Live witx guest e2e against LlamaSharp backend produces correct LLM output (confirmed locally on Apple M3 Max / Qwen2.5 0.5B Q4_K_M GGUF)
- [x] `wasi-nn 0.6` crate source (`graph.rs:251-260` / `generated.rs:230-250`) cross-checked for exact `MaybeUninit<T>` retArea read convention
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)