### PR TITLE
WACS.Cli 1.7.2: drop OpenVINO native runtimes from bundle (fix 413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## WACS.Cli 1.7.2 — drop OpenVINO native runtimes from bundle
+
+The 1.7.1 nupkg failed to publish to NuGet (HTTP 413 — package
+exceeds the 250 MB upload limit). Each `OpenVINO.runtime.<rid>`
+pack is 150-200 MB decompressed; pinning all four primary RIDs
+(`macos-arm64` / `macos-x86_64` / `win` / `ubuntu.22-x86_64`)
+plus the existing ORT natives pushed the wacs nupkg past the
+NuGet ceiling.
+
+Removed all four `OpenVINO.runtime.*` package references from
+`Wacs.Console.csproj`. The OpenVINO backend DLL still ships in
+the wacs bundle, but the matching native runtime is the user's
+responsibility — install
+`OpenVINO.runtime.<rid>` for your RID separately and drop the
+unpacked `runtimes/<rid>/native/` tree into the wacs install
+location. Full instructions in
+[`Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/README.md`](Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/README.md).
+
+The architecture matches how ML.NET and TorchSharp backends
+already ship — the WACS-native backend DLL is small and
+bundled, the heavy ML framework's natives are a separate
+install.
+
 ## WACS.WASI.NN.OpenVino 0.1.0 / WACS.Cli 1.7.1 — OpenVINO wasi-nn backend
 
 New backend package for `graph-encoding.openvino`, plus a CLI

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.7.1</Version>
-    <AssemblyVersion>1.7.1</AssemblyVersion>
+    <Version>1.7.2</Version>
+    <AssemblyVersion>1.7.2</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>
@@ -117,25 +117,14 @@
                       Version="8.0.0" />
   </ItemGroup>
 
-  <!-- OpenVINO native runtimes — pulled as compile-excluded
-       package references so the published `wacs` bundle ships
-       a working OpenVINO backend on the four primary RIDs.
-       NuGet's RID-aware restore drops the matching pack into
-       runtimes/<rid>/native/ in the published output; the
-       OpenVINO.CSharp.API DLL P/Invokes against the standard
-       library names (openvino.dylib / openvino.so / openvino.dll)
-       and finds them at load time. The native packs are sizable
-       (~40 MB per RID), but no larger than the ORT native runtimes
-       we already ship in the same way. -->
-  <ItemGroup>
-    <PackageReference Include="OpenVINO.runtime.macos-arm64" Version="2024.4.0.1"
-                      ExcludeAssets="compile" />
-    <PackageReference Include="OpenVINO.runtime.macos-x86_64" Version="2024.4.0.1"
-                      ExcludeAssets="compile" />
-    <PackageReference Include="OpenVINO.runtime.win" Version="2026.0.0"
-                      ExcludeAssets="compile" />
-    <PackageReference Include="OpenVINO.runtime.ubuntu.22-x86_64" Version="2024.4.0.1"
-                      ExcludeAssets="compile" />
-  </ItemGroup>
+  <!-- OpenVINO native runtimes are intentionally NOT bundled
+       here. The four primary RID packs are ~160-200 MB each
+       (decompressed) — pinning all four would push the wacs
+       NuGet upload past the 250 MB nupkg limit. Users who want
+       the OpenVINO backend install the runtime pack for their
+       RID separately: `dotnet add package
+       OpenVINO.runtime.macos-arm64` (or .win, .ubuntu.22-x86_64,
+       .macos-x86_64). See WACS.WASI.NN.OpenVino's README for
+       the full instructions. -->
 
 </Project>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/README.md
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/README.md
@@ -13,22 +13,55 @@ distribution format (Model + Weights). This backend reads those two builders dir
 ## Install
 
 ```bash
+# 1. Backend DLL (small, RID-agnostic).
 dotnet add package WACS.WASI.NN.OpenVino
+
+# 2. Native runtime for your platform (~150-200 MB unpacked).
+#    Pick exactly one matching your RID:
+dotnet add package OpenVINO.runtime.macos-arm64    # Apple Silicon
+dotnet add package OpenVINO.runtime.macos-x86_64   # Intel Mac
+dotnet add package OpenVINO.runtime.win            # Windows x64
+dotnet add package OpenVINO.runtime.ubuntu.22-x86_64
+# (other Linux distros + arm64 variants are published as
+#  OpenVINO.runtime.{centos7,rhel8,debian10}-x86_64 /
+#  OpenVINO.runtime.ubuntu.{18,20}-arm64 etc. — see
+#  https://www.nuget.org/packages?q=openvino.runtime)
 ```
 
-The package depends on `OpenVINO.CSharp.API` but **not** on any
-`OpenVINO.runtime.<rid>` native pack — pick the runtime matching your deployment
-target separately. The CLI bundle wires up matching native packs across the
-common RIDs already.
+The runtime pack is shipped as a sibling NuGet rather than bundled with the
+backend or CLI because each one is large enough that bundling all four would
+push the parent NuGet past the 250 MB upload limit. Native binaries land in
+`runtimes/<rid>/native/` of your published output via NuGet's standard
+RID-aware restore — `OpenVINO.CSharp.API` P/Invokes against the standard
+library names (`openvino.dylib` / `openvino.so` / `openvino.dll`) and finds
+them at load time.
 
 ## CLI
+
+The `wacs` CLI bundle ships `Wacs.WASI.NN.OpenVino.dll` but **not** the OpenVINO
+native runtime (size-bound — see the install note above). You need to drop the
+native libraries into the WACS install directory's `runtimes/<rid>/native/`
+folder yourself before invoking, or load them via `LD_LIBRARY_PATH` /
+`DYLD_LIBRARY_PATH` / `PATH`.
+
+The easiest way to get a matched set is to install `OpenVINO.runtime.<rid>` into
+a scratch project and copy the unpacked natives:
+
+```sh
+mkdir openvino-native && cd openvino-native
+dotnet new console
+dotnet add package OpenVINO.runtime.macos-arm64    # match your RID
+dotnet build
+cp -R bin/Debug/net*/runtimes "$(dirname $(which wacs))/"
+```
+
+Then invoke:
 
 ```sh
 wacs run my.component.wasm --wasip2 --bind WACS.WASI.NN.OpenVino.dll
 ```
 
-Drop `Wacs.WASI.NN.OpenVino.dll` on the load path and pass it via `--bind`. The
-CLI's `IBindable`-discovery pass auto-picks `WasiNNOpenVinoBindable` and the
+The CLI's `IBindable`-discovery pass auto-picks `WasiNNOpenVinoBindable` and the
 guest's `graph.load` calls with `encoding=openvino` route through this backend.
 
 ## Embedder


### PR DESCRIPTION
## Summary

The 1.7.1 publish failed with **HTTP 413 — package exceeds the 250 MB upload limit**. Each `OpenVINO.runtime.<rid>` pack is 150-200 MB decompressed; pinning the four primary RIDs plus the existing ORT natives pushed the wacs nupkg past the NuGet ceiling.

Removed all four `OpenVINO.runtime.*` package references from `Wacs.Console.csproj`. The OpenVINO backend DLL still ships, but the matching native runtime is now the user's responsibility — same architecture ML.NET / TorchSharp already use.

## Per-RID footprint that broke 1.7.1

| RID | OpenVINO native size |
|---|---|
| `osx-arm64` | 176 MB |
| `osx-x86_64` | 164 MB |
| `win-x64` | 199 MB |
| `ubuntu.22-x86_64` | 178 MB |

Sum: ~720 MB, plus ORT natives + everything else. Way past 250 MB.

`WACS.WASI.NN.OpenVino` 0.1.0 already published successfully — that package is unaffected and works the same way.

## After

Bundle drops from 700+ MB (would have 413'd) to ~200 MB (matches the pre-1.7.0 footprint). `Wacs.WASI.NN.OpenVino.dll` is still bundled — `wacs run --bind Wacs.WASI.NN.OpenVino` works; users supply the native runtime by:

```sh
mkdir openvino-native && cd openvino-native
dotnet new console
dotnet add package OpenVINO.runtime.macos-arm64    # match your RID
dotnet build
cp -R bin/Debug/net*/runtimes "$(dirname $(which wacs))/"
```

Full instructions in [`Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/README.md`](https://github.com/kelnishi/WACS/blob/cli-openvino-natives-fix/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/README.md).

## Test plan

- [x] `dotnet build Wacs.Console/Wacs.Console/Wacs.Console.csproj` clean
- [x] `runtimes/` no longer contains an `openvino*` subtree
- [x] `Wacs.WASI.NN.OpenVino.dll` + `OpenVINO_CSharp_API.dll` still in bin output
- [x] `wacs run --bind Wacs.WASI.NN.OpenVino` reports `1 binding(s)`
- [ ] CI
- [ ] NuGet publish succeeds at 1.7.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)