### PR TITLE
WACS.WASI.NN.OpenVino 0.2.1 / WACS.Cli 1.7.6: fix compile_model empty-Properties throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## WACS.WASI.NN.OpenVino 0.2.1 / WACS.Cli 1.7.6 — fix compile_model empty-Properties throw
+
+`OpenVINO.CSharp.API` 2025.4.0's `Core.compile_model(model, device,
+Dictionary)` dispatches on `properties.Count` with branches for 0,
+1, 2, 3 — but the `Count == 0` arm is unreachable: only a `null`
+`Dictionary` hits the wrapper's no-properties native call, while
+an empty dict falls through the if-else chain into a throw:
+`"Only supports parameter quantities of 0, 1, 2, and 3."`
+
+`OpenVinoBackend.LoadGraph` constructed `_options.Properties` as
+an empty `Dictionary<string,string>` and passed it through, so
+every guest that loaded an OpenVINO model without setting
+`WACS_WASINN_OPENVINO_PROPERTIES` blew up at compile time.
+Surfaced now on macOS arm64 because the 2026.1.0 runtime ships
+brought `read_model` past the IR-version-skew gate that had been
+masking it — Linux and Windows guests would hit the same throw.
+
+Fix: coerce empty `Properties` to `null` at the two
+`compile_model` call sites (primary + CPU fallback) before
+dispatching to the wrapper. Reported in
+`wasi-nn/WACS-GAPS.md` gap 34.
+
+### What changed
+
+- **`WACS.WASI.NN.OpenVino` 0.2.0 → 0.2.1** (point — bug fix):
+  one-line guard in `OpenVinoBackend.cs` to substitute `null` for
+  the default empty `Properties` dict.
+- **`WACS.Cli` 1.7.5 → 1.7.6** (point — bundle re-pack against
+  the fixed backend): no CLI surface changes.
+
 ## WACS.WASI.NN.OpenVino 0.2.0 / WACS.Cli 1.7.5 — bundle OpenVINO 2026.1.0 macOS arm64 runtime
 
 Upstream `OpenVINO-CSharp-API` shipped 2026.1.0 native packs after

--- a/Wacs.Console/Wacs.Console/Wacs.Console.csproj
+++ b/Wacs.Console/Wacs.Console/Wacs.Console.csproj
@@ -29,8 +29,8 @@
          library); the tool command users type is still `wacs`. -->
     <PackageId>WACS.Cli</PackageId>
     <Title>WACS CLI</Title>
-    <Version>1.7.5</Version>
-    <AssemblyVersion>1.7.5</AssemblyVersion>
+    <Version>1.7.6</Version>
+    <AssemblyVersion>1.7.6</AssemblyVersion>
     <FileVersion>1.4.1</FileVersion>
     <Description>WACS unified WebAssembly toolchain: run, build, aot, inspect, bindgen. v1.3 picks up WACS.Transpiler.Lib v0.7's PersistedAssemblyBuilder migration + RVA-mapped data segments, so `wacs build` produces ~11% smaller .dlls and the new EmissionTarget.Auto default cuts cold start by ~50% on the common module shapes. The `wacs aot` verb produces self-contained NativeAOT native binaries from a wasm input in one shot, with --wasi / --wasip2 baking in WASI Preview 1 / Preview 2 hosts. Supersedes wasm-transpile (WACS.Transpiler).</Description>
     <PackageProjectUrl>https://github.com/kelnishi/WACS</PackageProjectUrl>

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/OpenVinoBackend.cs
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/OpenVinoBackend.cs
@@ -121,11 +121,20 @@ namespace Wacs.WASI.NN.OpenVino
 
                 var core = new OvCore();
                 var model = core.read_model(xmlBytes, weightsTensor);
+                // OpenVINO.CSharp.API 2025.4.0's compile_model
+                // dispatches on properties.Count and throws when
+                // Count is 0; only `null` reaches the no-props
+                // branch. Coerce empty → null so the default
+                // case (no WACS_WASINN_OPENVINO_PROPERTIES set)
+                // doesn't trip the wrapper's else throw.
+                var props = _options.Properties.Count == 0
+                    ? null
+                    : _options.Properties;
                 CompiledModel compiled;
                 try
                 {
                     compiled = core.compile_model(
-                        model, deviceName, _options.Properties);
+                        model, deviceName, props);
                 }
                 catch (Exception) when (_options.FallbackToCpu
                     && !string.Equals(deviceName, "CPU", StringComparison.Ordinal))
@@ -135,7 +144,7 @@ namespace Wacs.WASI.NN.OpenVino
                     // OpenVINO runtime distribution, so this
                     // path is the safest landing zone.
                     compiled = core.compile_model(
-                        model, "CPU", _options.Properties);
+                        model, "CPU", props);
                 }
 
                 // Tensors created from the weights bytes can be

--- a/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/Wacs.WASI.NN.OpenVino.csproj
+++ b/Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino/Wacs.WASI.NN.OpenVino.csproj
@@ -12,8 +12,8 @@
         <RepositoryUrl>https://github.com/kelnishi/WACS</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <AssemblyName>Wacs.WASI.NN.OpenVino</AssemblyName>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
-        <Version>0.2.0</Version>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
+        <Version>0.2.1</Version>
         <RepositoryType>git</RepositoryType>
         <!-- OpenVINO.CSharp.API targets net6.0+, so net8.0 is fine.
              Like the ORT backend we restrict to net8.0 because the


### PR DESCRIPTION
## Summary

- **WACS.WASI.NN.OpenVino 0.2.0 → 0.2.1** (point — bug fix): coerce an empty `_options.Properties` dict to `null` before calling `core.compile_model(...)`. `OpenVINO.CSharp.API` 2025.4.0's `compile_model` dispatches on `properties.Count` with explicit branches for `0`, `1`, `2`, `3` — but the `Count == 0` arm is unreachable: only a `null` Dictionary hits the no-properties native call, while an empty dict falls through into the wrapper's `else` throw (`"Only supports parameter quantities of 0, 1, 2, and 3."`). The default code path (`WACS_WASINN_OPENVINO_PROPERTIES` unset, no programmatic property pin) constructed `Properties` as an empty dict and tripped the throw on every guest.
- **WACS.Cli 1.7.5 → 1.7.6** (point — bundle re-packs against the fixed backend): no CLI surface changes.

Surfaced first on macOS arm64 because the 2026.1.0 runtime bundled in 0.2.0 took `read_model` past the IR-version-skew gate that had been masking it. The bug is platform-independent — Linux and Windows guests would hit the same throw at `compile_model` time. Reported as gap 34 in [`wasi-nn/WACS-GAPS.md`](https://github.com/kelnishi/wasi-nn/blob/main/WACS-GAPS.md).

## Test plan

- [x] `dotnet build Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino` clean.
- [ ] End-to-end `scripts/run-embed.sh` against the MiniLM 2026 IR on macOS arm64 returns embeddings without the `"Only supports parameter quantities of 0, 1, 2, and 3."` throw (kelnishi to verify with the wasi-nn embed-demo).
- [ ] Same demo with `WACS_WASINN_OPENVINO_PROPERTIES=NUM_STREAMS=1` still works (Count == 1 path was already exercised pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)