### PR TITLE
WACS.WASI.Preview2.DependencyInjection 0.1.9 / WACS.Cli 1.7.3: auto-wire OpenVINO under `--wasip2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## WACS.WASI.Preview2.DependencyInjection 0.1.9 / WACS.Cli 1.7.3 — OpenVINO auto-wire under `--wasip2`
+
+Closes the gap reported in `wasi-nn/WACS-GAPS.md` §33: under
+`--wasip2 --bind Wacs.WASI.NN.OpenVino.dll`, guests calling
+`graph.load(encoding=openvino)` saw `InvalidEncoding: No backend
+registered for encoding OpenVINO`. Root cause was the same shape
+that bit OnnxRuntimeGenAI in an earlier round: the IBindable's
+`BindHostFunction` registrations get silently shadowed under
+`--wasip2` by the direct-link path, the WitBindings handlers
+drop, `GraphFuncsImpl.Load` reads the DI-bundle's
+`WasiNNConfiguration.Backends` dict, and without an auto-wire
+callback `Backends[OpenVINO]` stays empty.
+
+Added `BuildOpenVinoConfigureCallback` to
+`WasiPreview2RuntimeScope.ReflectivelyAddWasiNN` —
+mirrors `BuildOnnxConfigureCallback` (the cleanest analog; both
+register via the encoding-keyed `Backends` dict, no
+`LoadByNameBackend` plumbing). The callback joins the existing
+four-backend combine chain and registers an
+`OpenVinoBackend()` against `GraphEncoding.OpenVINO`. Failure
+modes (assembly not loadable / type not found / `Activator`
+throws) report on stderr instead of silently leaving the
+`Backends` dict empty — same pattern as the four siblings.
+
+WACS.Cli 1.7.3 picks up the rebuilt DI assembly. No user-facing
+flag change.
+
 ## WACS.Cli 1.7.2 — drop OpenVINO native runtimes from bundle
 
 The 1.7.1 nupkg failed to publish to NuGet (HTTP 413 — package

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.7.2</Version>
-    <AssemblyVersion>1.7.2</AssemblyVersion>
+    <Version>1.7.3</Version>
+    <AssemblyVersion>1.7.3</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.1.8</AssemblyVersion>
-        <Version>0.1.8</Version>
+        <AssemblyVersion>0.1.9</AssemblyVersion>
+        <Version>0.1.9</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
@@ -246,8 +246,10 @@ namespace Wacs.WASI.Preview2.DependencyInjection
             var llamaCallback = BuildLlamaSharpConfigureCallback(nnAsm!);
             var torchCallback = BuildTorchSharpConfigureCallback(nnAsm!);
             var genaiCallback = BuildOnnxGenAIConfigureCallback(nnAsm!);
+            var openVinoCallback = BuildOpenVinoConfigureCallback(nnAsm!);
             var configureDelegate = CombineCallbacks(
-                onnxCallback, llamaCallback, torchCallback, genaiCallback);
+                onnxCallback, llamaCallback, torchCallback,
+                genaiCallback, openVinoCallback);
 
             // services.AddWasiNN(configure) — configure runs
             // BEFORE TryAddSingleton(opts.Configuration), so each
@@ -722,6 +724,80 @@ namespace Wacs.WASI.Preview2.DependencyInjection
             var actionType = typeof(Action<>).MakeGenericType(optsType);
             return Expression.Lambda(actionType, assign, optsParam)
                 .Compile();
+        }
+
+        // Sibling of BuildOnnxConfigureCallback for the OpenVINO
+        // backend. Closest analog of the four (both register via
+        // the encoding-keyed Backends dict; neither uses
+        // LoadByNameBackend or a directory-registry factory).
+        // Closes the gap where the IBindable's BindHostFunction
+        // registrations get silently shadowed under --wasip2 by
+        // the direct-link path: the WitBindings handlers drop,
+        // GraphFuncsImpl reads the DI-bundle's WasiNNConfiguration,
+        // and without an auto-wire callback Backends[OpenVINO]
+        // stays empty → InvalidEncoding at guest call time.
+        //
+        // Returns null when:
+        //   - Wacs.WASI.NN.OpenVino isn't loadable (the common
+        //     `wacs run --wasip2` case without the OpenVINO
+        //     backend installed);
+        //   - OpenVinoBackend type / parameterless ctor can't be
+        //     resolved;
+        //   - Activator.CreateInstance throws (typically because
+        //     the OpenVINO native runtime isn't on the load
+        //     path — `OpenVINO.runtime.<rid>` not installed).
+        private static Delegate? BuildOpenVinoConfigureCallback(
+            Assembly nnAsm)
+        {
+            var optsType = nnAsm.GetType(
+                "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
+            if (optsType == null) return null;
+
+            var addBackend = optsType.GetMethod("AddBackend");
+            if (addBackend == null) return null;
+            var addBackendParams = addBackend.GetParameters();
+            if (addBackendParams.Length != 2) return null;
+            var encodingType = addBackendParams[0].ParameterType;
+            var backendIfaceType = addBackendParams[1].ParameterType;
+
+            var ovAsm = TryLoadAssembly("Wacs.WASI.NN.OpenVino");
+            if (ovAsm == null) return null;  // not an error.
+
+            var openVinoBackendType = ovAsm.GetType(
+                "Wacs.WASI.NN.OpenVino.OpenVinoBackend");
+            if (openVinoBackendType == null)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: Wacs.WASI.NN.OpenVino is loadable but "
+                    + "OpenVinoBackend type wasn't found. wasi-nn "
+                    + "OpenVINO guests will see InvalidEncoding errors.");
+                return null;
+            }
+
+            object? openVinoBackend;
+            try { openVinoBackend = Activator.CreateInstance(openVinoBackendType); }
+            catch (Exception ex)
+            {
+                System.Console.Error.WriteLine(
+                    "warn: OpenVinoBackend instantiation failed: "
+                    + ex.GetType().Name + ": " + ex.Message
+                    + ". wasi-nn OpenVINO guests will see InvalidEncoding "
+                    + "errors. Check that the OpenVINO native runtime "
+                    + "(`OpenVINO.runtime.<rid>` NuGet) is on the load "
+                    + "path.");
+                return null;
+            }
+            if (openVinoBackend == null) return null;
+
+            // GraphEncoding.OpenVINO = 0 in the WIT enum.
+            object openVinoEncoding = Enum.ToObject(encodingType, 0);
+
+            var optsParam = Expression.Parameter(optsType, "opts");
+            var call = Expression.Call(optsParam, addBackend,
+                Expression.Constant(openVinoEncoding, encodingType),
+                Expression.Constant(openVinoBackend, backendIfaceType));
+            var actionType = typeof(Action<>).MakeGenericType(optsType);
+            return Expression.Lambda(actionType, call, optsParam).Compile();
         }
 
         // Mirrors WasiNNOnnxGenAIBindable's env-driven scan:


### PR DESCRIPTION
## Summary

Closes the gap reported in `wasi-nn/WACS-GAPS.md` §33. Under `--wasip2 --bind Wacs.WASI.NN.OpenVino.dll`, guests calling `graph.load(encoding=openvino)` saw `InvalidEncoding: No backend registered for encoding OpenVINO`.

Root cause: the IBindable's `BindHostFunction` registrations get silently shadowed under `--wasip2` by the direct-link path (round-12-followup shadow rule). The WitBindings handlers drop, `GraphFuncsImpl.Load` reads the DI bundle's `WasiNNConfiguration.Backends` dict, and without an auto-wire callback `Backends[OpenVINO]` stays empty.

Same shape as the historical gaps that closed for:
- LlamaSharp (round 12)
- TorchSharp
- OnnxRuntimeGenAI (round 14)

## Fix

Added `BuildOpenVinoConfigureCallback` to `WasiPreview2RuntimeScope.ReflectivelyAddWasiNN`. Mirrors `BuildOnnxConfigureCallback` (the cleanest analog — both register via the encoding-keyed `Backends` dict; no `LoadByNameBackend` plumbing). Joins the existing four-backend combine chain at its registration site:

\`\`\`diff
 var genaiCallback    = BuildOnnxGenAIConfigureCallback(nnAsm!);
+var openVinoCallback = BuildOpenVinoConfigureCallback(nnAsm!);
 var configureDelegate = CombineCallbacks(
-    onnxCallback, llamaCallback, torchCallback, genaiCallback);
+    onnxCallback, llamaCallback, torchCallback,
+    genaiCallback, openVinoCallback);
\`\`\`

The new callback:

1. Resolves `Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions.AddBackend` reflectively (same pattern as ONNX).
2. Tries to load `Wacs.WASI.NN.OpenVino`; returns null silently if not present (the common `--wasip2` case without the OpenVINO backend installed).
3. Resolves `Wacs.WASI.NN.OpenVino.OpenVinoBackend` and constructs via parameterless ctor.
4. Falls through with a stderr warning when the assembly is loadable but the type / ctor isn't (likely native-runtime probe failure — `OpenVINO.runtime.<rid>` not on the load path).
5. Builds a strongly-typed `Action<WasiNNDependencyInjectionOptions>` via `Linq.Expressions` and returns it — same shape the other four siblings use.

## Versioning (per the rule)

- `WACS.WASI.Preview2.DependencyInjection` 0.1.8 → **0.1.9** (point bump — bug fix).
- `WACS.Cli` 1.7.2 → **1.7.3** (point bump — picks up the rebuilt DI assembly; no CLI surface change).

## Test plan

- [x] `dotnet build` clean on `Wacs.WASI.Preview2.DependencyInjection` + `Wacs.Console`.
- [x] `Wacs.Core.Test` suite 488/488 (no change — DI wiring fix, not a runtime change).
- [ ] End-to-end against `wasi-nn/scripts/run-embed.sh` (MiniLM-L6-v2 through OpenVINO) — requires the OpenVINO native runtime on the load path, which is the reporter's setup.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)