### PR TITLE
README: refresh cold-start fifth-path note for `wacs aot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,11 +713,12 @@ ships:
 For the absolute cold-start floor — both startup *and* steady-state on
 a single machine — there's a fifth path worth knowing about: link the
 transpiled `.dll` statically into a NativeAOT-published consumer (501 µs
-cold and ~100 ns per fib(100) call, in a 4.3 MB native binary). Today
-this requires hand-wired csproj plumbing; a future `wacs aot` workflow
-will automate it. Full breakdown, methodology, and the four-runtime ×
-three-build-flag matrix in
-[`docs/COLDSTART.md`](docs/COLDSTART.md).
+cold and ~100 ns per fib(100) call, in a 4.3 MB native binary). The
+`wacs aot` verb automates the whole pipeline end-to-end today
+(`wacs aot module.wasm -o module` → transpile → scaffold consumer
+csproj → `dotnet publish -p:PublishAot=true` → copy native binary
+out). Full breakdown, methodology, and the four-runtime ×
+three-build-flag matrix in [`docs/COLDSTART.md`](docs/COLDSTART.md).
 
 ### Running `wacs`
 


### PR DESCRIPTION
## Summary

The cold-start floor paragraph at the bottom of the Performance section was written before the `wacs aot` verb shipped. It referred to the static-link-NativeAOT-published-consumer recipe as a future workflow requiring hand-wired csproj plumbing.

The `wacs aot` verb is fully implemented today (`Wacs.Console/Verbs/AotHandler.cs`) — it transpiles the wasm, scaffolds a consumer csproj that statically references the produced `.dll`, runs `dotnet publish -p:PublishAot=true`, and copies the resulting native binary out, all in one command. `docs/COLDSTART.md` already documents this correctly; this PR catches the README prose up.

**Before:**
> Today this requires hand-wired csproj plumbing; a future `wacs aot` workflow will automate it.

**After:**
> The `wacs aot` verb automates the whole pipeline end-to-end today (`wacs aot module.wasm -o module` → transpile → scaffold consumer csproj → `dotnet publish -p:PublishAot=true` → copy native binary out).

The 501 µs cold / 4.3 MB native-binary numbers are unchanged — that's the measured floor for fib(100) iterative on osx-arm64, still the headline figure for the fifth path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)