### PR TITLE
WACS family: auto-discovery for wasi-nn backends (net -318 LOC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## WACS family release — auto-discovery for wasi-nn backends
+
+Replaces the hand-written per-backend `BuildXxxConfigureCallback`
+chain in `WasiPreview2RuntimeScope` (~620 LOC across five
+hardcoded backends) with a single auto-discovery loop. Adding a
+new wasi-nn backend no longer requires editing the DI scope —
+the new package implements `IWasiNNBackendRegistration` on its
+bindable and gets picked up the next time the bundle scope is
+built. Same shape this PR's refactor would have demanded for any
+seventh, eighth, … backend.
+
+### What changed
+
+- **`WACS.WASI.NN` 0.3.5 → 0.4.0** (minor — new public API):
+  added `IWasiNNBackendRegistration` interface with one method,
+  `ConfigureConfiguration(WasiNNConfiguration config)`.
+- **All six backend packages — `WACS.WASI.NN.OnnxRuntime` 0.3.1
+  → 0.3.2, `LlamaSharp` 0.2.3 → 0.2.4, `TorchSharp` 0.1.2 →
+  0.1.3, `OnnxRuntimeGenAI` 0.1.4 → 0.1.5, `OpenVino` 0.1.0 →
+  0.1.1, `MLNet` 0.2.3 → 0.2.4** (point — additive interface
+  implementation): each `WasiNN<Backend>Bindable` adds
+  `IWasiNNBackendRegistration` and refactors its ctor body into
+  the new method. Env-driven model-registry scanning
+  (`WACS_WASINN_GGUF_DIR` / `_TORCH_DIR` / `_GENAI_DIR`) lives
+  in the bindable as before — the DI scope no longer
+  duplicates the scan logic.
+- **`WACS.WASI.Preview2.DependencyInjection` 0.1.9 → 0.2.0**
+  (minor — behavior shift): `BuildOnnxConfigureCallback`,
+  `BuildLlamaSharpConfigureCallback`,
+  `BuildTorchSharpConfigureCallback`,
+  `BuildOnnxGenAIConfigureCallback`,
+  `BuildOpenVinoConfigureCallback`,
+  `BuildGenAIRegistryFromEnv`,
+  `BuildTorchScriptRegistryFromEnv`,
+  `BuildGgufRegistryFromEnv` and `CombineCallbacks` all gone;
+  one `BuildAutoDiscoveredCallback` walks the AppDomain for
+  `Wacs.WASI.NN.*` assemblies, finds public types implementing
+  `IWasiNNBackendRegistration`, and chains their
+  `ConfigureConfiguration` calls into the AddWasiNN configure
+  delegate. The DI scope dropped from ~945 lines to ~480.
+- **`WACS.WASI.NN.MLNet`** picks up auto-wire under `--wasip2`
+  for free (it was previously missing from the hardcoded
+  callback list — a latent gap nobody had hit).
+- **`WACS.Cli` 1.7.3 → 1.7.4** (point — rebuilt deps).
+
+### Cost analysis (the trade-offs we picked up)
+
+| | Before | After |
+|---|---|---|
+| LOC in `WasiPreview2RuntimeScope.cs` | 945 | 480 |
+| Adding a new backend touches | DI scope + new builder method | Implement interface on bindable only |
+| Env-scan code locations per backend | 2 (bindable ctor + DI builder) | 1 (bindable's `ConfigureConfiguration`) |
+| MLNet auto-wire under `--wasip2` | Missing | Works |
+| New surface area to maintain | Per-backend builders | One interface, one discovery loop |
+
+### Tests + smoke
+
+- `Wacs.Core.Test` suite: 488/488 (no change — this is DI wiring).
+- All six backend csproj's build clean.
+- Live: `wacs run --wasip2 --wasi-nn` still binds OnnxRuntime
+  (the shorthand path); `wacs run --wasip2 --bind
+  WACS.WASI.NN.OpenVino` binds via the new discovery — both
+  report `1 binding(s)` and proceed to instantiation without
+  the gap-33 `InvalidEncoding` error.
+
 ## WACS.WASI.Preview2.DependencyInjection 0.1.9 / WACS.Cli 1.7.3 — OpenVINO auto-wire under `--wasip2`
 
 Closes the gap reported in `wasi-nn/WACS-GAPS.md` §33: under

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.7.3</Version>
-    <AssemblyVersion>1.7.3</AssemblyVersion>
+    <Version>1.7.4</Version>
+    <AssemblyVersion>1.7.4</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/Wacs.WASI.NN.LlamaSharp.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.LlamaSharp</AssemblyName>
-        <AssemblyVersion>0.2.3</AssemblyVersion>
-        <Version>0.2.3</Version>
+        <AssemblyVersion>0.2.4</AssemblyVersion>
+        <Version>0.2.4</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;llm;llama;gguf;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/WasiNNLlamaSharpBindable.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.LlamaSharp/WasiNNLlamaSharpBindable.cs
@@ -43,7 +43,8 @@ namespace Wacs.WASI.NN.LlamaSharp
     /// <see cref="LlamaSharpBackend"/> directly and pass it through
     /// <c>runtime.UseWasiNN(b => b.AddBackend(...))</c>.</para>
     /// </summary>
-    public sealed class WasiNNLlamaSharpBindable : IBindable, IDisposable
+    public sealed class WasiNNLlamaSharpBindable
+        : IBindable, IWasiNNBackendRegistration, IDisposable
     {
         private const string EnvVarName = "WACS_WASINN_GGUF_DIR";
 
@@ -51,19 +52,24 @@ namespace Wacs.WASI.NN.LlamaSharp
 
         public WasiNNLlamaSharpBindable()
         {
+            var config = WasiNNConfiguration.DefaultConfiguration();
+            ConfigureConfiguration(config);
+            _host = new WasiNNHost(config);
+        }
+
+        public void ConfigureConfiguration(WasiNNConfiguration config)
+        {
             var registry = BuildEnvRegistry();
             var backend = new LlamaSharpBackend(name =>
                 registry.TryGetValue(name, out var path)
                     ? new GgufModelEntry(path)
                     : (GgufModelEntry?)null);
-            var config = WasiNNConfiguration.DefaultConfiguration();
             config.Backends[GraphEncoding.GGML] = backend;
             // LlamaSharpBackend's only practical entry is load-by-
             // name (the byte-buffer path traps for GB-scale GGUFs);
             // route load-by-name through this backend explicitly
             // rather than dropping back to the generic resolver.
             config.LoadByNameBackend = backend;
-            _host = new WasiNNHost(config);
         }
 
         public void BindToRuntime(WasmRuntime runtime)

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/Wacs.WASI.NN.MLNet.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.MLNet</AssemblyName>
-        <AssemblyVersion>0.2.3</AssemblyVersion>
-        <Version>0.2.3</Version>
+        <AssemblyVersion>0.2.4</AssemblyVersion>
+        <Version>0.2.4</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;mlnet;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/WasiNNMLNetBindable.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.MLNet/WasiNNMLNetBindable.cs
@@ -36,15 +36,21 @@ namespace Wacs.WASI.NN.MLNet
     /// programmatically when reproducibility or pipeline-shared
     /// state matters.</para>
     /// </summary>
-    public sealed class WasiNNMLNetBindable : IBindable, IDisposable
+    public sealed class WasiNNMLNetBindable
+        : IBindable, IWasiNNBackendRegistration, IDisposable
     {
         private readonly WasiNNHost _host;
 
         public WasiNNMLNetBindable()
         {
             var config = WasiNNConfiguration.DefaultConfiguration();
-            config.Backends[GraphEncoding.ONNX] = new MLNetBackend();
+            ConfigureConfiguration(config);
             _host = new WasiNNHost(config);
+        }
+
+        public void ConfigureConfiguration(WasiNNConfiguration config)
+        {
+            config.Backends[GraphEncoding.ONNX] = new MLNetBackend();
         }
 
         public void BindToRuntime(WasmRuntime runtime)

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/Wacs.WASI.NN.OnnxRuntime.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/Wacs.WASI.NN.OnnxRuntime.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OnnxRuntime</AssemblyName>
-        <AssemblyVersion>0.3.1</AssemblyVersion>
-        <Version>0.3.1</Version>
+        <AssemblyVersion>0.3.2</AssemblyVersion>
+        <Version>0.3.2</Version>
         <RepositoryType>git</RepositoryType>
         <!-- ONNX Runtime carries native binaries; restricting to
              net8.0 here is fine because ORT itself targets

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/WasiNNOnnxBindable.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntime/WasiNNOnnxBindable.cs
@@ -35,15 +35,21 @@ namespace Wacs.WASI.NN.OnnxRuntime
     /// adapter — keeps the per-package shape identical so
     /// <c>--bind</c> works for any wasi-nn backend WACS ships.</para>
     /// </summary>
-    public sealed class WasiNNOnnxBindable : IBindable, IDisposable
+    public sealed class WasiNNOnnxBindable
+        : IBindable, IWasiNNBackendRegistration, IDisposable
     {
         private readonly WasiNNHost _host;
 
         public WasiNNOnnxBindable()
         {
             var config = WasiNNConfiguration.DefaultConfiguration();
-            config.Backends[GraphEncoding.ONNX] = new OnnxBackend();
+            ConfigureConfiguration(config);
             _host = new WasiNNHost(config);
+        }
+
+        public void ConfigureConfiguration(WasiNNConfiguration config)
+        {
+            config.Backends[GraphEncoding.ONNX] = new OnnxBackend();
         }
 
         public void BindToRuntime(WasmRuntime runtime)

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/Wacs.WASI.NN.OnnxRuntimeGenAI.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OnnxRuntimeGenAI</AssemblyName>
-        <AssemblyVersion>0.1.4</AssemblyVersion>
-        <Version>0.1.4</Version>
+        <AssemblyVersion>0.1.5</AssemblyVersion>
+        <Version>0.1.5</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;onnx;genai;llm;gemma;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/WasiNNOnnxGenAIBindable.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OnnxRuntimeGenAI/WasiNNOnnxGenAIBindable.cs
@@ -42,7 +42,8 @@ namespace Wacs.WASI.NN.OnnxRuntimeGenAI
     /// Composes alongside the regular ONNX backend — each handles
     /// its preferred entry point.</para>
     /// </summary>
-    public sealed class WasiNNOnnxGenAIBindable : IBindable, IDisposable
+    public sealed class WasiNNOnnxGenAIBindable
+        : IBindable, IWasiNNBackendRegistration, IDisposable
     {
         private const string EnvVarName = "WACS_WASINN_GENAI_DIR";
 
@@ -50,15 +51,20 @@ namespace Wacs.WASI.NN.OnnxRuntimeGenAI
 
         public WasiNNOnnxGenAIBindable()
         {
+            var config = WasiNNConfiguration.DefaultConfiguration();
+            ConfigureConfiguration(config);
+            _host = new WasiNNHost(config);
+        }
+
+        public void ConfigureConfiguration(WasiNNConfiguration config)
+        {
             var registry = BuildEnvRegistry();
             var backend = new OnnxGenAIBackend(name =>
                 registry.TryGetValue(name, out var dir) ? dir : null);
-            var config = WasiNNConfiguration.DefaultConfiguration();
             // Wire through load-by-name only; leave Backends[ONNX]
             // untouched so the regular OnnxBackend can still serve
             // byte-loaded ONNX through graph.load.
             config.LoadByNameBackend = backend;
-            _host = new WasiNNHost(config);
         }
 
         public void BindToRuntime(WasmRuntime runtime)

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/Wacs.WASI.NN.OpenVino.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/Wacs.WASI.NN.OpenVino.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OpenVino</AssemblyName>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <Version>0.1.0</Version>
+        <AssemblyVersion>0.1.1</AssemblyVersion>
+        <Version>0.1.1</Version>
         <RepositoryType>git</RepositoryType>
         <!-- OpenVINO.CSharp.API targets net6.0+, so net8.0 is fine.
              Like the ORT backend we restrict to net8.0 because the

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/WasiNNOpenVinoBindable.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/WasiNNOpenVinoBindable.cs
@@ -36,15 +36,21 @@ namespace Wacs.WASI.NN.OpenVino
     /// adapter — keeps the per-package shape identical so
     /// <c>--bind</c> works for any wasi-nn backend WACS ships.</para>
     /// </summary>
-    public sealed class WasiNNOpenVinoBindable : IBindable, IDisposable
+    public sealed class WasiNNOpenVinoBindable
+        : IBindable, IWasiNNBackendRegistration, IDisposable
     {
         private readonly WasiNNHost _host;
 
         public WasiNNOpenVinoBindable()
         {
             var config = WasiNNConfiguration.DefaultConfiguration();
-            config.Backends[GraphEncoding.OpenVINO] = new OpenVinoBackend();
+            ConfigureConfiguration(config);
             _host = new WasiNNHost(config);
+        }
+
+        public void ConfigureConfiguration(WasiNNConfiguration config)
+        {
+            config.Backends[GraphEncoding.OpenVINO] = new OpenVinoBackend();
         }
 
         public void BindToRuntime(WasmRuntime runtime)

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.TorchSharp/Wacs.WASI.NN.TorchSharp.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.TorchSharp/Wacs.WASI.NN.TorchSharp.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.TorchSharp</AssemblyName>
-        <AssemblyVersion>0.1.2</AssemblyVersion>
-        <Version>0.1.2</Version>
+        <AssemblyVersion>0.1.3</AssemblyVersion>
+        <Version>0.1.3</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>wasm;wasi;nn;ml;pytorch;torchsharp;libtorch;wacs</PackageTags>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.TorchSharp/WasiNNTorchSharpBindable.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.TorchSharp/WasiNNTorchSharpBindable.cs
@@ -45,7 +45,8 @@ namespace Wacs.WASI.NN.TorchSharp
     /// <c>runtime.UseWasiNN(b => b.AddBackend(GraphEncoding.PyTorch,
     /// new TorchSharpBackend(...)))</c>.</para>
     /// </summary>
-    public sealed class WasiNNTorchSharpBindable : IBindable, IDisposable
+    public sealed class WasiNNTorchSharpBindable
+        : IBindable, IWasiNNBackendRegistration, IDisposable
     {
         private const string EnvVarName = "WACS_WASINN_TORCH_DIR";
 
@@ -53,15 +54,20 @@ namespace Wacs.WASI.NN.TorchSharp
 
         public WasiNNTorchSharpBindable()
         {
+            var config = WasiNNConfiguration.DefaultConfiguration();
+            ConfigureConfiguration(config);
+            _host = new WasiNNHost(config);
+        }
+
+        public void ConfigureConfiguration(WasiNNConfiguration config)
+        {
             var registry = BuildEnvRegistry();
             var backend = TorchSharpBackend.FromPaths(registry);
-            var config = WasiNNConfiguration.DefaultConfiguration();
             config.Backends[GraphEncoding.PyTorch] = backend;
             // Route load-by-name through this backend explicitly
             // so big TorchScript files skip the canonical-ABI
             // byte-flow indirection.
             config.LoadByNameBackend = backend;
-            _host = new WasiNNHost(config);
         }
 
         public void BindToRuntime(WasmRuntime runtime)

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/IWasiNNBackendRegistration.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/IWasiNNBackendRegistration.cs
@@ -1,0 +1,48 @@
+// Copyright 2026 Kelvin Nishikawa
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+namespace Wacs.WASI.NN
+{
+    /// <summary>
+    /// A backend assembly's contract for registering itself with a
+    /// shared <see cref="WasiNNConfiguration"/>. Implemented by each
+    /// <c>WasiNN&lt;Backend&gt;Bindable</c> alongside
+    /// <c>IBindable</c>; discovered reflectively by the
+    /// <c>WasiPreview2RuntimeScope</c> DI bundle so the
+    /// direct-link-served <see cref="WasiNNConfiguration.Backends"/>
+    /// dict picks up every loaded backend without explicit
+    /// per-backend wiring in the DI scope.
+    ///
+    /// <para>The bindable's existing parameterless ctor already
+    /// builds a per-host config and wires it into a
+    /// <see cref="WasiNNHost"/>. Implementations should refactor
+    /// that ctor body into a private helper called from both the
+    /// ctor and this method — the env-driven model-registry logic
+    /// (e.g. <c>WACS_WASINN_GGUF_DIR</c>) belongs in the helper so
+    /// both call sites stay in sync.</para>
+    ///
+    /// <para>Backends that wire <c>LoadByNameBackend</c> in
+    /// addition to <c>Backends[encoding]</c> (LlamaSharp,
+    /// TorchSharp, OnnxRuntimeGenAI) set both on
+    /// <paramref name="config"/>. Backends that only fill
+    /// <c>Backends[encoding]</c> (OnnxRuntime, OpenVino, MLNet)
+    /// leave <c>LoadByNameBackend</c> alone.</para>
+    /// </summary>
+    public interface IWasiNNBackendRegistration
+    {
+        /// <summary>
+        /// Mutate <paramref name="config"/> to register this
+        /// package's backend(s). Idempotent: multiple invocations
+        /// against the same config replace the prior entries
+        /// rather than appending. Throws if the backend can't be
+        /// constructed (typically a native-library probe failure
+        /// — surface as a startup-time error rather than a quiet
+        /// no-op so the misconfiguration is diagnosable).
+        /// </summary>
+        void ConfigureConfiguration(WasiNNConfiguration config);
+    }
+}

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN/Wacs.WASI.NN.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN</AssemblyName>
-        <AssemblyVersion>0.3.5</AssemblyVersion>
-        <Version>0.3.5</Version>
+        <AssemblyVersion>0.4.0</AssemblyVersion>
+        <Version>0.4.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/Wacs.WASI.Preview2.DependencyInjection.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.Preview2.DependencyInjection</AssemblyName>
-        <AssemblyVersion>0.1.9</AssemblyVersion>
-        <Version>0.1.9</Version>
+        <AssemblyVersion>0.2.0</AssemblyVersion>
+        <Version>0.2.0</Version>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
+++ b/Wacs.WASI/Wacs.WASI.Preview2/Wacs.WASI.Preview2.DependencyInjection/WasiPreview2RuntimeScope.cs
@@ -229,27 +229,27 @@ namespace Wacs.WASI.Preview2.DependencyInjection
                 "Wacs.WASI.NN.DependencyInjection.WasiNNServiceCollectionExtensions");
             if (nnExtType == null) return;
 
-            // Build per-backend configure callbacks for whatever
-            // wasi-nn backends are loadable. Each callback runs
-            // INSIDE AddWasiNN's configure step (before
-            // TryAddSingleton(opts.Configuration)), so the registered
-            // Configuration instance carries every wired backend in
-            // one go.
+            // Auto-discover every wasi-nn backend assembly loaded
+            // into the AppDomain. Each backend's bindable type
+            // implements `Wacs.WASI.NN.IWasiNNBackendRegistration`
+            // and exposes a `ConfigureConfiguration(WasiNNConfiguration)`
+            // method that mutates the shared config; we instantiate
+            // each one via its parameterless ctor and chain the
+            // mutations into the AddWasiNN configure callback.
             //
-            // Failures surface as stderr warnings (vs. silent
-            // returns) — the SLM's round-13 "InvalidEncoding"
-            // symptom and round-19's "no named-model resolver
-            // configured" both root-cause faster when the load /
-            // ctor failure shows up at startup time, not at first
-            // guest call.
-            var onnxCallback = BuildOnnxConfigureCallback(nnAsm!);
-            var llamaCallback = BuildLlamaSharpConfigureCallback(nnAsm!);
-            var torchCallback = BuildTorchSharpConfigureCallback(nnAsm!);
-            var genaiCallback = BuildOnnxGenAIConfigureCallback(nnAsm!);
-            var openVinoCallback = BuildOpenVinoConfigureCallback(nnAsm!);
-            var configureDelegate = CombineCallbacks(
-                onnxCallback, llamaCallback, torchCallback,
-                genaiCallback, openVinoCallback);
+            // Failures (assembly not loadable / type not found /
+            // Activator throws / ConfigureConfiguration throws)
+            // surface as stderr warnings — the SLM's round-13
+            // "InvalidEncoding" and round-19's "no named-model
+            // resolver configured" both root-cause faster when the
+            // load/ctor failure shows up at startup time, not at
+            // first guest call.
+            //
+            // Adding a new wasi-nn backend now requires no edit to
+            // this file: the new package's bindable implements
+            // IWasiNNBackendRegistration and gets picked up the
+            // next time the bundle scope is built.
+            var configureDelegate = BuildAutoDiscoveredCallback(nnAsm!);
 
             // services.AddWasiNN(configure) — configure runs
             // BEFORE TryAddSingleton(opts.Configuration), so each
@@ -268,627 +268,160 @@ namespace Wacs.WASI.Preview2.DependencyInjection
                 .Invoke(null, new object?[] { services });
         }
 
-        // Build an Action<WasiNNDependencyInjectionOptions>
-        // delegate (typed against the dynamically-loaded type)
-        // that calls opts.AddBackend(GraphEncoding.ONNX, new
-        // OnnxBackend()). Returns null when:
-        //   - Wacs.WASI.NN.OnnxRuntime isn't loadable
-        //   - the OnnxBackend type or its parameterless ctor
-        //     can't be resolved
-        //   - Activator.CreateInstance throws
-        // In each error case a stderr warning is emitted so the
-        // failure is diagnosable (vs the previous silent return
-        // that turned every error into "InvalidEncoding" at
-        // guest-call time).
-        private static Delegate? BuildOnnxConfigureCallback(Assembly nnAsm)
-        {
-            var optsType = nnAsm.GetType(
-                "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
-            if (optsType == null) return null;
-
-            // AddBackend(GraphEncoding, IBackend) lives in
-            // Wacs.WASI.NN.DependencyInjection but its first
-            // parameter is Wacs.WASI.NN.Types.GraphEncoding from
-            // the Wacs.WASI.NN assembly. Pull the type from the
-            // method signature so we don't have to load the
-            // sibling assembly explicitly — and so we don't fail
-            // silently if the WASI.NN type namespace ever changes.
-            var addBackend = optsType.GetMethod("AddBackend");
-            if (addBackend == null) return null;
-            var addBackendParams = addBackend.GetParameters();
-            if (addBackendParams.Length != 2) return null;
-            var encodingType = addBackendParams[0].ParameterType;
-            var backendIfaceType = addBackendParams[1].ParameterType;
-
-            var ortAsm = TryLoadAssembly("Wacs.WASI.NN.OnnxRuntime");
-            if (ortAsm == null)
-            {
-                // Not necessarily an error — `--wasip2` without
-                // `--wasi-nn` doesn't load OnnxRuntime, and that's
-                // fine. Stay quiet here; only complain when the
-                // assembly IS loadable but its Activator step
-                // fails.
-                return null;
-            }
-
-            var onnxBackendType = ortAsm.GetType(
-                "Wacs.WASI.NN.OnnxRuntime.OnnxBackend");
-            if (onnxBackendType == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: Wacs.WASI.NN.OnnxRuntime is loadable but "
-                    + "OnnxBackend type wasn't found. wasi-nn ONNX "
-                    + "guests will see InvalidEncoding errors.");
-                return null;
-            }
-
-            object? onnxBackend;
-            try { onnxBackend = Activator.CreateInstance(onnxBackendType); }
-            catch (Exception ex)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: OnnxBackend instantiation failed: "
-                    + ex.GetType().Name + ": " + ex.Message
-                    + ". wasi-nn ONNX guests will see InvalidEncoding "
-                    + "errors. Check that the native ONNX Runtime "
-                    + "library is on the load path.");
-                return null;
-            }
-            if (onnxBackend == null) return null;
-
-            object onnxEncoding = Enum.ToObject(encodingType, 1);
-
-            // Use Linq.Expressions to build a strongly-typed
-            // Action<WasiNNDependencyInjectionOptions> at runtime.
-            // Captures onnxBackend + onnxEncoding via Constant
-            // expressions so the AddBackend call site doesn't
-            // need to redo any reflection at invocation time.
-            var optsParam = System.Linq.Expressions.Expression
-                .Parameter(optsType, "opts");
-            var call = System.Linq.Expressions.Expression.Call(
-                optsParam,
-                addBackend,
-                System.Linq.Expressions.Expression.Constant(
-                    onnxEncoding, encodingType),
-                System.Linq.Expressions.Expression.Constant(
-                    onnxBackend, backendIfaceType));
-            var actionType = typeof(Action<>).MakeGenericType(optsType);
-            var lambda = System.Linq.Expressions.Expression.Lambda(
-                actionType, call, optsParam);
-            return lambda.Compile();
-        }
-
-        // Combine per-backend configure callbacks into one
-        // multicast Action<options>. Multicast invocation fires
-        // each subscriber in registration order against the same
-        // options instance — exactly what we need when
-        // AddWasiNN's `configure?.Invoke(opts)` runs. Returns
-        // null if every input is null (in which case AddWasiNN
-        // gets a null configure and runs with an empty
-        // Configuration, matching the no-backend-loadable
-        // behavior).
-        private static Delegate? CombineCallbacks(
-            params Delegate?[] callbacks)
-        {
-            Delegate? result = null;
-            foreach (var cb in callbacks)
-            {
-                if (cb == null) continue;
-                result = result == null
-                    ? cb
-                    : Delegate.Combine(result, cb);
-            }
-            return result;
-        }
-
-        // Build an Action<WasiNNDependencyInjectionOptions>
-        // delegate that wires the LlamaSharp backend, scanning
-        // <c>WACS_WASINN_GGUF_DIR</c> for *.gguf files (matches
-        // WasiNNLlamaSharpBindable's env-driven registry shape).
-        // Registers the backend under BOTH:
-        //   - opts.AddBackend(GraphEncoding.GGML, backend) — for
-        //     embedders that route through the encoding-keyed
-        //     Backends dict (currently unused for LlamaSharp
-        //     since its byte-loader path traps, but left wired
-        //     for symmetry with ONNX);
-        //   - opts.Configuration.LoadByNameBackend = backend —
-        //     the load-by-name path GraphFuncsImpl checks before
-        //     falling back to the byte-flow (gap 24).
+        // Auto-discover every wasi-nn backend assembly loaded into
+        // the AppDomain and build a single combined
+        // `Action<WasiNNDependencyInjectionOptions>` that registers
+        // each backend's `IWasiNNBackendRegistration` against the
+        // DI bundle's shared `WasiNNConfiguration`.
         //
-        // Returns null when:
-        //   - Wacs.WASI.NN.LlamaSharp isn't loadable (the common
-        //     case for `wacs run --wasip2 --wasi-nn` — only ONNX
-        //     ships bundled);
-        //   - the LlamaSharpBackend type / FromPaths factory /
-        //     LoadByNameBackend property can't be resolved;
-        //   - FromPaths throws.
-        // Each non-quiet error path emits a stderr warning so the
-        // failure mode is discoverable at startup time.
-        private static Delegate? BuildLlamaSharpConfigureCallback(
-            Assembly nnAsm)
-        {
-            var optsType = nnAsm.GetType(
-                "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
-            if (optsType == null) return null;
-
-            var addBackend = optsType.GetMethod("AddBackend");
-            if (addBackend == null) return null;
-            var addBackendParams = addBackend.GetParameters();
-            if (addBackendParams.Length != 2) return null;
-            var encodingType = addBackendParams[0].ParameterType;
-            var backendIfaceType = addBackendParams[1].ParameterType;
-
-            var llamaAsm = TryLoadAssembly("Wacs.WASI.NN.LlamaSharp");
-            if (llamaAsm == null) return null;  // not an error.
-
-            var llamaBackendType = llamaAsm.GetType(
-                "Wacs.WASI.NN.LlamaSharp.LlamaSharpBackend");
-            if (llamaBackendType == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: Wacs.WASI.NN.LlamaSharp is loadable but "
-                    + "LlamaSharpBackend type wasn't found. wasi-nn "
-                    + "GGUF guests will see NotFound errors.");
-                return null;
-            }
-
-            var fromPaths = llamaBackendType.GetMethod("FromPaths",
-                BindingFlags.Public | BindingFlags.Static);
-            if (fromPaths == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: LlamaSharpBackend.FromPaths(IDictionary"
-                    + "<string,string>) static factory not found. "
-                    + "Cannot auto-wire LlamaSharp; embedders should "
-                    + "construct LlamaSharpBackend directly via "
-                    + "AddWasiNN(b => b.AddBackend(...)).");
-                return null;
-            }
-
-            var registry = BuildGgufRegistryFromEnv();
-
-            object? llamaBackend;
-            try { llamaBackend = fromPaths.Invoke(null, new object?[] { registry }); }
-            catch (Exception ex)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: LlamaSharpBackend.FromPaths failed: "
-                    + ex.GetType().Name + ": " + ex.Message
-                    + ". wasi-nn GGUF guests will see NotFound "
-                    + "errors. Check that the LLamaSharp native "
-                    + "library is on the load path.");
-                return null;
-            }
-            if (llamaBackend == null) return null;
-
-            // Resolve the LoadByNameBackend property on
-            // WasiNNConfiguration via opts.Configuration.
-            var configProp = optsType.GetProperty("Configuration");
-            if (configProp == null) return null;
-            var configType = configProp.PropertyType;
-            var loadByNameProp = configType.GetProperty("LoadByNameBackend");
-            if (loadByNameProp == null
-                || loadByNameProp.GetSetMethod() == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: WasiNNConfiguration.LoadByNameBackend "
-                    + "property missing or read-only; cannot route "
-                    + "GGUF graph.load-by-name through LlamaSharp.");
-                return null;
-            }
-
-            // GGML = 5 in both Nn.GraphEncoding and
-            // Types.GraphEncoding (cross-checked at file scope).
-            object ggmlEncoding = Enum.ToObject(encodingType, 5);
-
-            // Build:
-            //   opts.AddBackend(GraphEncoding.GGML, backend);
-            //   opts.Configuration.LoadByNameBackend = backend;
-            var optsParam = Expression.Parameter(optsType, "opts");
-            var addCall = Expression.Call(
-                optsParam,
-                addBackend,
-                Expression.Constant(ggmlEncoding, encodingType),
-                Expression.Constant(llamaBackend, backendIfaceType));
-            var configAccess = Expression.Property(optsParam, configProp);
-            var assign = Expression.Assign(
-                Expression.Property(configAccess, loadByNameProp),
-                Expression.Constant(llamaBackend,
-                    loadByNameProp.PropertyType));
-            var block = Expression.Block(addCall, assign);
-            var actionType = typeof(Action<>).MakeGenericType(optsType);
-            return Expression.Lambda(actionType, block, optsParam)
-                .Compile();
-        }
-
-        // Sibling of BuildLlamaSharpConfigureCallback for the
-        // TorchSharp / PyTorch backend. Detects
-        // `Wacs.WASI.NN.TorchSharp.TorchSharpBackend`, builds an
-        // env-driven registry from $WACS_WASINN_TORCH_DIR
-        // (mirroring WasiNNTorchSharpBindable's scan), and wires
-        // the backend into BOTH `Backends[PyTorch]` AND
-        // `LoadByNameBackend` so guest `graph.load-by-name(...)`
-        // direct-links cleanly.
+        // Discovery rules:
+        //   1. Enumerate all assemblies whose name starts with
+        //      "Wacs.WASI.NN." (case-insensitive). Excludes the DI
+        //      sibling (which doesn't ship a backend) and any
+        //      `.Test` assemblies.
+        //   2. For each, find every public type implementing
+        //      `Wacs.WASI.NN.IWasiNNBackendRegistration` with a
+        //      parameterless ctor.
+        //   3. Activator.CreateInstance + call
+        //      ConfigureConfiguration(opts.Configuration) per
+        //      registrant. Failures stderr-warn and skip — one
+        //      backend's ctor failure doesn't bring down scope
+        //      construction for the others.
         //
-        // Returns null when:
-        //   - Wacs.WASI.NN.TorchSharp isn't loadable (the common
-        //     `wacs run --wasip2 --wasi-nn` ONNX-default case;
-        //     stay quiet)
-        //   - the TorchSharpBackend type / FromPaths factory /
-        //     LoadByNameBackend property isn't resolvable
-        //   - FromPaths throws (libtorch native lib missing /
-        //     mismatch)
-        // Each non-quiet error path emits a stderr warning so the
-        // failure is discoverable at startup, not at first
-        // `compute(...)`.
-        private static Delegate? BuildTorchSharpConfigureCallback(
-            Assembly nnAsm)
+        // Adding a new wasi-nn backend now requires no edit to this
+        // file: the new package's bindable implements
+        // IWasiNNBackendRegistration and gets picked up the next
+        // time the bundle scope is built.
+        private static Delegate? BuildAutoDiscoveredCallback(Assembly nnAsm)
         {
             var optsType = nnAsm.GetType(
                 "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
             if (optsType == null) return null;
-
-            var addBackend = optsType.GetMethod("AddBackend");
-            if (addBackend == null) return null;
-            var addBackendParams = addBackend.GetParameters();
-            if (addBackendParams.Length != 2) return null;
-            var encodingType = addBackendParams[0].ParameterType;
-            var backendIfaceType = addBackendParams[1].ParameterType;
-
-            var torchAsm = TryLoadAssembly("Wacs.WASI.NN.TorchSharp");
-            if (torchAsm == null) return null;  // not an error.
-
-            var torchBackendType = torchAsm.GetType(
-                "Wacs.WASI.NN.TorchSharp.TorchSharpBackend");
-            if (torchBackendType == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: Wacs.WASI.NN.TorchSharp is loadable but "
-                    + "TorchSharpBackend type wasn't found. wasi-nn "
-                    + "PyTorch guests will see NotFound errors.");
-                return null;
-            }
-
-            var fromPaths = torchBackendType.GetMethod("FromPaths",
-                BindingFlags.Public | BindingFlags.Static);
-            if (fromPaths == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: TorchSharpBackend.FromPaths(IDictionary"
-                    + "<string,string>) static factory not found. "
-                    + "Cannot auto-wire TorchSharp; embedders should "
-                    + "construct TorchSharpBackend directly via "
-                    + "AddWasiNN(b => b.AddBackend(...)).");
-                return null;
-            }
-
-            var registry = BuildTorchScriptRegistryFromEnv();
-
-            object? torchBackend;
-            try { torchBackend = fromPaths.Invoke(null, new object?[] { registry }); }
-            catch (Exception ex)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: TorchSharpBackend.FromPaths failed: "
-                    + ex.GetType().Name + ": " + ex.Message
-                    + ". wasi-nn PyTorch guests will see NotFound "
-                    + "errors. Check that the libtorch native "
-                    + "library is on the load path.");
-                return null;
-            }
-            if (torchBackend == null) return null;
 
             var configProp = optsType.GetProperty("Configuration");
             if (configProp == null) return null;
             var configType = configProp.PropertyType;
-            var loadByNameProp = configType.GetProperty("LoadByNameBackend");
-            if (loadByNameProp == null
-                || loadByNameProp.GetSetMethod() == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: WasiNNConfiguration.LoadByNameBackend "
-                    + "property missing or read-only; cannot route "
-                    + "PyTorch graph.load-by-name through TorchSharp.");
-                return null;
-            }
 
-            // PyTorch = 3 in both Nn.GraphEncoding and
-            // Types.GraphEncoding (cross-checked at file scope —
-            // OpenVINO=0, ONNX=1, TensorFlow=2, PyTorch=3).
-            object pytorchEncoding = Enum.ToObject(encodingType, 3);
+            // IWasiNNBackendRegistration lives in Wacs.WASI.NN; the
+            // DI assembly already references the core, so its
+            // referenced-assembly list points at the right version.
+            Assembly? coreAsm = TryLoadAssembly("Wacs.WASI.NN");
+            var regIface = coreAsm?.GetType(
+                "Wacs.WASI.NN.IWasiNNBackendRegistration");
+            if (regIface == null) return null;
+            var regMethod = regIface.GetMethod("ConfigureConfiguration");
+            if (regMethod == null) return null;
 
-            // Build:
-            //   opts.AddBackend(GraphEncoding.PyTorch, backend);
-            //   opts.Configuration.LoadByNameBackend = backend;
-            var optsParam = Expression.Parameter(optsType, "opts");
-            var addCall = Expression.Call(
-                optsParam,
-                addBackend,
-                Expression.Constant(pytorchEncoding, encodingType),
-                Expression.Constant(torchBackend, backendIfaceType));
-            var configAccess = Expression.Property(optsParam, configProp);
-            var assign = Expression.Assign(
-                Expression.Property(configAccess, loadByNameProp),
-                Expression.Constant(torchBackend,
-                    loadByNameProp.PropertyType));
-            var block = Expression.Block(addCall, assign);
-            var actionType = typeof(Action<>).MakeGenericType(optsType);
-            return Expression.Lambda(actionType, block, optsParam)
-                .Compile();
-        }
+            var registrants = DiscoverBackendRegistrants(regIface);
+            if (registrants.Count == 0) return null;
 
-        // Sibling of BuildLlamaSharpConfigureCallback /
-        // BuildTorchSharpConfigureCallback for the
-        // OnnxRuntime-GenAI backend (generative LLMs in GenAI
-        // directory format: genai_config.json + tokenizer.json +
-        // model.onnx + weights). Detects
-        // `Wacs.WASI.NN.OnnxRuntimeGenAI.OnnxGenAIBackend`, builds
-        // an env-driven registry from $WACS_WASINN_GENAI_DIR
-        // (mirroring WasiNNOnnxGenAIBindable's subdirectory scan
-        // for genai_config.json), and wires the backend into
-        // `LoadByNameBackend` ONLY — leaves `Backends[ONNX]` to
-        // the regular OnnxBackend so `graph.load(bytes)` and
-        // `graph.load-by-name(directory)` route to the right
-        // place when both packages are present.
-        //
-        // Returns null when:
-        //   - Wacs.WASI.NN.OnnxRuntimeGenAI isn't loadable (the
-        //     common `wacs run --wasip2 --wasi-nn` case);
-        //   - OnnxGenAIBackend / FromDirectories factory /
-        //     LoadByNameBackend property can't be resolved;
-        //   - FromDirectories throws.
-        // Closes gap 31 (wasi-nn/WACS-GAPS.md).
-        private static Delegate? BuildOnnxGenAIConfigureCallback(
-            Assembly nnAsm)
-        {
-            var optsType = nnAsm.GetType(
-                "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
-            if (optsType == null) return null;
-
-            var addBackend = optsType.GetMethod("AddBackend");
-            if (addBackend == null) return null;
-            var addBackendParams = addBackend.GetParameters();
-            if (addBackendParams.Length != 2) return null;
-            var backendIfaceType = addBackendParams[1].ParameterType;
-
-            var genaiAsm = TryLoadAssembly(
-                "Wacs.WASI.NN.OnnxRuntimeGenAI");
-            if (genaiAsm == null) return null;  // not an error.
-
-            var genaiBackendType = genaiAsm.GetType(
-                "Wacs.WASI.NN.OnnxRuntimeGenAI.OnnxGenAIBackend");
-            if (genaiBackendType == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: Wacs.WASI.NN.OnnxRuntimeGenAI is loadable "
-                    + "but OnnxGenAIBackend type wasn't found. "
-                    + "wasi-nn GenAI guests will see NotFound errors.");
-                return null;
-            }
-
-            var fromDirs = genaiBackendType.GetMethod(
-                "FromDirectories",
-                BindingFlags.Public | BindingFlags.Static);
-            if (fromDirs == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: OnnxGenAIBackend.FromDirectories(IDictionary"
-                    + "<string,string>) static factory not found. "
-                    + "Cannot auto-wire OnnxRuntimeGenAI; embedders "
-                    + "should construct OnnxGenAIBackend directly "
-                    + "via AddWasiNN(b => b.AddBackend(...)).");
-                return null;
-            }
-
-            var registry = BuildGenAIRegistryFromEnv();
-
-            object? genaiBackend;
-            try { genaiBackend = fromDirs.Invoke(null, new object?[] { registry }); }
-            catch (Exception ex)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: OnnxGenAIBackend.FromDirectories failed: "
-                    + ex.GetType().Name + ": " + ex.Message
-                    + ". wasi-nn GenAI guests will see NotFound "
-                    + "errors. Check that the Microsoft.ML.OnnxRuntimeGenAI "
-                    + "native library is on the load path.");
-                return null;
-            }
-            if (genaiBackend == null) return null;
-
-            var configProp = optsType.GetProperty("Configuration");
-            if (configProp == null) return null;
-            var configType = configProp.PropertyType;
-            var loadByNameProp = configType.GetProperty("LoadByNameBackend");
-            if (loadByNameProp == null
-                || loadByNameProp.GetSetMethod() == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: WasiNNConfiguration.LoadByNameBackend "
-                    + "property missing or read-only; cannot route "
-                    + "GenAI graph.load-by-name through OnnxGenAIBackend.");
-                return null;
-            }
-
-            // GenAI backend takes the LoadByNameBackend slot only —
-            // leaves Backends[ONNX] for the regular OnnxBackend so
-            // `graph.load(bytes)` keeps its byte-tensor I/O path
-            // while `graph.load-by-name(<dir>)` routes to GenAI's
-            // KV-cached decode loop.
+            // Build an Action<opts> that walks each registrant and
+            // invokes `reg.ConfigureConfiguration(opts.Configuration)`.
+            // Pure reflection at invocation time (not Linq.Expressions)
+            // because the registrants list is dynamic — building a
+            // typed delegate against `IWasiNNBackendRegistration`
+            // doesn't gain us anything since each call is already a
+            // reflection invoke. The Action<opts> is typed against
+            // the dynamically-resolved options type so it satisfies
+            // AddWasiNN's configure parameter contract.
             var optsParam = Expression.Parameter(optsType, "opts");
             var configAccess = Expression.Property(optsParam, configProp);
-            var assign = Expression.Assign(
-                Expression.Property(configAccess, loadByNameProp),
-                Expression.Constant(genaiBackend,
-                    loadByNameProp.PropertyType));
-            var actionType = typeof(Action<>).MakeGenericType(optsType);
-            return Expression.Lambda(actionType, assign, optsParam)
-                .Compile();
-        }
-
-        // Sibling of BuildOnnxConfigureCallback for the OpenVINO
-        // backend. Closest analog of the four (both register via
-        // the encoding-keyed Backends dict; neither uses
-        // LoadByNameBackend or a directory-registry factory).
-        // Closes the gap where the IBindable's BindHostFunction
-        // registrations get silently shadowed under --wasip2 by
-        // the direct-link path: the WitBindings handlers drop,
-        // GraphFuncsImpl reads the DI-bundle's WasiNNConfiguration,
-        // and without an auto-wire callback Backends[OpenVINO]
-        // stays empty → InvalidEncoding at guest call time.
-        //
-        // Returns null when:
-        //   - Wacs.WASI.NN.OpenVino isn't loadable (the common
-        //     `wacs run --wasip2` case without the OpenVINO
-        //     backend installed);
-        //   - OpenVinoBackend type / parameterless ctor can't be
-        //     resolved;
-        //   - Activator.CreateInstance throws (typically because
-        //     the OpenVINO native runtime isn't on the load
-        //     path — `OpenVINO.runtime.<rid>` not installed).
-        private static Delegate? BuildOpenVinoConfigureCallback(
-            Assembly nnAsm)
-        {
-            var optsType = nnAsm.GetType(
-                "Wacs.WASI.NN.DependencyInjection.WasiNNDependencyInjectionOptions");
-            if (optsType == null) return null;
-
-            var addBackend = optsType.GetMethod("AddBackend");
-            if (addBackend == null) return null;
-            var addBackendParams = addBackend.GetParameters();
-            if (addBackendParams.Length != 2) return null;
-            var encodingType = addBackendParams[0].ParameterType;
-            var backendIfaceType = addBackendParams[1].ParameterType;
-
-            var ovAsm = TryLoadAssembly("Wacs.WASI.NN.OpenVino");
-            if (ovAsm == null) return null;  // not an error.
-
-            var openVinoBackendType = ovAsm.GetType(
-                "Wacs.WASI.NN.OpenVino.OpenVinoBackend");
-            if (openVinoBackendType == null)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: Wacs.WASI.NN.OpenVino is loadable but "
-                    + "OpenVinoBackend type wasn't found. wasi-nn "
-                    + "OpenVINO guests will see InvalidEncoding errors.");
-                return null;
-            }
-
-            object? openVinoBackend;
-            try { openVinoBackend = Activator.CreateInstance(openVinoBackendType); }
-            catch (Exception ex)
-            {
-                System.Console.Error.WriteLine(
-                    "warn: OpenVinoBackend instantiation failed: "
-                    + ex.GetType().Name + ": " + ex.Message
-                    + ". wasi-nn OpenVINO guests will see InvalidEncoding "
-                    + "errors. Check that the OpenVINO native runtime "
-                    + "(`OpenVINO.runtime.<rid>` NuGet) is on the load "
-                    + "path.");
-                return null;
-            }
-            if (openVinoBackend == null) return null;
-
-            // GraphEncoding.OpenVINO = 0 in the WIT enum.
-            object openVinoEncoding = Enum.ToObject(encodingType, 0);
-
-            var optsParam = Expression.Parameter(optsType, "opts");
-            var call = Expression.Call(optsParam, addBackend,
-                Expression.Constant(openVinoEncoding, encodingType),
-                Expression.Constant(openVinoBackend, backendIfaceType));
+            // Build a non-generic body: call ApplyAll(opts.Configuration, regMethod, registrants)
+            var applyAll = typeof(WasiPreview2RuntimeScope).GetMethod(
+                nameof(ApplyAllRegistrants),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            var call = Expression.Call(applyAll,
+                Expression.Convert(configAccess, typeof(object)),
+                Expression.Constant(regMethod, typeof(MethodInfo)),
+                Expression.Constant(registrants, typeof(List<object>)));
             var actionType = typeof(Action<>).MakeGenericType(optsType);
             return Expression.Lambda(actionType, call, optsParam).Compile();
         }
 
-        // Mirrors WasiNNOnnxGenAIBindable's env-driven scan:
-        // read $WACS_WASINN_GENAI_DIR, enumerate first-level
-        // subdirectories containing `genai_config.json`, register
-        // each under its directory name. Fail-soft on IO error.
-        private static IDictionary<string, string>
-            BuildGenAIRegistryFromEnv()
+        // Invoke ConfigureConfiguration on every discovered
+        // registrant. Errors stderr-warn and skip so one bad
+        // registrant doesn't sink the others.
+        private static void ApplyAllRegistrants(
+            object config, MethodInfo regMethod, List<object> registrants)
         {
-            var dir = Environment.GetEnvironmentVariable(
-                "WACS_WASINN_GENAI_DIR");
-            var registry = new Dictionary<string, string>(
-                StringComparer.OrdinalIgnoreCase);
-            if (string.IsNullOrEmpty(dir)) return registry;
-            try
+            foreach (var r in registrants)
             {
-                if (!Directory.Exists(dir)) return registry;
-                foreach (var modelDir in Directory.EnumerateDirectories(dir))
+                try { regMethod.Invoke(r, new[] { config }); }
+                catch (TargetInvocationException ex)
                 {
-                    var configPath = Path.Combine(
-                        modelDir, "genai_config.json");
-                    if (!File.Exists(configPath)) continue;
-                    var name = Path.GetFileName(modelDir);
-                    if (!string.IsNullOrEmpty(name))
-                        registry[name!] = modelDir;
+                    var inner = ex.InnerException ?? ex;
+                    Console.Error.WriteLine(
+                        "warn: " + r.GetType().FullName
+                        + ".ConfigureConfiguration threw "
+                        + inner.GetType().Name + ": " + inner.Message
+                        + ". guests requesting this backend will see "
+                        + "InvalidEncoding / NotFound errors.");
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        "warn: " + r.GetType().FullName
+                        + ".ConfigureConfiguration failed: "
+                        + ex.GetType().Name + ": " + ex.Message);
                 }
             }
-            catch (IOException) { }
-            catch (UnauthorizedAccessException) { }
-            return registry;
         }
 
-        // Mirrors WasiNNTorchSharpBindable's env-driven scan:
-        // read $WACS_WASINN_TORCH_DIR, enumerate *.pt + *.ts in
-        // the top-level dir, register each under filename-sans-
-        // extension. Fail-soft on IO error.
-        private static IDictionary<string, string>
-            BuildTorchScriptRegistryFromEnv()
+        // Walk every loaded assembly with a `Wacs.WASI.NN.*` name
+        // (excluding the DI / Test subpackages), find every public
+        // class implementing the registration interface, and
+        // instantiate via parameterless ctor. Errors stderr-warn
+        // and skip — one misbehaving backend doesn't kill the rest.
+        private static List<object> DiscoverBackendRegistrants(
+            Type regIface)
         {
-            var dir = Environment.GetEnvironmentVariable(
-                "WACS_WASINN_TORCH_DIR");
-            var registry = new Dictionary<string, string>(
-                StringComparer.OrdinalIgnoreCase);
-            if (string.IsNullOrEmpty(dir)) return registry;
-            try
+            var result = new List<object>();
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
             {
-                if (!Directory.Exists(dir)) return registry;
-                foreach (var pattern in new[] { "*.pt", "*.ts" })
+                if (asm.IsDynamic) continue;
+                string name;
+                try { name = asm.GetName().Name ?? ""; }
+                catch { continue; }
+                if (!name.StartsWith("Wacs.WASI.NN.",
+                    StringComparison.OrdinalIgnoreCase)) continue;
+                if (name.EndsWith(".DependencyInjection",
+                        StringComparison.OrdinalIgnoreCase)
+                    || name.EndsWith(".Test",
+                        StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                Type[] types;
+                try { types = asm.GetExportedTypes(); }
+                catch (ReflectionTypeLoadException ex)
                 {
-                    foreach (var path in Directory.EnumerateFiles(dir,
-                        pattern, SearchOption.TopDirectoryOnly))
+                    types = ex.Types.Where(t => t != null)
+                        .Select(t => t!).ToArray();
+                }
+                catch { continue; }
+
+                foreach (var t in types)
+                {
+                    if (t == null) continue;
+                    if (t.IsAbstract || t.IsInterface) continue;
+                    if (!regIface.IsAssignableFrom(t)) continue;
+                    if (t.GetConstructor(Type.EmptyTypes) == null) continue;
+
+                    object? instance;
+                    try { instance = Activator.CreateInstance(t); }
+                    catch (Exception ex)
                     {
-                        var name = Path.GetFileNameWithoutExtension(path);
-                        if (!string.IsNullOrEmpty(name))
-                            registry[name!] = path;
+                        Console.Error.WriteLine(
+                            "warn: wasi-nn backend " + t.FullName
+                            + " ctor failed: " + ex.GetType().Name
+                            + ": " + ex.Message
+                            + ". guests requesting this backend will "
+                            + "see InvalidEncoding / NotFound errors.");
+                        continue;
                     }
+                    if (instance != null) result.Add(instance);
                 }
             }
-            catch (IOException) { }
-            catch (UnauthorizedAccessException) { }
-            return registry;
-        }
-
-        // Mirrors WasiNNLlamaSharpBindable's env-driven scan:
-        // read $WACS_WASINN_GGUF_DIR, enumerate *.gguf files in
-        // the top-level dir, register each under its filename-
-        // sans-extension. Empty registry on miss / unset / IO
-        // error — matches the IBindable's fail-soft posture so
-        // the auto-wire never crashes scope construction.
-        private static IDictionary<string, string>
-            BuildGgufRegistryFromEnv()
-        {
-            var dir = Environment.GetEnvironmentVariable(
-                "WACS_WASINN_GGUF_DIR");
-            var registry = new Dictionary<string, string>(
-                StringComparer.OrdinalIgnoreCase);
-            if (string.IsNullOrEmpty(dir)) return registry;
-            try
-            {
-                if (!Directory.Exists(dir)) return registry;
-                foreach (var path in Directory.EnumerateFiles(dir,
-                    "*.gguf", SearchOption.TopDirectoryOnly))
-                {
-                    var name = Path.GetFileNameWithoutExtension(path);
-                    if (!string.IsNullOrEmpty(name))
-                        registry[name!] = path;
-                }
-            }
-            catch (IOException) { }
-            catch (UnauthorizedAccessException) { }
-            return registry;
+            return result;
         }
 
         // Resolve a named assembly across both .NET load contexts.


### PR DESCRIPTION
## Summary

Replaces the hand-written per-backend `BuildXxxConfigureCallback` chain in `WasiPreview2RuntimeScope` (~620 LOC across five hardcoded backends) with a single auto-discovery loop. **Adding a new wasi-nn backend no longer requires editing the DI scope** — the new package implements `IWasiNNBackendRegistration` on its bindable and gets picked up the next time the bundle scope is built.

This is the architectural follow-up to PR #152's per-backend OpenVINO auto-wire fix.

## The interface

New in `Wacs.WASI.NN`:

\`\`\`csharp
public interface IWasiNNBackendRegistration
{
    void ConfigureConfiguration(WasiNNConfiguration config);
}
\`\`\`

Each backend's existing `WasiNN<Backend>Bindable` adds the interface; its parameterless ctor body refactors into `ConfigureConfiguration`. The bindable's ctor calls the method to populate its own private host config (preserving the `--bind`-via-`IBindable` path); the DI scope's auto-discovery calls the same method against the bundle's shared config.

| Backend | Shape |
|---|---|
| `Onnx`, `OpenVino`, `MLNet` | `config.Backends[encoding] = new XxxBackend()` |
| `LlamaSharp` | env-driven registry → `Backends[GGML] = backend` + `LoadByNameBackend = backend` |
| `TorchSharp` | env-driven registry → `Backends[PyTorch] = backend` + `LoadByNameBackend = backend` |
| `OnnxGenAI` | env-driven registry → `LoadByNameBackend = backend` (only) |

Env-driven scan logic stays where it already lives (in each bindable) — the DI scope no longer duplicates it.

## The discovery loop

In `WasiPreview2RuntimeScope.cs`:

\`\`\`csharp
private static Delegate? BuildAutoDiscoveredCallback(Assembly nnAsm)
{
    // resolve IWasiNNBackendRegistration via the core assembly
    var registrants = DiscoverBackendRegistrants(regIface);
    if (registrants.Count == 0) return null;
    // Build Action<opts> that walks each registrant + invokes
    // reg.ConfigureConfiguration(opts.Configuration). Errors
    // stderr-warn + skip — one bad registrant doesn't sink the rest.
    return ...;
}

private static List<object> DiscoverBackendRegistrants(Type regIface)
{
    // Walk AppDomain for Wacs.WASI.NN.* assemblies (skipping
    // .DependencyInjection and .Test). For each, find public
    // classes implementing the interface with a parameterless
    // ctor. Activator.CreateInstance each one.
}
\`\`\`

## Stats

| | Before | After |
|---|---|---|
| LOC in `WasiPreview2RuntimeScope.cs` | 945 | 480 |
| Adding a new backend touches | DI scope + new `BuildXxx` method | Implement interface on bindable only |
| Env-scan code locations per backend | 2 (bindable ctor + DI builder) | 1 (bindable's `ConfigureConfiguration`) |
| `WACS.WASI.NN.MLNet` auto-wire under `--wasip2` | Missing | Works |

**Net diff: +324 / -642 = -318 LOC.**

## Versioning (per the rule)

| Package | Old | New | Why |
|---|---|---|---|
| `WACS.WASI.NN` | 0.3.5 | **0.4.0** | minor — new public API |
| `WACS.WASI.NN.OnnxRuntime` | 0.3.1 | 0.3.2 | point — additive interface impl |
| `WACS.WASI.NN.LlamaSharp` | 0.2.3 | 0.2.4 | point |
| `WACS.WASI.NN.TorchSharp` | 0.1.2 | 0.1.3 | point |
| `WACS.WASI.NN.OnnxRuntimeGenAI` | 0.1.4 | 0.1.5 | point |
| `WACS.WASI.NN.OpenVino` | 0.1.0 | 0.1.1 | point |
| `WACS.WASI.NN.MLNet` | 0.2.3 | 0.2.4 | point |
| `WACS.WASI.Preview2.DependencyInjection` | 0.1.9 | **0.2.0** | minor — behavior shift |
| `WACS.Cli` | 1.7.3 | 1.7.4 | point — rebuilt deps |

## Test plan

- [x] `Wacs.Core.Test` 488/488 (no change — this is DI wiring).
- [x] All six backend csprojs build clean.
- [x] `wacs run --wasip2 --wasi-nn` still binds OnnxRuntime → `1 binding(s)`.
- [x] `wacs run --wasip2 --bind WACS.WASI.NN.OpenVino` binds via discovery → `1 binding(s)`, no `InvalidEncoding` at runtime.
- [ ] End-to-end against `wasi-nn/scripts/run-embed.sh` (MiniLM through OpenVINO).
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)