### PR TITLE
ci: add WACS-WASI-GFX-v* publish trigger + matrix entries

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -20,12 +20,19 @@ on:
       - 'WACS-HostBindings-v*.*.*'
       # `WACS-WASI-NN-v*` publishes the wasi-nn family — the
       # backend-agnostic core, the DI bundle (concrete resource
-      # impls + composite WasiPreview2NNBundle), and the three
-      # backend siblings (ONNX Runtime, ML.NET, LlamaSharp).
-      # Versioned together because the bundle's [WitSource]
-      # forwarding properties expose interfaces from the core
-      # package — a stale core breaks the composite.
+      # impls + composite WasiPreview2NNBundle), and the backend
+      # siblings (ONNX Runtime, ONNX Runtime GenAI, ML.NET,
+      # LlamaSharp, TorchSharp, OpenVINO). Versioned together
+      # because the bundle's [WitSource] forwarding properties
+      # expose interfaces from the core package — a stale core
+      # breaks the composite.
       - 'WACS-WASI-NN-v*.*.*'
+      # `WACS-WASI-GFX-v*` publishes the wasi-gfx family — the
+      # backend-agnostic core, the webgpu contract sibling, the
+      # DI bundle, and the Silk.NET/SDL + wgpu-native backend.
+      # All four versioned together; the wasi-gfx WIT proposal
+      # is still at WASI Phase 2 so packages ship -preview.
+      - 'WACS-WASI-GFX-v*.*.*'
 
 jobs:
   build-and-publish:
@@ -130,6 +137,24 @@ jobs:
           - path: Wacs.WASI/Wacs.WASI.NN/Wacs.WASI.NN.OpenVino
             package_name: WACS.WASI.NN.OpenVino
             tag_prefix: WACS-WASI-NN-v
+
+          # `WACS-WASI-GFX-v*` → wasi-gfx family. Backend-agnostic
+          # core + webgpu contract sibling + DI bundle + Silk.NET/
+          # SDL + wgpu-native backend. Versioned together; the
+          # csproj versions carry a -preview suffix while the
+          # upstream wasi-gfx proposal sits at WASI Phase 2.
+          - path: Wacs.WASI/Wacs.WASI.GFX/Wacs.WASI.GFX
+            package_name: WACS.WASI.GFX
+            tag_prefix: WACS-WASI-GFX-v
+          - path: Wacs.WASI/Wacs.WASI.GFX/Wacs.WASI.GFX.Webgpu
+            package_name: WACS.WASI.GFX.Webgpu
+            tag_prefix: WACS-WASI-GFX-v
+          - path: Wacs.WASI/Wacs.WASI.GFX/Wacs.WASI.GFX.DependencyInjection
+            package_name: WACS.WASI.GFX.DependencyInjection
+            tag_prefix: WACS-WASI-GFX-v
+          - path: Wacs.WASI/Wacs.WASI.GFX/Wacs.WASI.GFX.Silk
+            package_name: WACS.WASI.GFX.Silk
+            tag_prefix: WACS-WASI-GFX-v
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Add the four wasi-gfx NuGet packages to `.github/workflows/nuget.yml` so a `WACS-WASI-GFX-v*.*.*` tag publishes them. Today the workflow has no `WACS-WASI-GFX-v*` trigger and no matrix entries for the gfx packages — tagging the family on `main` (`WACS-WASI-GFX-v0.2.0` for the v1 release just merged in #160) would silently no-op.

- Adds `WACS-WASI-GFX-v*.*.*` to the trigger list.
- Adds four matrix entries pointing at `WACS.WASI.GFX`, `.Webgpu`, `.DependencyInjection`, `.Silk`.
- Refreshes the `WACS-WASI-NN-v*` comment to list the six backends shipping today (was: three) — ONNX Runtime, ONNX Runtime GenAI, ML.NET, LlamaSharp, TorchSharp, OpenVINO.

Once this merges, `WACS-WASI-GFX-v0.2.0` tag can fire and the four `-preview`-suffixed packages will publish to NuGet.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nuget.yml'))"` — workflow YAML parses.
- [ ] Merge + push `WACS-WASI-GFX-v0.2.0` tag — verify the four gfx jobs run and `dotnet nuget search WACS.WASI.GFX --prerelease` returns the new 0.2.0-preview / 0.1.0-preview / 0.1.1-preview entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)