### PR TITLE
wacs-core: 0.15.24 — full name-section subsection coverage (ids 0–11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## WACS 0.15.24 — field-names and tag-names subsections
+
+Adds parser and writer support for two more `name` custom-section
+subsections that were previously unrecognized (and would have
+thrown `FormatException` on any binary carrying them):
+
+- **Field names** (id 10, from the GC proposal) — indirect map
+  keyed by typeidx, then fieldidx. Exposed as
+  `Module.NameSection.FieldNames` (`IndirectNameMap`).
+- **Tag names** (id 11, from the exception-handling proposal) —
+  flat name map keyed by tagidx. Exposed as
+  `Module.NameSection.TagNames` (`NameMap`).
+
+Names are preserved on the `NameSection` object only; this
+change does not stamp `TagType.Id` or `FieldType.Id` (those
+types don't carry id strings today). Round-trip tests added
+against hand-built binaries.
+
+## WACS 0.15.23 — extended-name-section label-names wire shape
+
+Fixes the binary parser and writer for the label-names subsection
+(id 3) of the `name` custom section. Per the extended-name-section
+proposal, label names use an **indirect** name map
+(funcidx → labelidx → name), not the flat name map WACS was
+emitting and parsing. Any binary actually carrying label names
+would round-trip incorrectly before this fix.
+
+### What changed
+
+- `Module.NameSubsection.LabelNameSubsection.Names` is now an
+  `IndirectNameMap` (was `NameMap`). External consumers that read
+  the property directly need to switch from `.NameAssocMap` to
+  the indirect form (`labels[funcIdx].NameAssocMap[labelIdx]`).
+- `BinaryModuleWriter` emits the subsection as an indirect map.
+- New round-trip test covers the wire shape against a hand-built
+  binary.
+
 ## WACS.ComponentModel.Harness.Runtime 0.7.0 / WACS.ComponentModel.Harness.Lib 0.27.0 — separate host handle space + Borrowed&lt;T&gt;
 
 Layers an independent host-side handle space over the existing

--- a/Wacs.Core/Wacs.Core.Test/NameSectionRoundTripTests.cs
+++ b/Wacs.Core/Wacs.Core.Test/NameSectionRoundTripTests.cs
@@ -60,6 +60,181 @@ namespace Wacs.Core.Test
         }
 
         [Fact]
+        public void LabelNames_ParsedAsIndirectMap()
+        {
+            // Extended-name-section §Label Names: labels are an
+            // *indirect* name map keyed by funcidx, then labelidx
+            // — not a flat name map. Hand-craft a minimal wasm whose
+            // `name` custom section carries only the label-names
+            // subsection, then verify the parser interprets the wire
+            // shape as IndirectNameMap.
+            byte[] bytes = BuildWasmWithLabelNamesSubsection(
+                (funcIdx: 0u, new[] { (idx: 0u, name: "outer"), (idx: 1u, name: "inner") }));
+
+            bool prev = BinaryModuleParser.ParseCustomNames;
+            BinaryModuleParser.ParseCustomNames = true;
+            try
+            {
+                using var ms = new MemoryStream(bytes);
+                var module = BinaryModuleParser.ParseWasm(ms);
+
+                Assert.NotNull(module.Names);
+                Assert.NotNull(module.Names!.LabelNames);
+                var labels = module.Names.LabelNames!.Names;
+                Assert.Equal("outer", labels[0].NameAssocMap[0]);
+                Assert.Equal("inner", labels[0].NameAssocMap[1]);
+            }
+            finally
+            {
+                BinaryModuleParser.ParseCustomNames = prev;
+            }
+        }
+
+        [Fact]
+        public void FieldNames_ParsedAsIndirectMap()
+        {
+            // GC spec §Field Names: id 10, indirect map keyed by
+            // typeidx, then fieldidx. Same pattern as label-names but
+            // grouped per struct type.
+            byte[] indirect = EncodeIndirectMap(
+                (7u, new[] { (0u, "x"), (1u, "y") }));
+            byte[] bytes = BuildWasmWithSubsection(subsectionId: 10, indirect);
+
+            bool prev = BinaryModuleParser.ParseCustomNames;
+            BinaryModuleParser.ParseCustomNames = true;
+            try
+            {
+                using var ms = new MemoryStream(bytes);
+                var module = BinaryModuleParser.ParseWasm(ms);
+
+                Assert.NotNull(module.Names);
+                Assert.NotNull(module.Names!.FieldNames);
+                var fields = module.Names.FieldNames!.Names;
+                Assert.Equal("x", fields[7].NameAssocMap[0]);
+                Assert.Equal("y", fields[7].NameAssocMap[1]);
+            }
+            finally
+            {
+                BinaryModuleParser.ParseCustomNames = prev;
+            }
+        }
+
+        [Fact]
+        public void TagNames_ParsedAsFlatMap()
+        {
+            // Exception-handling spec §Tag Names: id 11, flat name map.
+            byte[] flat = EncodeFlatMap(new[] { (0u, "oom"), (1u, "io") });
+            byte[] bytes = BuildWasmWithSubsection(subsectionId: 11, flat);
+
+            bool prev = BinaryModuleParser.ParseCustomNames;
+            BinaryModuleParser.ParseCustomNames = true;
+            try
+            {
+                using var ms = new MemoryStream(bytes);
+                var module = BinaryModuleParser.ParseWasm(ms);
+
+                Assert.NotNull(module.Names);
+                Assert.NotNull(module.Names!.TagNames);
+                var tags = module.Names.TagNames!.Names.NameAssocMap;
+                Assert.Equal("oom", tags[0]);
+                Assert.Equal("io",  tags[1]);
+            }
+            finally
+            {
+                BinaryModuleParser.ParseCustomNames = prev;
+            }
+        }
+
+        private static byte[] BuildWasmWithLabelNamesSubsection(
+            params (uint funcIdx, (uint idx, string name)[] entries)[] groups)
+        {
+            byte[] indirect = EncodeIndirectMap(groups);
+            return BuildWasmWithSubsection(subsectionId: 3, indirect);
+        }
+
+        private static byte[] EncodeIndirectMap(
+            params (uint key, (uint idx, string name)[] entries)[] groups)
+        {
+            using var inner = new MemoryStream();
+            using var iw = new BinaryWriter(inner, Encoding.UTF8, leaveOpen: true);
+            WriteLeb128U32(iw, (uint)groups.Length);
+            foreach (var g in groups)
+            {
+                WriteLeb128U32(iw, g.key);
+                WriteLeb128U32(iw, (uint)g.entries.Length);
+                foreach (var (idx, name) in g.entries)
+                {
+                    WriteLeb128U32(iw, idx);
+                    WriteUtf8(iw, name);
+                }
+            }
+            iw.Flush();
+            return inner.ToArray();
+        }
+
+        private static byte[] EncodeFlatMap((uint idx, string name)[] entries)
+        {
+            using var inner = new MemoryStream();
+            using var iw = new BinaryWriter(inner, Encoding.UTF8, leaveOpen: true);
+            WriteLeb128U32(iw, (uint)entries.Length);
+            foreach (var (idx, name) in entries)
+            {
+                WriteLeb128U32(iw, idx);
+                WriteUtf8(iw, name);
+            }
+            iw.Flush();
+            return inner.ToArray();
+        }
+
+        private static byte[] BuildWasmWithSubsection(byte subsectionId, byte[] payload)
+        {
+            using var sub = new MemoryStream();
+            using (var sw = new BinaryWriter(sub, Encoding.UTF8, leaveOpen: true))
+            {
+                sw.Write(subsectionId);
+                WriteLeb128U32(sw, (uint)payload.Length);
+                sw.Write(payload);
+            }
+            byte[] nameSectionPayload = sub.ToArray();
+
+            using var cs = new MemoryStream();
+            using (var cw = new BinaryWriter(cs, Encoding.UTF8, leaveOpen: true))
+            {
+                WriteUtf8(cw, "name");
+                cw.Write(nameSectionPayload);
+            }
+            byte[] customBody = cs.ToArray();
+
+            using var ms = new MemoryStream();
+            using (var w = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+            {
+                w.Write(new byte[] { 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+                w.Write((byte)0); // custom section id
+                WriteLeb128U32(w, (uint)customBody.Length);
+                w.Write(customBody);
+            }
+            return ms.ToArray();
+        }
+
+        private static void WriteLeb128U32(BinaryWriter w, uint value)
+        {
+            do
+            {
+                byte b = (byte)(value & 0x7F);
+                value >>= 7;
+                if (value != 0) b |= 0x80;
+                w.Write(b);
+            } while (value != 0);
+        }
+
+        private static void WriteUtf8(BinaryWriter w, string s)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(s);
+            WriteLeb128U32(w, (uint)bytes.Length);
+            w.Write(bytes);
+        }
+
+        [Fact]
         public void RoundTrip_WatToBinaryToWasmFuncIdSurvives()
         {
             // Full loop: WAT → BinaryModuleWriter → BinaryModuleParser.

--- a/Wacs.Core/Wacs.Core/BinaryFormat/CustomSectionEncoders.cs
+++ b/Wacs.Core/Wacs.Core/BinaryFormat/CustomSectionEncoders.cs
@@ -51,7 +51,7 @@ namespace Wacs.Core.Bin
 
             if (names.LabelNames != null)
                 WriteSubsection(w, NameSubsectionIdValue(NameSubKind.LabelName), inner =>
-                    WriteNameMap(inner, names.LabelNames.Names));
+                    WriteIndirectNameMap(inner, names.LabelNames.Names));
 
             if (names.TypeNames != null)
                 WriteSubsection(w, NameSubsectionIdValue(NameSubKind.TypeName), inner =>
@@ -76,6 +76,14 @@ namespace Wacs.Core.Bin
             if (names.DataSegNames != null)
                 WriteSubsection(w, NameSubsectionIdValue(NameSubKind.DataSegName), inner =>
                     WriteNameMap(inner, names.DataSegNames.Names));
+
+            if (names.FieldNames != null)
+                WriteSubsection(w, NameSubsectionIdValue(NameSubKind.FieldName), inner =>
+                    WriteIndirectNameMap(inner, names.FieldNames.Names));
+
+            if (names.TagNames != null)
+                WriteSubsection(w, NameSubsectionIdValue(NameSubKind.TagName), inner =>
+                    WriteNameMap(inner, names.TagNames.Names));
         }
 
         private enum NameSubKind : byte
@@ -89,7 +97,9 @@ namespace Wacs.Core.Bin
             MemoryName = 6,
             GlobalName = 7,
             ElementSegName = 8,
-            DataSegName = 9
+            DataSegName = 9,
+            FieldName = 10,
+            TagName = 11
         }
 
         private static byte NameSubsectionIdValue(NameSubKind kind) => (byte)kind;

--- a/Wacs.Core/Wacs.Core/Modules/Sections/NameSubsection.cs
+++ b/Wacs.Core/Wacs.Core/Modules/Sections/NameSubsection.cs
@@ -31,7 +31,11 @@ namespace Wacs.Core
         MemoryName = 6,
         GlobalName = 7,
         ElementSegName = 8,
-        DataSegName = 9
+        DataSegName = 9,
+        // From the GC proposal: indirect map (typeidx → fieldidx → name).
+        FieldName = 10,
+        // From the exception-handling proposal: flat map (tagidx → name).
+        TagName = 11
     }
 
     public partial class Module
@@ -62,6 +66,8 @@ namespace Wacs.Core
             public NameSubsection.MemoryNameSubsection? MemoryNames { get; internal set; }
             public NameSubsection.LabelNameSubsection? LabelNames { get; internal set; }
             public NameSubsection.TypeNameSubsection? TypeNames { get; internal set; }
+            public NameSubsection.FieldNameSubsection? FieldNames { get; internal set; }
+            public NameSubsection.TagNameSubsection? TagNames { get; internal set; }
 
             public static NameSection Parse(BinaryReader reader)
             {
@@ -104,7 +110,13 @@ namespace Wacs.Core
                         case NameSubsectionId.DataSegName:
                             nameSection.DataSegNames = NameSubsection.DataSegNameSubsection.Parse(reader);
                             break;
-                        
+                        case NameSubsectionId.FieldName:
+                            nameSection.FieldNames = NameSubsection.FieldNameSubsection.Parse(reader);
+                            break;
+                        case NameSubsectionId.TagName:
+                            nameSection.TagNames = NameSubsection.TagNameSubsection.Parse(reader);
+                            break;
+
                         default:
                             throw new FormatException($"Name Subsection had invalid id: {subsectionId}");
                     }
@@ -140,8 +152,11 @@ namespace Wacs.Core
 
             public class LabelNameSubsection : NameSubsection
             {
-                public NameMap Names { get; internal set; } = null!;
-                public static LabelNameSubsection Parse(BinaryReader reader) => new() { Names = NameMap.Parse(reader) };
+                // Per the extended-name-section proposal: labels are
+                // grouped by funcidx, so the wire shape is an indirect
+                // name map (funcidx → labelidx → name), not a flat map.
+                public IndirectNameMap Names { get; internal set; } = null!;
+                public static LabelNameSubsection Parse(BinaryReader reader) => new() { Names = IndirectNameMap.Parse(reader) };
             }
 
             public class TypeNameSubsection : NameSubsection
@@ -178,6 +193,20 @@ namespace Wacs.Core
             {
                 public NameMap Names { get; internal set; } = null!;
                 public static DataSegNameSubsection Parse(BinaryReader reader) => new() { Names = NameMap.Parse(reader) };
+            }
+
+            public class FieldNameSubsection : NameSubsection
+            {
+                // GC spec §Field Names: indirect map (typeidx → fieldidx → name).
+                public IndirectNameMap Names { get; internal set; } = null!;
+                public static FieldNameSubsection Parse(BinaryReader reader) => new() { Names = IndirectNameMap.Parse(reader) };
+            }
+
+            public class TagNameSubsection : NameSubsection
+            {
+                // Exception-handling §Tag Names: flat name map.
+                public NameMap Names { get; internal set; } = null!;
+                public static TagNameSubsection Parse(BinaryReader reader) => new() { Names = NameMap.Parse(reader) };
             }
         }
 

--- a/Wacs.Core/Wacs.Core/Wacs.Core.csproj
+++ b/Wacs.Core/Wacs.Core/Wacs.Core.csproj
@@ -4,8 +4,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
-    <AssemblyVersion>0.15.22</AssemblyVersion>
-    <Version>0.15.22</Version>
+    <AssemblyVersion>0.15.24</AssemblyVersion>
+    <Version>0.15.24</Version>
     <Authors>Kelvin Nishikawa</Authors>
     <Description>A Pure C# WebAssembly Interpreter. v0.13 introduces selectable linear-memory storage: ManagedArray (byte[], default, ~2 GiB) or NativePointer (NativeMemory.AllocZeroed, no 2 GiB cap) via RuntimeOptions.MemoryStorage. NativePointer + (memory i64) lifts the cap to WasmMaxPages64 (2^48), unlocking memory64 modules end-to-end through the interpreter and transpiler. Memory-op bounds checks moved to a wrap-safe unsigned form covering memory32 and memory64. v0.12 brought the in-process WAT/WAST parser to full parity with the binary parser — every wast in the WebAssembly spec testsuite (SIMD, GC, relaxed-SIMD, hex-float edge cases) round-trips identically through both pipelines, dropping the wasm-tools / wast2json CI dependency. v0.12.1 tracks the wasm-3.0 spec submodule to tip d7aada5: inclusive memory page-count limit (PRs #105/#106/#108), tail-call to imported host functions (PR #1872), `array.new_data` bounds (PR #1881), malformed memop reserved bits (PRs #1886/#1936), table64 u64 limits (PR #104), `(module definition …)` validate-only support, u32 offset enforcement on memory32, and `;;` line-comment CR termination.</Description>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>


### PR DESCRIPTION
Audits WACS against the extended-name-section proposal plus the field/tag-name subsections defined by the GC and exception-handling proposals. Two gaps were found and fixed:

- **Label names (id 3)** — were parsed/written as a flat `NameMap`, but the spec requires an `IndirectNameMap` (funcidx → labelidx → name). Any binary actually carrying label names would have round-tripped incorrectly. `LabelNameSubsection.Names` is now typed as `IndirectNameMap`.
- **Field names (id 10, GC)** and **tag names (id 11, exceptions)** — previously hit the unrecognized-subsection throw. Now parsed and emitted; exposed as `NameSection.FieldNames` (`IndirectNameMap`, typeidx → fieldidx → name) and `NameSection.TagNames` (`NameMap`, tagidx → name).

Names are preserved on the `NameSection` only; this commit does not stamp `TagType.Id` / `FieldType.Id` (those types don't carry id strings today). Round-trip tests added for label, field, and tag subsections against hand-built binaries.